### PR TITLE
Pi boot hang recovery (DSI cmdline, splash timeouts, MPE_HOME)

### DIFF
--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -30,6 +30,7 @@
 # MPE_SURGE_DOCS="$HOME/Documents/Surge XT"
 # MPE_SURGE_LOG=$HOME/surge-cli.log
 # MPE_PI_USER=your-pi-username
+# MPE_HOME=/home/your-pi-username  # set by configure-pi-paths.sh --local
 
 # --- Audio output profile (Pi) ---
 #

--- a/config/touch-boot-animation.service
+++ b/config/touch-boot-animation.service
@@ -16,7 +16,7 @@ ExecStart=/usr/bin/python3 -u @MPE_MODULE_REPO@/touch_boot_splash.py --mode hold
 RemainAfterExit=no
 StandardOutput=null
 StandardError=journal
-TimeoutStopSec=3
+TimeoutStopSec=8
 KillMode=mixed
 KillSignal=SIGTERM
 

--- a/config/touch-boot-animation.service
+++ b/config/touch-boot-animation.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Touch DSI Boot Splash (5 inch panel)
+After=systemd-modules-load.service local-fs.target
+Before=touch-patch-browser.service
+Conflicts=boot-animation.service
+
+[Service]
+Type=simple
+User=@MPE_PI_USER@
+WorkingDirectory=@MPE_MODULE_REPO@
+EnvironmentFile=-/etc/mpe/mpe.env
+Environment=SDL_VIDEODRIVER=kmsdrm
+Environment=SDL_MOUSE_TOUCH_EVENTS=1
+ExecStart=/usr/bin/python3 -u @MPE_MODULE_REPO@/touch_boot_splash.py --mode hold
+RemainAfterExit=no
+StandardOutput=journal
+StandardError=journal
+TimeoutStopSec=3
+KillMode=mixed
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target

--- a/config/touch-boot-animation.service
+++ b/config/touch-boot-animation.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Touch DSI Boot Splash (5 inch panel)
-After=systemd-modules-load.service local-fs.target
-Before=touch-patch-browser.service
+DefaultDependencies=no
+After=local-fs.target systemd-udev-settle.service
+Before=getty@tty1.service touch-patch-browser.service
 Conflicts=boot-animation.service
 
 [Service]
@@ -13,11 +14,11 @@ Environment=SDL_VIDEODRIVER=kmsdrm
 Environment=SDL_MOUSE_TOUCH_EVENTS=1
 ExecStart=/usr/bin/python3 -u @MPE_MODULE_REPO@/touch_boot_splash.py --mode hold
 RemainAfterExit=no
-StandardOutput=journal
+StandardOutput=null
 StandardError=journal
 TimeoutStopSec=3
 KillMode=mixed
 KillSignal=SIGTERM
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target

--- a/config/touch-boot-animation.service
+++ b/config/touch-boot-animation.service
@@ -19,6 +19,7 @@ StandardError=journal
 TimeoutStopSec=8
 KillMode=mixed
 KillSignal=SIGTERM
+TimeoutStartSec=120
 
 [Install]
 WantedBy=sysinit.target

--- a/config/touch-patch-browser.service
+++ b/config/touch-patch-browser.service
@@ -11,11 +11,10 @@ WorkingDirectory=@MPE_MODULE_REPO@
 EnvironmentFile=-/etc/mpe/mpe.env
 Environment=SDL_VIDEODRIVER=kmsdrm
 Environment=SDL_MOUSE_TOUCH_EVENTS=1
-ExecStartPre=/bin/sleep 1
 ExecStart=@MPE_MODULE_REPO@/scripts/start-touch-patch-browser.sh
 Restart=on-failure
 RestartSec=5
-StandardOutput=journal
+StandardOutput=null
 StandardError=journal
 
 [Install]

--- a/config/touch-patch-browser.service
+++ b/config/touch-patch-browser.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Touch Patch Browser UI for 5 inch DSI Display
-After=surge-xt-cli.service
-Wants=surge-xt-cli.service
+After=surge-xt-cli.service touch-boot-animation.service
+Wants=surge-xt-cli.service touch-boot-animation.service
 Conflicts=patch-browser.service
 
 [Service]
@@ -11,7 +11,7 @@ WorkingDirectory=@MPE_MODULE_REPO@
 EnvironmentFile=-/etc/mpe/mpe.env
 Environment=SDL_VIDEODRIVER=kmsdrm
 Environment=SDL_MOUSE_TOUCH_EVENTS=1
-ExecStartPre=/bin/sleep 3
+ExecStartPre=/bin/sleep 1
 ExecStart=@MPE_MODULE_REPO@/scripts/start-touch-patch-browser.sh
 Restart=on-failure
 RestartSec=5

--- a/config/touch-shutdown-animation.service
+++ b/config/touch-shutdown-animation.service
@@ -1,19 +1,21 @@
 [Unit]
 Description=Touch DSI Shutdown Splash (5 inch panel)
 DefaultDependencies=no
-Before=shutdown.target reboot.target halt.target
+Before=shutdown.target reboot.target halt.target getty@tty1.service
 Conflicts=shutdown-animation.service
 
 [Service]
-Type=oneshot
+Type=simple
 User=@MPE_PI_USER@
 WorkingDirectory=@MPE_MODULE_REPO@
 EnvironmentFile=-/etc/mpe/mpe.env
 Environment=SDL_VIDEODRIVER=kmsdrm
-ExecStart=/usr/bin/python3 -u @MPE_MODULE_REPO@/touch_shutdown_splash.py
-StandardOutput=journal
+ExecStartPre=-/bin/systemctl stop getty@tty1.service
+ExecStart=/usr/bin/python3 -u @MPE_MODULE_REPO@/touch_shutdown_splash.py --hold
+StandardOutput=null
 StandardError=journal
-TimeoutStartSec=10
+TimeoutStopSec=infinity
+KillMode=mixed
 
 [Install]
 WantedBy=halt.target reboot.target shutdown.target

--- a/config/touch-shutdown-animation.service
+++ b/config/touch-shutdown-animation.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Touch DSI Shutdown Splash (5 inch panel)
+DefaultDependencies=no
+Before=shutdown.target reboot.target halt.target
+Conflicts=shutdown-animation.service
+
+[Service]
+Type=oneshot
+User=@MPE_PI_USER@
+WorkingDirectory=@MPE_MODULE_REPO@
+EnvironmentFile=-/etc/mpe/mpe.env
+Environment=SDL_VIDEODRIVER=kmsdrm
+ExecStart=/usr/bin/python3 -u @MPE_MODULE_REPO@/touch_shutdown_splash.py
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=10
+
+[Install]
+WantedBy=halt.target reboot.target shutdown.target

--- a/docs/PI-BOOT-RECOVERY.md
+++ b/docs/PI-BOOT-RECOVERY.md
@@ -1,0 +1,77 @@
+# Pi boot recovery (DSI / USB gadget / cmdline)
+
+*Last updated: 2026-07-31 (America/Toronto)*
+
+Use this when the SmartiPi panel stays on the **four raspberries** splash for several minutes, SSH never comes up, or boot loops after USB-host or DSI cmdline changes.
+
+## Fastest path (no SD card edit)
+
+1. **Power off** the Pi completely.
+2. **Unplug the USB-C data cable** to the laptop/PC (gadget/peripheral mode). Leave power and normal USB-A devices (Roli, DAC) as they were.
+3. Power on and wait ~90s, then try SSH:
+
+   ```bash
+   ssh -i ~/.ssh/surge_pi_key mitch@192.168.1.143
+   ```
+
+4. If SSH works, temporarily return to analog audio until stable:
+
+   ```bash
+   sudo sed -i 's/^MPE_AUDIO_PROFILE=.*/MPE_AUDIO_PROFILE=standalone/' /etc/mpe/mpe.env
+   sudo systemctl disable --now usb-audio-gadget.service
+   sudo systemctl restart surge-xt-cli touch-patch-browser
+   ```
+
+## SD card rollback order (Pi still stuck)
+
+Mount the **boot** partition on another machine (`/boot/firmware` on Pi OS Bookworm).
+
+### Step 1 — cmdline (safest first)
+
+File: **`cmdline.txt`** (same folder as `config.txt`).
+
+- Restore from backup if present: `cmdline.txt.bak.*` (created by `apply-dsi-cmdline.sh`).
+- Or manually:
+  - Ensure **`console=tty1`** is present (single line, space-separated tokens).
+  - Remove **`fbcon=map:0`**, **`logo.nologo`**, extra **`console=serial0,115200`** if you do not need serial.
+
+Reboot and test SSH.
+
+### Step 2 — USB dwc2 peripheral overlay
+
+File: **`config.txt`**.
+
+Remove or comment:
+
+```ini
+dtoverlay=dwc2,dr_mode=peripheral
+```
+
+Reboot. This returns the USB-C port to **host** mode; USB-host audio profile will not work until you re-add the overlay (see [USB-AUDIO-HOST.md](USB-AUDIO-HOST.md)).
+
+### Step 3 — disable boot splash unit (if userspace hangs)
+
+Only after the kernel boots (SSH works) or from a chroot:
+
+```bash
+sudo systemctl disable touch-boot-animation.service
+```
+
+## Root causes we have seen
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Four raspberries, no SSH, USB-C tethered | `dr_mode=peripheral` + host PC connected during **early** boot |
+| Kernel text flash then hang | Rare cmdline combos; keep `console=tty1` unless using `--strip-tty1` with serial recovery |
+| SSH up, panel black | `touch-boot-animation` or DRM handoff — check `journalctl -u touch-boot-animation` |
+
+## After recovery — safer re-apply
+
+```bash
+cd ~/MPE-Module
+git pull
+sudo ./scripts/apply-dsi-cmdline.sh          # keeps console=tty1; adds fbcon + quiet flags
+sudo ./scripts/apply-dsi-cmdline.sh --strip-tty1   # only if serial console attached
+```
+
+For USB-host: add `dtoverlay=dwc2,dr_mode=peripheral`, reboot **with USB-C unplugged**, then plug the cable after `multi-user.target` is up.

--- a/docs/TOUCH_PATCH_BROWSER.md
+++ b/docs/TOUCH_PATCH_BROWSER.md
@@ -124,7 +124,7 @@ Both browser units are installed by `configure-pi-paths.sh`. Which one **boots**
 | `MPE_UI_MODE` | Enabled | Disabled |
 |---------------|---------|----------|
 | `oled` (default) | `patch-browser.service`, `boot-animation.service` | `touch-patch-browser.service` |
-| `touch` | `touch-patch-browser.service` | `patch-browser.service`, `boot-animation.service` |
+| `touch` | `touch-patch-browser.service`, `touch-boot-animation.service`, `touch-shutdown-animation.service` | `patch-browser.service`, `boot-animation.service`, `shutdown-animation.service` |
 
 On the SmartiPi Pi, set in `config/mpe.env` then reconfigure:
 
@@ -137,13 +137,23 @@ systemctl is-enabled patch-browser touch-patch-browser
 
 Only one browser UI should talk to Surge over OSC.
 
-### Boot / restart — no stale UI flash
+### Boot / restart — branded splash (no console flash)
 
-On the SmartiPi DSI panel, **KMS/DRM keeps the last pygame frame** when `touch-patch-browser` stops or before the new process flips the display. That frame can be an **older build** (e.g. pre-`d66ef3a` with four stub faders Cut/Res/Snd/Vol) until the current app draws.
+On the SmartiPi DSI panel, **KMS/DRM keeps the last pygame frame** when `touch-patch-browser` stops or before the new process flips the display.
 
-**Ruled out on `raspberrypi2` (2026-07-31):** `boot-animation.service` and `patch-browser.service` are **disabled**; `ExecStart` points at `~/MPE-Module/touch_patch_browser.py` (single Vol fader at `8fca259`); no second service races the DSI.
+**Touch boot sequence** (`MPE_UI_MODE=touch`):
 
-**Fix:** `scripts/clear-dsi-framebuffer.py` runs from `start-touch-patch-browser.sh` before Python import; `touch_patch_browser.py` fills the background and flips immediately after `set_mode()`.
+1. `touch-boot-animation.service` — claims DRM early and loops the branded **MPE Sound Module** splash until the browser starts.
+2. `start-touch-patch-browser.sh` — stops the splash service, clears stale pixels (`clear-dsi-framebuffer.py`), starts `touch_patch_browser.py`.
+3. Browser — fills background immediately, then plays a short in-app boot splash (~1.2 s) unless a full splash ran within the last 30 s (service restart debounce).
+
+**Calibration handoff:** the browser paints **Starting calibration…** and `exec`s `calibration_loader.py` directly (no bash wrapper). The loader paints on first frame before Surge prep. On exit it shows **Returning to patch browser…** before async restart.
+
+**Shutdown:** Power menu confirm runs an in-app shutdown splash (~2 s) before `poweroff`/`reboot`. `touch-shutdown-animation.service` covers systemd halt/reboot paths.
+
+Implementation: `patch_browser/dsi_splash.py`, `touch_boot_splash.py`, `touch_shutdown_splash.py`. OLED builds keep `boot-animation.service` / `shutdown-animation.service`.
+
+**Stale-frame belt-and-suspenders:** `scripts/clear-dsi-framebuffer.py` still runs between splash stop and browser import; `touch_patch_browser.py` fills the background and flips immediately after `set_mode()`.
 
 ## Config
 
@@ -152,6 +162,7 @@ Same `/etc/mpe/mpe.env` as the encoder build:
 | Variable | Purpose |
 |----------|---------|
 | `MPE_UI_MODE` | `oled` or `touch` — which patch browser systemd enables at boot |
+| `MPE_BOOT_SPLASH_SECONDS` | Max in-app boot splash duration (default 3; min 1.2) |
 | `MPE_FAVORITES_NAME` | Quick-access folder under Surge user patches |
 | `MPE_TOUCH_WINDOWED` | Set `1` for windowed dev mode |
 
@@ -185,7 +196,7 @@ Set `MPE_TOUCH_EVDEV=0` to fall back to SDL-only input (debugging).
 - **Norm.** — label-left / checkbox-right on the patch detail pane; persists per patch stem in `~/.patch_browser_normalization.json` (calibration data kept when toggling off). Greyed out when global normalization is off.
 - **Calibrate missing patches** / **Force full re-calibration** — System settings (⋯) → confirm modal → loader on DSI. See **[PATCH_NORMALIZATION.md](PATCH_NORMALIZATION.md)**.
 
-**Calibration handoff:** launching calibration from the touch browser sets `MPE_CALIB_FROM_BROWSER=1` before `exec` into `calibrate-with-loader.sh`. Teardown must not stop `touch-patch-browser` synchronously (same systemd main process) and schedules an async restart instead. Constant and invariant live in `patch_browser/calibration_constants.py` and `calibration_teardown.py`.
+**Calibration handoff:** launching calibration from the touch browser sets `MPE_CALIB_FROM_BROWSER=1` before `exec` into `calibration_loader.py` (direct Python exec — no bash gap). Teardown must not stop `touch-patch-browser` synchronously (same systemd main process) and schedules an async restart instead. Constant and invariant live in `patch_browser/calibration_constants.py` and `calibration_teardown.py`.
 
 ## System settings (⋯)
 
@@ -224,5 +235,4 @@ Implementation: `patch_browser/ui_theme.py` (`theme_oled_black()` / `OLED_BLACK_
 
 - Search/filter across 3000+ patches not implemented (scroll lists first)
 - Portrait panels are unsupported for this rig (yours is landscape)
-- Boot/shutdown animations still target the 1.3" OLED service
 - Very large patches (e.g. **Bowed String**, ~8 MB) may need a calibration retry — use `--patch "Bowed String"` or re-run loader with `--force`

--- a/docs/TOUCH_PATCH_BROWSER.md
+++ b/docs/TOUCH_PATCH_BROWSER.md
@@ -153,7 +153,7 @@ On the SmartiPi DSI panel, **KMS/DRM keeps the last pygame frame** when `touch-p
 sudo ./scripts/apply-dsi-cmdline.sh
 ```
 
-This adds `console=serial0,115200 fbcon=map:0` to `/boot/firmware/cmdline.txt` so boot messages go to serial and fbcon stays off the panel. A timestamped backup is saved beside the original file.
+This adds `console=serial0,115200 fbcon=map:0` to `/boot/firmware/cmdline.txt` and removes `console=tty1` when present so boot messages go to serial and fbcon stays off the panel. A timestamped backup is saved beside the original file.
 
 **Calibration handoff:** the browser paints **Starting calibration…**, flips, and `exec`s `calibration_loader.py`. The loader paints on its first frame (`paint_immediate`) before heavy init. On exit it shows **Returning to patch browser…**, re-arms `touch-boot-animation`, then async-restarts the browser.
 

--- a/docs/TOUCH_PATCH_BROWSER.md
+++ b/docs/TOUCH_PATCH_BROWSER.md
@@ -145,17 +145,23 @@ On the SmartiPi DSI panel, **KMS/DRM keeps the last pygame frame** when `touch-p
 
 1. `touch-boot-animation.service` — starts before `getty@tty1`, claims DRM, loops the branded splash until the browser takes over.
 2. `start-touch-patch-browser.sh` — does **not** stop the splash or clear the framebuffer (that would release DRM and flash the console).
-3. `touch_patch_browser.py` — stops the splash service, opens kmsdrm, paints boot splash immediately, keeps animating during patch scan, then signals ready.
+3. `touch_patch_browser.py` — cooperative handoff from the boot splash, paints boot splash immediately on kmsdrm, keeps an **indeterminate spinner** during patch scan, then draws the UI and signals ready (no percentage bar).
+
+**Kernel console on DSI:** run once on the Pi (requires reboot):
+
+```bash
+sudo ./scripts/apply-dsi-cmdline.sh
+```
+
+This adds `console=serial0,115200 fbcon=map:0` to `/boot/firmware/cmdline.txt` so boot messages go to serial and fbcon stays off the panel. A timestamped backup is saved beside the original file.
 
 **Calibration handoff:** the browser paints **Starting calibration…**, flips, and `exec`s `calibration_loader.py`. The loader paints on its first frame (`paint_immediate`) before heavy init. On exit it shows **Returning to patch browser…**, re-arms `touch-boot-animation`, then async-restarts the browser.
 
 **Shutdown:** Power menu confirm runs an in-app shutdown splash (~3 s), stops `getty@tty1`, spawns `poweroff`/`reboot`, and holds the shutdown frame until halt. `touch-shutdown-animation.service` covers systemd halt/reboot paths with `--hold`.
 
-**Optional (reduce kernel scroll on the panel):** add `console=serial0,115200 fbcon=map:0` to `/boot/firmware/cmdline.txt` so boot messages go to serial and fbcon stays off the DSI.
+Implementation: `patch_browser/dsi_splash.py`, `touch_boot_splash.py`, `touch_shutdown_splash.py`, `scripts/apply-dsi-cmdline.sh`. OLED builds keep `boot-animation.service` / `shutdown-animation.service`.
 
-Implementation: `patch_browser/dsi_splash.py`, `touch_boot_splash.py`, `touch_shutdown_splash.py`. OLED builds keep `boot-animation.service` / `shutdown-animation.service`.
-
-**Ready flag:** `/run/mpe-touch-browser-ready` is written when the browser finishes its boot splash (after initial patch scan).
+**Ready flag:** `/run/mpe-touch-browser-ready` is written after the browser's first full UI frame (post boot splash).
 
 ## Config
 

--- a/docs/TOUCH_PATCH_BROWSER.md
+++ b/docs/TOUCH_PATCH_BROWSER.md
@@ -143,17 +143,19 @@ On the SmartiPi DSI panel, **KMS/DRM keeps the last pygame frame** when `touch-p
 
 **Touch boot sequence** (`MPE_UI_MODE=touch`):
 
-1. `touch-boot-animation.service` — claims DRM early and loops the branded **MPE Sound Module** splash until the browser starts.
-2. `start-touch-patch-browser.sh` — stops the splash service, clears stale pixels (`clear-dsi-framebuffer.py`), starts `touch_patch_browser.py`.
-3. Browser — fills background immediately, then plays a short in-app boot splash (~1.2 s) unless a full splash ran within the last 30 s (service restart debounce).
+1. `touch-boot-animation.service` — starts before `getty@tty1`, claims DRM, loops the branded splash until the browser takes over.
+2. `start-touch-patch-browser.sh` — does **not** stop the splash or clear the framebuffer (that would release DRM and flash the console).
+3. `touch_patch_browser.py` — stops the splash service, opens kmsdrm, paints boot splash immediately, keeps animating during patch scan, then signals ready.
 
-**Calibration handoff:** the browser paints **Starting calibration…** and `exec`s `calibration_loader.py` directly (no bash wrapper). The loader paints on first frame before Surge prep. On exit it shows **Returning to patch browser…** before async restart.
+**Calibration handoff:** the browser paints **Starting calibration…**, flips, and `exec`s `calibration_loader.py`. The loader paints on its first frame (`paint_immediate`) before heavy init. On exit it shows **Returning to patch browser…**, re-arms `touch-boot-animation`, then async-restarts the browser.
 
-**Shutdown:** Power menu confirm runs an in-app shutdown splash (~2 s) before `poweroff`/`reboot`. `touch-shutdown-animation.service` covers systemd halt/reboot paths.
+**Shutdown:** Power menu confirm runs an in-app shutdown splash (~3 s), stops `getty@tty1`, spawns `poweroff`/`reboot`, and holds the shutdown frame until halt. `touch-shutdown-animation.service` covers systemd halt/reboot paths with `--hold`.
+
+**Optional (reduce kernel scroll on the panel):** add `console=serial0,115200 fbcon=map:0` to `/boot/firmware/cmdline.txt` so boot messages go to serial and fbcon stays off the DSI.
 
 Implementation: `patch_browser/dsi_splash.py`, `touch_boot_splash.py`, `touch_shutdown_splash.py`. OLED builds keep `boot-animation.service` / `shutdown-animation.service`.
 
-**Stale-frame belt-and-suspenders:** `scripts/clear-dsi-framebuffer.py` still runs between splash stop and browser import; `touch_patch_browser.py` fills the background and flips immediately after `set_mode()`.
+**Ready flag:** `/run/mpe-touch-browser-ready` is written when the browser finishes its boot splash (after initial patch scan).
 
 ## Config
 

--- a/docs/TOUCH_PATCH_BROWSER.md
+++ b/docs/TOUCH_PATCH_BROWSER.md
@@ -150,7 +150,7 @@ On the SmartiPi DSI panel, **KMS/DRM keeps the last pygame frame** when `touch-p
 **Kernel console on DSI:** run once on the Pi (requires reboot):
 
 ```bash
-sudo ./scripts/apply-dsi-cmdline.sh
+sudo ./scripts/apply-dsi-cmdline (default keeps `console=tty1`; use `--strip-tty1` only with serial recovery).sh
 ```
 
 This adds `console=serial0,115200 fbcon=map:0` to `/boot/firmware/cmdline.txt` and removes `console=tty1` when present so boot messages go to serial and fbcon stays off the panel. A timestamped backup is saved beside the original file.

--- a/docs/USB-AUDIO-HOST.md
+++ b/docs/USB-AUDIO-HOST.md
@@ -16,7 +16,9 @@ Edit **`/boot/firmware/config.txt`** on the Pi and add:
 dtoverlay=dwc2,dr_mode=peripheral
 ```
 
-Reboot once. This enables the USB-C port as a **device (gadget)** port. Do not enable legacy `g_audio` / `g_midi` modules alongside configfs — the setup script uses **configfs UAC2** only.
+Reboot once. This enables the USB-C port as a **device (gadget)** port.
+
+**Important:** On Pi 4, boot with the **USB-C data cable unplugged** from the host PC. A connected host during early firmware/kernel init can hang the boot splash (four raspberries) before SSH starts. Plug the cable in after the Pi is up (or after `usb-audio-gadget.service` is active). See [PI-BOOT-RECOVERY.md](PI-BOOT-RECOVERY.md). Do not enable legacy `g_audio` / `g_midi` modules alongside configfs — the setup script uses **configfs UAC2** only.
 
 **Pi 4 / Pi 5 only** — Pi 3 has no OTG. Roli and Sound Blaster stay on **USB-A host ports**.
 

--- a/patch_browser/calibration_constants.py
+++ b/patch_browser/calibration_constants.py
@@ -22,6 +22,7 @@ MPE_CALIB_FROM_BROWSER_ACTIVE = "1"
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CALIBRATE_WITH_LOADER_SCRIPT = REPO_ROOT / "scripts" / "calibrate-with-loader.sh"
+CALIBRATION_LOADER_SCRIPT = REPO_ROOT / "patch_browser" / "calibration_loader.py"
 
 
 def calibration_from_browser() -> bool:

--- a/patch_browser/calibration_loader.py
+++ b/patch_browser/calibration_loader.py
@@ -28,7 +28,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from patch_browser.calibration_teardown import restore_mpe_audio_services  # noqa: E402
-from patch_browser.dsi_splash import SplashMode, draw_splash_frame  # noqa: E402
+from patch_browser.dsi_splash import (
+    CAL_RETURN_HOLD_SECONDS,
+    SplashMode,
+    draw_splash_frame,
+    paint_immediate,
+    start_boot_splash_service,
+)
 from patch_browser.geometry import Rect  # noqa: E402
 from patch_browser.ui_text import (
     draw_wrapped_text_in_rect,
@@ -195,15 +201,24 @@ def _write_loader_exit_report(state: LoaderState, *, subprocess_code: int | None
 
 
 class CalibrationLoaderApp:
-    def __init__(self, calibrate_args: list[str]) -> None:
-        pygame.init()
-        pygame.display.set_caption("Patch Calibration")
-        windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
-        if windowed:
-            self.screen = pygame.display.set_mode((800, 480))
+    def __init__(
+        self,
+        calibrate_args: list[str],
+        *,
+        preopened_screen: "pygame.Surface | None" = None,
+    ) -> None:
+        if preopened_screen is not None:
+            self.screen = preopened_screen
+            self.width, self.height = self.screen.get_size()
         else:
-            self.screen = pygame.display.set_mode((800, 480), pygame.FULLSCREEN)
-        self.width, self.height = self.screen.get_size()
+            pygame.init()
+            pygame.display.set_caption("Patch Calibration")
+            windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+            if windowed:
+                self.screen = pygame.display.set_mode((800, 480))
+            else:
+                self.screen = pygame.display.set_mode((800, 480), pygame.FULLSCREEN)
+            self.width, self.height = self.screen.get_size()
         pygame.mouse.set_visible(False)
 
         self.theme = theme_for_mode(load_theme_mode_from_prefs())
@@ -458,8 +473,10 @@ class CalibrationLoaderApp:
                 theme=self.theme,
                 progress=1.0,
             )
-            time.sleep(0.6)
+            time.sleep(CAL_RETURN_HOLD_SECONDS)
             pygame.quit()
+            if not os.environ.get("MPE_TOUCH_WINDOWED") == "1" and not os.environ.get("DISPLAY"):
+                start_boot_splash_service()
             # Release kmsdrm before touch-patch-browser claims the display.
             restore_mpe_audio_services()
 
@@ -471,7 +488,16 @@ def main(argv: list[str] | None = None) -> int:
     if not CALIBRATE_SCRIPT.is_file():
         print(f"Missing calibrator: {CALIBRATE_SCRIPT}", file=sys.stderr)
         return 1
-    return CalibrationLoaderApp(args).run()
+
+    preopened: pygame.Surface | None = None
+    windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+    if not windowed and not os.environ.get("DISPLAY"):
+        try:
+            preopened, _ = paint_immediate(mode=SplashMode.CAL_ENTER)
+        except RuntimeError:
+            preopened = None
+
+    return CalibrationLoaderApp(args, preopened_screen=preopened).run()
 
 
 if __name__ == "__main__":

--- a/patch_browser/calibration_loader.py
+++ b/patch_browser/calibration_loader.py
@@ -28,6 +28,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from patch_browser.calibration_teardown import restore_mpe_audio_services  # noqa: E402
+from patch_browser.dsi_splash import SplashMode, draw_splash_frame  # noqa: E402
 from patch_browser.geometry import Rect  # noqa: E402
 from patch_browser.ui_text import (
     draw_wrapped_text_in_rect,
@@ -209,6 +210,12 @@ class CalibrationLoaderApp:
         self.font_title = _load_font(32)
         self.font_md = _load_font(22)
         self.font_sm = _load_font(18)
+        draw_splash_frame(
+            self.screen,
+            mode=SplashMode.CAL_ENTER,
+            theme=self.theme,
+            progress=0.05,
+        )
 
         self.state = LoaderState()
         self._started_at = time.monotonic()
@@ -445,6 +452,13 @@ class CalibrationLoaderApp:
                 exit_code = self.reader.join()
             if exit_code not in (0, 130):
                 _write_loader_exit_report(self.state, subprocess_code=exit_code)
+            draw_splash_frame(
+                self.screen,
+                mode=SplashMode.CAL_RETURN,
+                theme=self.theme,
+                progress=1.0,
+            )
+            time.sleep(0.6)
             pygame.quit()
             # Release kmsdrm before touch-patch-browser claims the display.
             restore_mpe_audio_services()

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -233,7 +233,25 @@ def draw_splash_frame(
     pygame.display.flip()
 
 
-def paint_immediate(
+def acquire_browser_display(
+    width: int = DEFAULT_WIDTH,
+    height: int = DEFAULT_HEIGHT,
+) -> "pygame.Surface":
+    """Stop the boot splash if needed and open kmsdrm with retries."""
+    if pygame is None:
+        raise RuntimeError("pygame is required for dsi_splash")
+    windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+    if windowed or os.environ.get("DISPLAY"):
+        if not pygame.get_init():
+            pygame.init()
+        return pygame.display.set_mode((width, height))
+
+    stop_boot_splash_service()
+    configure_kmsdrm_env()
+    if not pygame.get_init():
+        pygame.init()
+    time.sleep(0.15)
+    return _open_fullscreen_surface(width, height)
     *,
     mode: SplashMode,
     width: int = DEFAULT_WIDTH,
@@ -242,14 +260,7 @@ def paint_immediate(
     """Open kmsdrm, paint one splash frame, return (screen, theme.bg). Caller keeps DRM."""
     if pygame is None:
         raise RuntimeError("pygame is required for dsi_splash")
-    configure_kmsdrm_env()
-    if not pygame.get_init():
-        pygame.init()
-    windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
-    if windowed:
-        screen = pygame.display.set_mode((width, height))
-    else:
-        screen = _open_fullscreen_surface(width, height)
+    screen = acquire_browser_display(width=width, height=height)
     theme = theme_for_mode(load_theme_mode_from_prefs())
     draw_splash_frame(screen, mode=mode, theme=theme, progress=0.0)
     return screen, theme.bg

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -1,0 +1,299 @@
+"""Branded fullscreen splash frames for the Pi DSI touch display (kmsdrm).
+
+Used for boot, shutdown, and calibration handoff so Linux console or stale
+pygame frames never flash on the panel.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from enum import Enum
+from pathlib import Path
+
+try:
+    import pygame
+except ImportError:
+    pygame = None  # type: ignore[assignment]
+
+from patch_browser.ui_theme import load_theme_mode_from_prefs, theme_for_mode
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_WIDTH = 800
+DEFAULT_HEIGHT = 480
+BOOT_MIN_SECONDS = 1.2
+BOOT_MAX_SECONDS = 3.0
+SHUTDOWN_SECONDS = 2.0
+FAST_RESTART_DEBOUNCE_S = 30.0
+LAST_SPLASH_STAMP = Path("/tmp/mpe-dsi-splash-last.ts")
+
+
+class SplashMode(str, Enum):
+    BOOT = "boot"
+    SHUTDOWN = "shutdown"
+    CAL_ENTER = "cal_enter"
+    CAL_RETURN = "cal_return"
+    HOLD = "hold"
+
+
+def configure_kmsdrm_env() -> None:
+    """Set SDL kmsdrm env when running headless on the Pi DSI panel."""
+    if os.environ.get("MPE_TOUCH_WINDOWED") == "1" or os.environ.get("DISPLAY"):
+        return
+    if os.environ.get("SDL_VIDEODRIVER"):
+        return
+    os.environ["SDL_VIDEODRIVER"] = "kmsdrm"
+    detect = REPO_ROOT / "scripts" / "lib" / "detect-drm-card.sh"
+    if detect.is_file():
+        try:
+            card = subprocess.check_output(["bash", str(detect)], text=True).strip()
+            if card:
+                os.environ["SDL_KMSDRM_DEVICE"] = card
+        except (subprocess.CalledProcessError, OSError):
+            pass
+    os.environ.setdefault("SDL_KMSDRM_REQUIRE_DRM_MASTER", "1")
+    os.environ.setdefault("SDL_VIDEO_EGL", "0")
+
+
+def _load_font(size: int) -> "pygame.font.Font":
+    for name in ("dejavusans", "dejavusansmono", "liberationsans", "arial", None):
+        try:
+            if name:
+                path = pygame.font.match_font(name)
+                if path:
+                    return pygame.font.Font(path, size)
+            return pygame.font.SysFont(name, size)
+        except (OSError, TypeError):
+            continue
+    return pygame.font.Font(None, size)
+
+
+def _subtitle_for_mode(mode: SplashMode) -> str:
+    if mode == SplashMode.BOOT:
+        return "Starting…"
+    if mode == SplashMode.SHUTDOWN:
+        return "Shutting down…"
+    if mode == SplashMode.CAL_ENTER:
+        return "Starting calibration…"
+    if mode == SplashMode.CAL_RETURN:
+        return "Returning to patch browser…"
+    return ""
+
+
+def _recent_splash_debounce() -> bool:
+    try:
+        if not LAST_SPLASH_STAMP.is_file():
+            return False
+        last = float(LAST_SPLASH_STAMP.read_text().strip())
+        return (time.time() - last) < FAST_RESTART_DEBOUNCE_S
+    except (OSError, ValueError):
+        return False
+
+
+def recent_splash_debounce() -> bool:
+    """True when a full boot animation ran within FAST_RESTART_DEBOUNCE_S."""
+    return _recent_splash_debounce()
+
+
+def _mark_splash_ran() -> None:
+    try:
+        LAST_SPLASH_STAMP.write_text(f"{time.time():.3f}\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def draw_splash_frame(
+    screen: "pygame.Surface",
+    *,
+    mode: SplashMode,
+    theme=None,
+    progress: float = 0.0,
+    title: str = "MPE Sound Module",
+) -> None:
+    """Paint one branded splash frame onto *screen*."""
+    if theme is None:
+        theme = theme_for_mode(load_theme_mode_from_prefs())
+    screen.fill(theme.bg)
+
+    title_font = _load_font(36)
+    sub_font = _load_font(22)
+    hint_font = _load_font(18)
+
+    title_surf = title_font.render(title, True, theme.text)
+    screen.blit(title_surf, ((screen.get_width() - title_surf.get_width()) // 2, 150))
+
+    subtitle = _subtitle_for_mode(mode)
+    if subtitle:
+        sub_surf = sub_font.render(subtitle, True, theme.muted)
+        screen.blit(sub_surf, ((screen.get_width() - sub_surf.get_width()) // 2, 210))
+
+    if mode == SplashMode.BOOT:
+        bar_w = min(420, screen.get_width() - 120)
+        bar_h = 10
+        bar_x = (screen.get_width() - bar_w) // 2
+        bar_y = 280
+        track = pygame.Rect(bar_x, bar_y, bar_w, bar_h)
+        pygame.draw.rect(screen, theme.surface_alt, track, border_radius=6)
+        fill_w = max(0, min(bar_w, int(bar_w * max(0.0, min(1.0, progress)))))
+        if fill_w > 0:
+            fill = pygame.Rect(bar_x, bar_y, fill_w, bar_h)
+            pygame.draw.rect(screen, theme.accent, fill, border_radius=6)
+        pct = hint_font.render(f"{int(progress * 100)}%", True, theme.muted)
+        screen.blit(pct, ((screen.get_width() - pct.get_width()) // 2, bar_y + 24))
+    elif mode == SplashMode.SHUTDOWN:
+        hint = hint_font.render("Please wait", True, theme.muted)
+        screen.blit(hint, ((screen.get_width() - hint.get_width()) // 2, 280))
+
+    pygame.display.flip()
+
+
+def paint_immediate(
+    *,
+    mode: SplashMode,
+    width: int = DEFAULT_WIDTH,
+    height: int = DEFAULT_HEIGHT,
+) -> tuple["pygame.Surface", tuple[int, int, int]]:
+    """Open kmsdrm, paint one splash frame, return (screen, theme.bg). Caller keeps DRM."""
+    if pygame is None:
+        raise RuntimeError("pygame is required for dsi_splash")
+    configure_kmsdrm_env()
+    if not pygame.get_init():
+        pygame.init()
+    windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+    if windowed:
+        screen = pygame.display.set_mode((width, height))
+    else:
+        screen = pygame.display.set_mode((width, height), pygame.FULLSCREEN)
+    theme = theme_for_mode(load_theme_mode_from_prefs())
+    draw_splash_frame(screen, mode=mode, theme=theme, progress=0.0)
+    return screen, theme.bg
+
+
+def run_boot_animation(*, duration: float | None = None, debounce: bool = True) -> None:
+    """Fullscreen boot splash until *duration* elapses or the process is killed."""
+    if pygame is None:
+        return
+    if debounce and _recent_splash_debounce():
+        paint_hold_black()
+        return
+
+    configure_kmsdrm_env()
+    pygame.init()
+    windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+    if windowed:
+        screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
+    else:
+        screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT), pygame.FULLSCREEN)
+    pygame.mouse.set_visible(False)
+    theme = theme_for_mode(load_theme_mode_from_prefs())
+
+    total = duration
+    if total is None:
+        env = os.environ.get("MPE_BOOT_SPLASH_SECONDS", "").strip()
+        total = float(env) if env else BOOT_MAX_SECONDS
+    total = max(BOOT_MIN_SECONDS, min(total, BOOT_MAX_SECONDS))
+
+    start = time.monotonic()
+    clock = pygame.time.Clock()
+    _mark_splash_ran()
+
+    try:
+        while True:
+            elapsed = time.monotonic() - start
+            progress = min(1.0, elapsed / total)
+            draw_splash_frame(screen, mode=SplashMode.BOOT, theme=theme, progress=progress)
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    return
+            if duration is not None and elapsed >= duration:
+                return
+            if duration is None and progress >= 1.0:
+                # Hold final frame until systemd stops us (touch browser start).
+                clock.tick(30)
+                continue
+            clock.tick(30)
+    finally:
+        pygame.quit()
+
+
+def run_shutdown_animation(*, screen: "pygame.Surface | None" = None) -> None:
+    """Fade branded shutdown splash; reuse *screen* when called from the live browser."""
+    if pygame is None:
+        return
+    owns_display = screen is None
+    theme = theme_for_mode(load_theme_mode_from_prefs())
+
+    if owns_display:
+        configure_kmsdrm_env()
+        pygame.init()
+        windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+        if windowed:
+            screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
+        else:
+            screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT), pygame.FULLSCREEN)
+
+    assert screen is not None
+    start = time.monotonic()
+    clock = pygame.time.Clock()
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= SHUTDOWN_SECONDS:
+            break
+        alpha = min(1.0, elapsed / SHUTDOWN_SECONDS)
+        draw_splash_frame(screen, mode=SplashMode.SHUTDOWN, theme=theme, progress=1.0 - alpha * 0.35)
+        clock.tick(30)
+
+    draw_splash_frame(screen, mode=SplashMode.SHUTDOWN, theme=theme, progress=0.0)
+    screen.fill((0, 0, 0))
+    pygame.display.flip()
+    if owns_display:
+        pygame.quit()
+
+
+def paint_hold_black() -> None:
+    """Fill panel true black (fast path after debounced restart)."""
+    if pygame is None:
+        return
+    configure_kmsdrm_env()
+    pygame.init()
+    try:
+        windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+        if windowed:
+            screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
+        else:
+            screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT), pygame.FULLSCREEN)
+        screen.fill((0, 0, 0))
+        pygame.display.flip()
+    finally:
+        pygame.quit()
+
+
+def run_hold_loop() -> None:
+    """Hold branded boot frame until killed (systemd early boot service)."""
+    if pygame is None:
+        sys.exit(0)
+    configure_kmsdrm_env()
+    pygame.init()
+    windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+    if windowed:
+        screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
+    else:
+        screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT), pygame.FULLSCREEN)
+    pygame.mouse.set_visible(False)
+    theme = theme_for_mode(load_theme_mode_from_prefs())
+    _mark_splash_ran()
+    clock = pygame.time.Clock()
+    frame = 0
+    try:
+        while True:
+            progress = 0.15 + 0.75 * (0.5 + 0.5 * ((frame % 120) / 120.0))
+            draw_splash_frame(screen, mode=SplashMode.BOOT, theme=theme, progress=progress)
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    return
+            frame += 1
+            clock.tick(30)
+    finally:
+        pygame.quit()

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -7,6 +7,7 @@ pygame frames never flash on the panel.
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -30,6 +31,7 @@ CAL_RETURN_HOLD_SECONDS = 1.2
 FAST_RESTART_DEBOUNCE_S = 30.0
 LAST_SPLASH_STAMP = Path("/tmp/mpe-dsi-splash-last.ts")
 BROWSER_READY_FLAG = Path("/run/mpe-touch-browser-ready")
+DISPLAY_REQUEST_FLAG = Path("/run/mpe-touch-display-request")
 BOOT_SPLASH_UNIT = "touch-boot-animation.service"
 
 
@@ -188,6 +190,35 @@ def clear_browser_ready_flag() -> None:
         pass
 
 
+def request_display_handoff() -> None:
+    """Ask touch-boot-animation to release kmsdrm (cooperative exit)."""
+    try:
+        DISPLAY_REQUEST_FLAG.write_text(f"{time.time():.3f}\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def clear_display_handoff_request() -> None:
+    try:
+        DISPLAY_REQUEST_FLAG.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def display_handoff_requested() -> bool:
+    return DISPLAY_REQUEST_FLAG.is_file()
+
+
+def wait_for_boot_splash_release(*, timeout: float = 5.0) -> None:
+    """Wait until the boot splash unit exits after a cooperative handoff."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not boot_splash_service_active():
+            return
+        time.sleep(0.05)
+    stop_boot_splash_service(wait=True, timeout=max(1.0, timeout / 2))
+
+
 def draw_splash_frame(
     screen: "pygame.Surface",
     *,
@@ -246,11 +277,14 @@ def acquire_browser_display(
             pygame.init()
         return pygame.display.set_mode((width, height))
 
-    stop_boot_splash_service()
     configure_kmsdrm_env()
     if not pygame.get_init():
         pygame.init()
-    time.sleep(0.15)
+    if boot_splash_service_active():
+        request_display_handoff()
+        wait_for_boot_splash_release()
+    clear_display_handoff_request()
+    time.sleep(0.1)
     return _open_fullscreen_surface(width, height)
 
 
@@ -394,7 +428,7 @@ def paint_hold_black() -> None:
 
 
 def run_hold_loop() -> None:
-    """Hold branded boot frame until killed (systemd early boot service)."""
+    """Hold branded boot frame until killed or display handoff is requested."""
     if pygame is None:
         sys.exit(0)
     configure_kmsdrm_env()
@@ -409,8 +443,17 @@ def run_hold_loop() -> None:
     _mark_splash_ran()
     clock = pygame.time.Clock()
     frame = 0
+    exiting = False
+
+    def _request_exit(*_args: object) -> None:
+        nonlocal exiting
+        exiting = True
+
+    signal.signal(signal.SIGTERM, _request_exit)
+    signal.signal(signal.SIGINT, _request_exit)
+
     try:
-        while True:
+        while not exiting and not display_handoff_requested():
             progress = 0.15 + 0.75 * (0.5 + 0.5 * ((frame % 120) / 120.0))
             draw_splash_frame(screen, mode=SplashMode.BOOT, theme=theme, progress=progress)
             for event in pygame.event.get():
@@ -420,3 +463,4 @@ def run_hold_loop() -> None:
             clock.tick(30)
     finally:
         pygame.quit()
+        clear_display_handoff_request()

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -25,9 +25,12 @@ DEFAULT_WIDTH = 800
 DEFAULT_HEIGHT = 480
 BOOT_MIN_SECONDS = 1.2
 BOOT_MAX_SECONDS = 3.0
-SHUTDOWN_SECONDS = 2.0
+SHUTDOWN_SECONDS = 3.0
+CAL_RETURN_HOLD_SECONDS = 1.2
 FAST_RESTART_DEBOUNCE_S = 30.0
 LAST_SPLASH_STAMP = Path("/tmp/mpe-dsi-splash-last.ts")
+BROWSER_READY_FLAG = Path("/run/mpe-touch-browser-ready")
+BOOT_SPLASH_UNIT = "touch-boot-animation.service"
 
 
 class SplashMode(str, Enum):
@@ -124,6 +127,63 @@ def recent_splash_debounce() -> bool:
 def _mark_splash_ran() -> None:
     try:
         LAST_SPLASH_STAMP.write_text(f"{time.time():.3f}\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _systemctl(*args: str) -> None:
+    try:
+        subprocess.run(["sudo", "systemctl", *args], check=False, capture_output=True)
+    except OSError:
+        pass
+
+
+def boot_splash_service_active() -> bool:
+    """True while the early-boot splash unit holds DRM."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", "--quiet", BOOT_SPLASH_UNIT],
+            check=False,
+        )
+        return result.returncode == 0
+    except OSError:
+        return False
+
+
+def stop_boot_splash_service(*, wait: bool = True, timeout: float = 2.5) -> None:
+    """Stop the systemd boot splash so this process can claim kmsdrm."""
+    if not boot_splash_service_active():
+        return
+    _systemctl("stop", BOOT_SPLASH_UNIT)
+    if not wait:
+        return
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not boot_splash_service_active():
+            return
+        time.sleep(0.05)
+
+
+def start_boot_splash_service() -> None:
+    """Re-arm the boot splash (calibration return / async browser restart)."""
+    _systemctl("start", BOOT_SPLASH_UNIT)
+
+
+def stop_getty_tty1() -> None:
+    """Hide login prompt on the panel framebuffer during shutdown."""
+    _systemctl("stop", "getty@tty1.service")
+
+
+def signal_browser_ready() -> None:
+    try:
+        BROWSER_READY_FLAG.write_text(f"{time.time():.3f}\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def clear_browser_ready_flag() -> None:
+    try:
+        BROWSER_READY_FLAG.unlink(missing_ok=True)
     except OSError:
         pass
 
@@ -242,7 +302,11 @@ def run_boot_animation(*, duration: float | None = None, debounce: bool = True) 
         pygame.quit()
 
 
-def run_shutdown_animation(*, screen: "pygame.Surface | None" = None) -> None:
+def run_shutdown_animation(
+    *,
+    screen: "pygame.Surface | None" = None,
+    hold_until_halt: bool = False,
+) -> None:
     """Fade branded shutdown splash; reuse *screen* when called from the live browser."""
     if pygame is None:
         return
@@ -259,21 +323,42 @@ def run_shutdown_animation(*, screen: "pygame.Surface | None" = None) -> None:
             screen = _open_fullscreen_surface()
 
     assert screen is not None
+    windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+    if not windowed and not os.environ.get("DISPLAY"):
+        stop_getty_tty1()
+
     start = time.monotonic()
     clock = pygame.time.Clock()
     while True:
         elapsed = time.monotonic() - start
-        if elapsed >= SHUTDOWN_SECONDS:
+        if elapsed >= SHUTDOWN_SECONDS and not hold_until_halt:
             break
         alpha = min(1.0, elapsed / SHUTDOWN_SECONDS)
-        draw_splash_frame(screen, mode=SplashMode.SHUTDOWN, theme=theme, progress=1.0 - alpha * 0.35)
-        clock.tick(30)
+        draw_splash_frame(
+            screen,
+            mode=SplashMode.SHUTDOWN,
+            theme=theme,
+            progress=1.0 - alpha * 0.35 if elapsed < SHUTDOWN_SECONDS else 0.0,
+        )
+        if hold_until_halt and elapsed >= SHUTDOWN_SECONDS:
+            clock.tick(10)
+            continue
+        if not hold_until_halt:
+            clock.tick(30)
+            continue
+        clock.tick(10)
 
-    draw_splash_frame(screen, mode=SplashMode.SHUTDOWN, theme=theme, progress=0.0)
-    screen.fill((0, 0, 0))
-    pygame.display.flip()
-    if owns_display:
-        pygame.quit()
+    if not hold_until_halt:
+        draw_splash_frame(screen, mode=SplashMode.SHUTDOWN, theme=theme, progress=0.0)
+        screen.fill((0, 0, 0))
+        pygame.display.flip()
+        if owns_display:
+            pygame.quit()
+
+
+def hold_shutdown_frame(*, screen: "pygame.Surface | None" = None) -> None:
+    """Paint shutdown splash once and loop until systemd kills the process."""
+    run_shutdown_animation(screen=screen, hold_until_halt=True)
 
 
 def paint_hold_black() -> None:

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -6,6 +6,7 @@ pygame frames never flash on the panel.
 
 from __future__ import annotations
 
+import math
 import os
 import signal
 import subprocess
@@ -27,6 +28,10 @@ DEFAULT_HEIGHT = 480
 BOOT_MIN_SECONDS = 1.2
 BOOT_MAX_SECONDS = 3.0
 SHUTDOWN_SECONDS = 3.0
+SHUTDOWN_HOLD_MAX_SECONDS = 120.0
+SHUTDOWN_SLOW_HINT_SECONDS = 15.0
+SHUTDOWN_SPINNER_PERIOD = 1.2
+SHUTDOWN_LOG = Path("/tmp/mpe-shutdown-splash.log")
 CAL_RETURN_HOLD_SECONDS = 1.2
 FAST_RESTART_DEBOUNCE_S = 30.0
 LAST_SPLASH_STAMP = Path("/tmp/mpe-dsi-splash-last.ts")
@@ -97,6 +102,32 @@ def _load_font(size: int) -> "pygame.font.Font":
         except (OSError, TypeError):
             continue
     return pygame.font.Font(None, size)
+
+
+def _hide_cursor() -> None:
+    if pygame is not None:
+        pygame.mouse.set_visible(False)
+
+
+def _log_shutdown(message: str) -> None:
+    try:
+        with SHUTDOWN_LOG.open("a", encoding="utf-8") as handle:
+            handle.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} {message}\n")
+    except OSError:
+        pass
+
+
+def shutdown_animation_phase(elapsed: float, *, period: float = SHUTDOWN_SPINNER_PERIOD) -> float:
+    """Return 0..1 cycle phase for the shutdown spinner."""
+    if period <= 0:
+        return 0.0
+    return (elapsed % period) / period
+
+
+def shutdown_subtitle(elapsed: float) -> str:
+    if elapsed >= SHUTDOWN_SLOW_HINT_SECONDS:
+        return "Still shutting down…"
+    return "Shutting down…"
 
 
 def _subtitle_for_mode(mode: SplashMode) -> str:
@@ -219,12 +250,35 @@ def wait_for_boot_splash_release(*, timeout: float = 5.0) -> None:
     stop_boot_splash_service(wait=True, timeout=max(1.0, timeout / 2))
 
 
+def _draw_shutdown_spinner(
+    screen: "pygame.Surface",
+    theme,
+    center_x: int,
+    center_y: int,
+    phase: float,
+) -> None:
+    """Rotating dot spinner (*phase* 0..1)."""
+    dot_count = 8
+    radius = 16
+    active = int(phase * dot_count) % dot_count
+    for index in range(dot_count):
+        angle = (2 * math.pi * index / dot_count) - (math.pi / 2)
+        x = int(center_x + radius * math.cos(angle))
+        y = int(center_y + radius * math.sin(angle))
+        trail = (active - index) % dot_count
+        dot_radius = 5 if trail == 0 else max(2, 5 - trail)
+        color = theme.accent if trail <= 1 else theme.muted
+        pygame.draw.circle(screen, color, (x, y), dot_radius)
+
+
 def draw_splash_frame(
     screen: "pygame.Surface",
     *,
     mode: SplashMode,
     theme=None,
     progress: float = 0.0,
+    animation_phase: float = 0.0,
+    subtitle_override: str | None = None,
     title: str = "MPE Sound Module",
 ) -> None:
     """Paint one branded splash frame onto *screen*."""
@@ -239,7 +293,7 @@ def draw_splash_frame(
     title_surf = title_font.render(title, True, theme.text)
     screen.blit(title_surf, ((screen.get_width() - title_surf.get_width()) // 2, 150))
 
-    subtitle = _subtitle_for_mode(mode)
+    subtitle = subtitle_override if subtitle_override is not None else _subtitle_for_mode(mode)
     if subtitle:
         sub_surf = sub_font.render(subtitle, True, theme.muted)
         screen.blit(sub_surf, ((screen.get_width() - sub_surf.get_width()) // 2, 210))
@@ -258,8 +312,17 @@ def draw_splash_frame(
         pct = hint_font.render(f"{int(progress * 100)}%", True, theme.muted)
         screen.blit(pct, ((screen.get_width() - pct.get_width()) // 2, bar_y + 24))
     elif mode == SplashMode.SHUTDOWN:
-        hint = hint_font.render("Please wait", True, theme.muted)
-        screen.blit(hint, ((screen.get_width() - hint.get_width()) // 2, 280))
+        slow = subtitle_override is not None and "Still" in subtitle_override
+        hint_text = "This may take a moment" if slow else "Please wait"
+        hint = hint_font.render(hint_text, True, theme.muted)
+        screen.blit(hint, ((screen.get_width() - hint.get_width()) // 2, 330))
+        _draw_shutdown_spinner(
+            screen,
+            theme,
+            screen.get_width() // 2,
+            295,
+            animation_phase,
+        )
 
     pygame.display.flip()
 
@@ -275,7 +338,9 @@ def acquire_browser_display(
     if windowed or os.environ.get("DISPLAY"):
         if not pygame.get_init():
             pygame.init()
-        return pygame.display.set_mode((width, height))
+        screen = pygame.display.set_mode((width, height))
+        _hide_cursor()
+        return screen
 
     configure_kmsdrm_env()
     if not pygame.get_init():
@@ -285,7 +350,9 @@ def acquire_browser_display(
         wait_for_boot_splash_release()
     clear_display_handoff_request()
     time.sleep(0.1)
-    return _open_fullscreen_surface(width, height)
+    screen = _open_fullscreen_surface(width, height)
+    _hide_cursor()
+    return screen
 
 
 def paint_immediate(
@@ -298,6 +365,7 @@ def paint_immediate(
     if pygame is None:
         raise RuntimeError("pygame is required for dsi_splash")
     screen = acquire_browser_display(width=width, height=height)
+    _hide_cursor()
     theme = theme_for_mode(load_theme_mode_from_prefs())
     draw_splash_frame(screen, mode=mode, theme=theme, progress=0.0)
     return screen, theme.bg
@@ -318,7 +386,7 @@ def run_boot_animation(*, duration: float | None = None, debounce: bool = True) 
         screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
     else:
         screen = _open_fullscreen_surface()
-    pygame.mouse.set_visible(False)
+    _hide_cursor()
     theme = theme_for_mode(load_theme_mode_from_prefs())
 
     total = duration
@@ -355,7 +423,7 @@ def run_shutdown_animation(
     screen: "pygame.Surface | None" = None,
     hold_until_halt: bool = False,
 ) -> None:
-    """Fade branded shutdown splash; reuse *screen* when called from the live browser."""
+    """Animated shutdown splash; reuse *screen* when called from the live browser."""
     if pygame is None:
         return
     owns_display = screen is None
@@ -371,37 +439,93 @@ def run_shutdown_animation(
             screen = _open_fullscreen_surface()
 
     assert screen is not None
+    _hide_cursor()
     windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
     if not windowed and not os.environ.get("DISPLAY"):
         stop_getty_tty1()
 
     start = time.monotonic()
     clock = pygame.time.Clock()
+    _log_shutdown(f"shutdown splash started hold={hold_until_halt}")
     while True:
         elapsed = time.monotonic() - start
-        if elapsed >= SHUTDOWN_SECONDS and not hold_until_halt:
+        if not hold_until_halt and elapsed >= SHUTDOWN_SECONDS:
             break
-        alpha = min(1.0, elapsed / SHUTDOWN_SECONDS)
+        if hold_until_halt and elapsed >= SHUTDOWN_HOLD_MAX_SECONDS:
+            _log_shutdown(
+                f"systemd hold exceeded {SHUTDOWN_HOLD_MAX_SECONDS:.0f}s, exiting splash",
+            )
+            break
         draw_splash_frame(
             screen,
             mode=SplashMode.SHUTDOWN,
             theme=theme,
-            progress=1.0 - alpha * 0.35 if elapsed < SHUTDOWN_SECONDS else 0.0,
+            animation_phase=shutdown_animation_phase(elapsed),
+            subtitle_override=shutdown_subtitle(elapsed),
         )
-        if hold_until_halt and elapsed >= SHUTDOWN_SECONDS:
-            clock.tick(10)
-            continue
-        if not hold_until_halt:
-            clock.tick(30)
-            continue
-        clock.tick(10)
+        clock.tick(30)
 
     if not hold_until_halt:
-        draw_splash_frame(screen, mode=SplashMode.SHUTDOWN, theme=theme, progress=0.0)
         screen.fill((0, 0, 0))
         pygame.display.flip()
         if owns_display:
             pygame.quit()
+
+
+def _spawn_power_action(power_action: str, *, retry: bool = False) -> None:
+    shell_cmd = "sync && poweroff" if power_action == "shutdown" else "sync && reboot"
+    cmd = ["sudo", "poweroff"] if power_action == "shutdown" else ["sudo", "reboot"]
+    try:
+        if retry:
+            subprocess.Popen(
+                ["sudo", "sh", "-c", shell_cmd],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            _log_shutdown(f"retry: {shell_cmd}")
+        else:
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            _log_shutdown(f"spawned: {' '.join(cmd)}")
+    except OSError as exc:
+        _log_shutdown(f"spawn failed: {exc}")
+
+
+def run_browser_shutdown_hold(
+    screen: "pygame.Surface",
+    theme,
+    *,
+    power_action: str = "shutdown",
+) -> None:
+    """User-confirmed shutdown: spawn poweroff/reboot and animate until halt."""
+    _hide_cursor()
+    _spawn_power_action(power_action, retry=False)
+    start = time.monotonic()
+    clock = pygame.time.Clock()
+    retried = False
+
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= SHUTDOWN_HOLD_MAX_SECONDS:
+            _log_shutdown("browser hold max reached, exiting splash loop")
+            break
+        if elapsed >= SHUTDOWN_SLOW_HINT_SECONDS and not retried:
+            retried = True
+            _log_shutdown(f"slow shutdown after {SHUTDOWN_SLOW_HINT_SECONDS:.0f}s")
+            _spawn_power_action(power_action, retry=True)
+        draw_splash_frame(
+            screen,
+            mode=SplashMode.SHUTDOWN,
+            theme=theme,
+            animation_phase=shutdown_animation_phase(elapsed),
+            subtitle_override=shutdown_subtitle(elapsed),
+        )
+        clock.tick(30)
 
 
 def hold_shutdown_frame(*, screen: "pygame.Surface | None" = None) -> None:
@@ -421,6 +545,7 @@ def paint_hold_black() -> None:
             screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
         else:
             screen = _open_fullscreen_surface()
+        _hide_cursor()
         screen.fill((0, 0, 0))
         pygame.display.flip()
     finally:
@@ -438,7 +563,7 @@ def run_hold_loop() -> None:
         screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
     else:
         screen = _open_fullscreen_surface()
-    pygame.mouse.set_visible(False)
+    _hide_cursor()
     theme = theme_for_mode(load_theme_mode_from_prefs())
     _mark_splash_ran()
     clock = pygame.time.Clock()

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -252,6 +252,9 @@ def acquire_browser_display(
         pygame.init()
     time.sleep(0.15)
     return _open_fullscreen_surface(width, height)
+
+
+def paint_immediate(
     *,
     mode: SplashMode,
     width: int = DEFAULT_WIDTH,

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -31,6 +31,7 @@ SHUTDOWN_SECONDS = 3.0
 SHUTDOWN_HOLD_MAX_SECONDS = 120.0
 SHUTDOWN_SLOW_HINT_SECONDS = 15.0
 SHUTDOWN_SPINNER_PERIOD = 1.2
+BOOT_SPINNER_PERIOD = 1.2
 SHUTDOWN_LOG = Path("/tmp/mpe-shutdown-splash.log")
 CAL_RETURN_HOLD_SECONDS = 1.2
 FAST_RESTART_DEBOUNCE_S = 30.0
@@ -117,11 +118,25 @@ def _log_shutdown(message: str) -> None:
         pass
 
 
-def shutdown_animation_phase(elapsed: float, *, period: float = SHUTDOWN_SPINNER_PERIOD) -> float:
-    """Return 0..1 cycle phase for the shutdown spinner."""
+def spinner_animation_phase(
+    elapsed: float,
+    *,
+    period: float = SHUTDOWN_SPINNER_PERIOD,
+) -> float:
+    """Return 0..1 cycle phase for rotating-dot spinners."""
     if period <= 0:
         return 0.0
     return (elapsed % period) / period
+
+
+def shutdown_animation_phase(elapsed: float, *, period: float = SHUTDOWN_SPINNER_PERIOD) -> float:
+    """Return 0..1 cycle phase for the shutdown spinner."""
+    return spinner_animation_phase(elapsed, period=period)
+
+
+def boot_animation_phase(elapsed: float, *, period: float = BOOT_SPINNER_PERIOD) -> float:
+    """Return 0..1 cycle phase for the boot splash spinner."""
+    return spinner_animation_phase(elapsed, period=period)
 
 
 def shutdown_subtitle(elapsed: float) -> str:
@@ -250,7 +265,7 @@ def wait_for_boot_splash_release(*, timeout: float = 5.0) -> None:
     stop_boot_splash_service(wait=True, timeout=max(1.0, timeout / 2))
 
 
-def _draw_shutdown_spinner(
+def _draw_spinner(
     screen: "pygame.Surface",
     theme,
     center_x: int,
@@ -298,25 +313,13 @@ def draw_splash_frame(
         sub_surf = sub_font.render(subtitle, True, theme.muted)
         screen.blit(sub_surf, ((screen.get_width() - sub_surf.get_width()) // 2, 210))
 
-    if mode == SplashMode.BOOT:
-        bar_w = min(420, screen.get_width() - 120)
-        bar_h = 10
-        bar_x = (screen.get_width() - bar_w) // 2
-        bar_y = 280
-        track = pygame.Rect(bar_x, bar_y, bar_w, bar_h)
-        pygame.draw.rect(screen, theme.surface_alt, track, border_radius=6)
-        fill_w = max(0, min(bar_w, int(bar_w * max(0.0, min(1.0, progress)))))
-        if fill_w > 0:
-            fill = pygame.Rect(bar_x, bar_y, fill_w, bar_h)
-            pygame.draw.rect(screen, theme.accent, fill, border_radius=6)
-        pct = hint_font.render(f"{int(progress * 100)}%", True, theme.muted)
-        screen.blit(pct, ((screen.get_width() - pct.get_width()) // 2, bar_y + 24))
-    elif mode == SplashMode.SHUTDOWN:
-        slow = subtitle_override is not None and "Still" in subtitle_override
-        hint_text = "This may take a moment" if slow else "Please wait"
-        hint = hint_font.render(hint_text, True, theme.muted)
-        screen.blit(hint, ((screen.get_width() - hint.get_width()) // 2, 330))
-        _draw_shutdown_spinner(
+    if mode in (SplashMode.BOOT, SplashMode.SHUTDOWN):
+        if mode == SplashMode.SHUTDOWN:
+            slow = subtitle_override is not None and "Still" in subtitle_override
+            hint_text = "This may take a moment" if slow else "Please wait"
+            hint = hint_font.render(hint_text, True, theme.muted)
+            screen.blit(hint, ((screen.get_width() - hint.get_width()) // 2, 330))
+        _draw_spinner(
             screen,
             theme,
             screen.get_width() // 2,
@@ -349,9 +352,15 @@ def acquire_browser_display(
         request_display_handoff()
         wait_for_boot_splash_release()
     clear_display_handoff_request()
-    time.sleep(0.1)
     screen = _open_fullscreen_surface(width, height)
     _hide_cursor()
+    theme = theme_for_mode(load_theme_mode_from_prefs())
+    draw_splash_frame(
+        screen,
+        mode=SplashMode.BOOT,
+        theme=theme,
+        animation_phase=0.0,
+    )
     return screen
 
 
@@ -367,7 +376,7 @@ def paint_immediate(
     screen = acquire_browser_display(width=width, height=height)
     _hide_cursor()
     theme = theme_for_mode(load_theme_mode_from_prefs())
-    draw_splash_frame(screen, mode=mode, theme=theme, progress=0.0)
+    draw_splash_frame(screen, mode=mode, theme=theme, animation_phase=0.0)
     return screen, theme.bg
 
 
@@ -402,14 +411,18 @@ def run_boot_animation(*, duration: float | None = None, debounce: bool = True) 
     try:
         while True:
             elapsed = time.monotonic() - start
-            progress = min(1.0, elapsed / total)
-            draw_splash_frame(screen, mode=SplashMode.BOOT, theme=theme, progress=progress)
+            draw_splash_frame(
+                screen,
+                mode=SplashMode.BOOT,
+                theme=theme,
+                animation_phase=boot_animation_phase(elapsed),
+            )
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     return
             if duration is not None and elapsed >= duration:
                 return
-            if duration is None and progress >= 1.0:
+            if duration is None and elapsed >= total:
                 # Hold final frame until systemd stops us (touch browser start).
                 clock.tick(30)
                 continue
@@ -567,7 +580,7 @@ def run_hold_loop() -> None:
     theme = theme_for_mode(load_theme_mode_from_prefs())
     _mark_splash_ran()
     clock = pygame.time.Clock()
-    frame = 0
+    hold_start = time.monotonic()
     exiting = False
 
     def _request_exit(*_args: object) -> None:
@@ -579,12 +592,16 @@ def run_hold_loop() -> None:
 
     try:
         while not exiting and not display_handoff_requested():
-            progress = 0.15 + 0.75 * (0.5 + 0.5 * ((frame % 120) / 120.0))
-            draw_splash_frame(screen, mode=SplashMode.BOOT, theme=theme, progress=progress)
+            elapsed = time.monotonic() - hold_start
+            draw_splash_frame(
+                screen,
+                mode=SplashMode.BOOT,
+                theme=theme,
+                animation_phase=boot_animation_phase(elapsed),
+            )
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     return
-            frame += 1
             clock.tick(30)
     finally:
         pygame.quit()

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -29,6 +29,7 @@ BOOT_MIN_SECONDS = 1.2
 BOOT_MAX_SECONDS = 3.0
 SHUTDOWN_SECONDS = 3.0
 SHUTDOWN_HOLD_MAX_SECONDS = 120.0
+BOOT_HOLD_MAX_SECONDS = 180.0
 SHUTDOWN_SLOW_HINT_SECONDS = 15.0
 SHUTDOWN_SPINNER_PERIOD = 1.2
 BOOT_SPINNER_PERIOD = 1.2
@@ -593,6 +594,11 @@ def run_hold_loop() -> None:
     try:
         while not exiting and not display_handoff_requested():
             elapsed = time.monotonic() - hold_start
+            if elapsed >= BOOT_HOLD_MAX_SECONDS:
+                _log_shutdown(
+                    f"boot hold exceeded {BOOT_HOLD_MAX_SECONDS:.0f}s, exiting splash",
+                )
+                break
             draw_splash_frame(
                 screen,
                 mode=SplashMode.BOOT,

--- a/patch_browser/dsi_splash.py
+++ b/patch_browser/dsi_splash.py
@@ -42,19 +42,43 @@ def configure_kmsdrm_env() -> None:
     """Set SDL kmsdrm env when running headless on the Pi DSI panel."""
     if os.environ.get("MPE_TOUCH_WINDOWED") == "1" or os.environ.get("DISPLAY"):
         return
-    if os.environ.get("SDL_VIDEODRIVER"):
+    driver = os.environ.get("SDL_VIDEODRIVER", "").strip()
+    if driver and driver != "kmsdrm":
         return
     os.environ["SDL_VIDEODRIVER"] = "kmsdrm"
-    detect = REPO_ROOT / "scripts" / "lib" / "detect-drm-card.sh"
-    if detect.is_file():
-        try:
-            card = subprocess.check_output(["bash", str(detect)], text=True).strip()
-            if card:
-                os.environ["SDL_KMSDRM_DEVICE"] = card
-        except (subprocess.CalledProcessError, OSError):
-            pass
+    if not os.environ.get("SDL_KMSDRM_DEVICE"):
+        detect = REPO_ROOT / "scripts" / "lib" / "detect-drm-card.sh"
+        if detect.is_file():
+            try:
+                card = subprocess.check_output(["bash", str(detect)], text=True).strip()
+                if card:
+                    os.environ["SDL_KMSDRM_DEVICE"] = card
+            except (subprocess.CalledProcessError, OSError):
+                pass
     os.environ.setdefault("SDL_KMSDRM_REQUIRE_DRM_MASTER", "1")
     os.environ.setdefault("SDL_VIDEO_EGL", "0")
+
+
+def _open_fullscreen_surface(
+    width: int = DEFAULT_WIDTH,
+    height: int = DEFAULT_HEIGHT,
+) -> "pygame.Surface":
+    """Open kmsdrm fullscreen with short retries while DRM comes up at boot."""
+    windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+    if windowed:
+        return pygame.display.set_mode((width, height))
+    last_error: pygame.error | None = None
+    for attempt in range(24):
+        try:
+            return pygame.display.set_mode((width, height), pygame.FULLSCREEN)
+        except pygame.error as exc:
+            last_error = exc
+            if "kmsdrm" not in str(exc).lower() or attempt >= 23:
+                raise
+            time.sleep(0.5)
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("failed to open kmsdrm display")
 
 
 def _load_font(size: int) -> "pygame.font.Font":
@@ -165,7 +189,7 @@ def paint_immediate(
     if windowed:
         screen = pygame.display.set_mode((width, height))
     else:
-        screen = pygame.display.set_mode((width, height), pygame.FULLSCREEN)
+        screen = _open_fullscreen_surface(width, height)
     theme = theme_for_mode(load_theme_mode_from_prefs())
     draw_splash_frame(screen, mode=mode, theme=theme, progress=0.0)
     return screen, theme.bg
@@ -185,7 +209,7 @@ def run_boot_animation(*, duration: float | None = None, debounce: bool = True) 
     if windowed:
         screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
     else:
-        screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT), pygame.FULLSCREEN)
+        screen = _open_fullscreen_surface()
     pygame.mouse.set_visible(False)
     theme = theme_for_mode(load_theme_mode_from_prefs())
 
@@ -232,7 +256,7 @@ def run_shutdown_animation(*, screen: "pygame.Surface | None" = None) -> None:
         if windowed:
             screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
         else:
-            screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT), pygame.FULLSCREEN)
+            screen = _open_fullscreen_surface()
 
     assert screen is not None
     start = time.monotonic()
@@ -263,7 +287,7 @@ def paint_hold_black() -> None:
         if windowed:
             screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
         else:
-            screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT), pygame.FULLSCREEN)
+            screen = _open_fullscreen_surface()
         screen.fill((0, 0, 0))
         pygame.display.flip()
     finally:
@@ -280,7 +304,7 @@ def run_hold_loop() -> None:
     if windowed:
         screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT))
     else:
-        screen = pygame.display.set_mode((DEFAULT_WIDTH, DEFAULT_HEIGHT), pygame.FULLSCREEN)
+        screen = _open_fullscreen_surface()
     pygame.mouse.set_visible(False)
     theme = theme_for_mode(load_theme_mode_from_prefs())
     _mark_splash_ran()

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -41,6 +41,7 @@ from patch_browser.dsi_splash import (
     BOOT_MIN_SECONDS,
     SplashMode,
     acquire_browser_display,
+    boot_animation_phase,
     clear_browser_ready_flag,
     draw_splash_frame,
     signal_browser_ready,
@@ -71,29 +72,32 @@ class TouchPatchBrowser(
         self.screen.fill(self.theme.bg)
         pygame.display.flip()
 
-    def _paint_boot_splash_frame(self, *, progress: float) -> None:
+    def _paint_boot_splash_frame(self, *, animation_phase: float) -> None:
         draw_splash_frame(
             self.screen,
             mode=SplashMode.BOOT,
             theme=self.theme,
-            progress=progress,
+            animation_phase=animation_phase,
         )
 
-    def _finish_boot_splash(self) -> None:
-        """Hold branded boot frames until minimum time and first scan settle."""
-        start = getattr(self, "_boot_splash_started", time.monotonic())
-        clock = pygame.time.Clock()
-        while True:
-            elapsed = time.monotonic() - start
-            progress = min(1.0, elapsed / BOOT_MIN_SECONDS)
-            self._paint_boot_splash_frame(progress=progress)
-            if elapsed >= BOOT_MIN_SECONDS:
-                break
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    self._running = False
-                    return
-            clock.tick(30)
+    def _boot_splash_elapsed(self) -> float:
+        return time.monotonic() - getattr(self, "_boot_splash_started", time.monotonic())
+
+    def _tick_boot_splash_until_ready(self) -> bool:
+        """Animate boot splash until min time elapsed. True when ready for first UI draw."""
+        if self._boot_splash_done:
+            return True
+        elapsed = self._boot_splash_elapsed()
+        if elapsed < BOOT_MIN_SECONDS:
+            self._paint_boot_splash_frame(animation_phase=boot_animation_phase(elapsed))
+            return False
+        return True
+
+    def _complete_boot_splash(self) -> None:
+        """End boot splash after the first full UI frame is on screen."""
+        if self._boot_splash_done:
+            return
+        self._boot_splash_done = True
         signal_browser_ready()
     def _pointer_move_distance(
         self, start: tuple[int, int] | None, end: tuple[int, int]
@@ -113,13 +117,24 @@ class TouchPatchBrowser(
         self.toast_message = message
         self.toast_until = time.time() + seconds
     def run(self) -> None:
-        signal_browser_ready()
         clock = pygame.time.Clock()
         print("Touch patch browser running.")
         print(f"Display: {self.width}x{self.height}")
         print(f"Quick Select folder: {favorites_display_name()} ({FAVORITES_NAME.lstrip('!')})")
 
         while self._running:
+            if not self._boot_splash_done:
+                if not self._tick_boot_splash_until_ready():
+                    for event in pygame.event.get():
+                        if event.type == pygame.QUIT:
+                            self._running = False
+                            break
+                    clock.tick(30)
+                    continue
+                self._draw()
+                self._complete_boot_splash()
+                clock.tick(60)
+                continue
             if self._scan_dirty and not (
                 self.screen_state == Screen.BROWSER
                 and not self.left_nav_collapsed
@@ -161,7 +176,8 @@ class TouchPatchBrowser(
         self.theme_mode = load_theme_mode_from_prefs()
         self.theme = theme_for_mode(self.theme_mode)
         self._boot_splash_started = time.monotonic()
-        self._paint_boot_splash_frame(progress=0.05)
+        self._boot_splash_done = False
+        self._paint_boot_splash_frame(animation_phase=0.0)
         self.font_lg = self._load_font(34)
         self.font_md = self._load_font(22)
         self.font_sm = self._load_font(18)
@@ -224,7 +240,6 @@ class TouchPatchBrowser(
         self._bootstrap_patches()
         self._start_background_scan()
         self._wait_for_initial_scan()
-        self._finish_boot_splash()
         self._start_evdev_touch_bridge()
 
 

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -40,8 +40,10 @@ from patch_browser.touch_ui_enums import CalibrateMode, LeftNavMode, Screen
 from patch_browser.dsi_splash import (
     BOOT_MIN_SECONDS,
     SplashMode,
+    clear_browser_ready_flag,
     draw_splash_frame,
-    recent_splash_debounce,
+    signal_browser_ready,
+    stop_boot_splash_service,
 )
 from patch_browser.ui_theme import load_theme_mode_from_prefs, theme_for_mode
 
@@ -68,28 +70,31 @@ class TouchPatchBrowser(
         """Paint background immediately so stale DRM frames never show."""
         self.screen.fill(self.theme.bg)
         pygame.display.flip()
-    def _play_boot_splash_if_needed(self) -> None:
-        """Brief branded boot frames after early splash service hands off."""
-        if recent_splash_debounce():
-            return
-        start = time.monotonic()
+
+    def _paint_boot_splash_frame(self, *, progress: float) -> None:
+        draw_splash_frame(
+            self.screen,
+            mode=SplashMode.BOOT,
+            theme=self.theme,
+            progress=progress,
+        )
+
+    def _finish_boot_splash(self) -> None:
+        """Hold branded boot frames until minimum time and first scan settle."""
+        start = getattr(self, "_boot_splash_started", time.monotonic())
         clock = pygame.time.Clock()
         while True:
             elapsed = time.monotonic() - start
+            progress = min(1.0, elapsed / BOOT_MIN_SECONDS)
+            self._paint_boot_splash_frame(progress=progress)
             if elapsed >= BOOT_MIN_SECONDS:
                 break
-            progress = min(1.0, elapsed / BOOT_MIN_SECONDS)
-            draw_splash_frame(
-                self.screen,
-                mode=SplashMode.BOOT,
-                theme=self.theme,
-                progress=progress,
-            )
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self._running = False
                     return
             clock.tick(30)
+        signal_browser_ready()
     def _pointer_move_distance(
         self, start: tuple[int, int] | None, end: tuple[int, int]
     ) -> float:
@@ -141,9 +146,13 @@ class TouchPatchBrowser(
         self.cpu_monitor.stop()
         pygame.quit()
     def __init__(self) -> None:
+        clear_browser_ready_flag()
+        windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
+        if not windowed and not os.environ.get("DISPLAY"):
+            stop_boot_splash_service()
+
         pygame.init()
         pygame.display.set_caption("Pi-Surge-MPE Touch Browser")
-        windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
         if windowed:
             self.screen = pygame.display.set_mode((800, 480))
         else:
@@ -152,7 +161,8 @@ class TouchPatchBrowser(
         pygame.mouse.set_visible(False)
         self.theme_mode = load_theme_mode_from_prefs()
         self.theme = theme_for_mode(self.theme_mode)
-        self._clear_display()
+        self._boot_splash_started = time.monotonic()
+        self._paint_boot_splash_frame(progress=0.05)
         self.font_lg = self._load_font(34)
         self.font_md = self._load_font(22)
         self.font_sm = self._load_font(18)
@@ -215,7 +225,7 @@ class TouchPatchBrowser(
         self._bootstrap_patches()
         self._start_background_scan()
         self._wait_for_initial_scan()
-        self._play_boot_splash_if_needed()
+        self._finish_boot_splash()
         self._start_evdev_touch_bridge()
 
 

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -37,6 +37,12 @@ from patch_browser.touch_browser_patches import TouchBrowserPatchesMixin
 from patch_browser.touch_browser_prefs import TouchBrowserPrefsMixin
 from patch_browser.touch_ui_constants import TAP_MOVE_THRESHOLD_PX
 from patch_browser.touch_ui_enums import CalibrateMode, LeftNavMode, Screen
+from patch_browser.dsi_splash import (
+    BOOT_MIN_SECONDS,
+    SplashMode,
+    draw_splash_frame,
+    recent_splash_debounce,
+)
 from patch_browser.ui_theme import load_theme_mode_from_prefs, theme_for_mode
 
 
@@ -62,6 +68,28 @@ class TouchPatchBrowser(
         """Paint background immediately so stale DRM frames never show."""
         self.screen.fill(self.theme.bg)
         pygame.display.flip()
+    def _play_boot_splash_if_needed(self) -> None:
+        """Brief branded boot frames after early splash service hands off."""
+        if recent_splash_debounce():
+            return
+        start = time.monotonic()
+        clock = pygame.time.Clock()
+        while True:
+            elapsed = time.monotonic() - start
+            if elapsed >= BOOT_MIN_SECONDS:
+                break
+            progress = min(1.0, elapsed / BOOT_MIN_SECONDS)
+            draw_splash_frame(
+                self.screen,
+                mode=SplashMode.BOOT,
+                theme=self.theme,
+                progress=progress,
+            )
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    self._running = False
+                    return
+            clock.tick(30)
     def _pointer_move_distance(
         self, start: tuple[int, int] | None, end: tuple[int, int]
     ) -> float:
@@ -187,6 +215,7 @@ class TouchPatchBrowser(
         self._bootstrap_patches()
         self._start_background_scan()
         self._wait_for_initial_scan()
+        self._play_boot_splash_if_needed()
         self._start_evdev_touch_bridge()
 
 

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -113,6 +113,7 @@ class TouchPatchBrowser(
         self.toast_message = message
         self.toast_until = time.time() + seconds
     def run(self) -> None:
+        signal_browser_ready()
         clock = pygame.time.Clock()
         print("Touch patch browser running.")
         print(f"Display: {self.width}x{self.height}")

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -40,10 +40,10 @@ from patch_browser.touch_ui_enums import CalibrateMode, LeftNavMode, Screen
 from patch_browser.dsi_splash import (
     BOOT_MIN_SECONDS,
     SplashMode,
+    acquire_browser_display,
     clear_browser_ready_flag,
     draw_splash_frame,
     signal_browser_ready,
-    stop_boot_splash_service,
 )
 from patch_browser.ui_theme import load_theme_mode_from_prefs, theme_for_mode
 
@@ -148,15 +148,13 @@ class TouchPatchBrowser(
     def __init__(self) -> None:
         clear_browser_ready_flag()
         windowed = os.environ.get("MPE_TOUCH_WINDOWED") == "1"
-        if not windowed and not os.environ.get("DISPLAY"):
-            stop_boot_splash_service()
-
-        pygame.init()
-        pygame.display.set_caption("Pi-Surge-MPE Touch Browser")
         if windowed:
+            pygame.init()
+            pygame.display.set_caption("Pi-Surge-MPE Touch Browser")
             self.screen = pygame.display.set_mode((800, 480))
         else:
-            self.screen = pygame.display.set_mode((800, 480), pygame.FULLSCREEN)
+            self.screen = acquire_browser_display()
+            pygame.display.set_caption("Pi-Surge-MPE Touch Browser")
         self.width, self.height = self.screen.get_size()
         pygame.mouse.set_visible(False)
         self.theme_mode = load_theme_mode_from_prefs()

--- a/patch_browser/touch_browser_input.py
+++ b/patch_browser/touch_browser_input.py
@@ -7,6 +7,7 @@ import time
 
 import pygame
 
+from patch_browser.dsi_splash import run_shutdown_animation
 from patch_browser.touch_ui_constants import (
     DEFAULT_BRIGHTNESS_PERCENT,
     MIXER_DOUBLE_TAP_MS,
@@ -269,6 +270,9 @@ class TouchBrowserInputMixin:
             if self._modal_pending_index == 0:
                 self.screen_state = Screen.POWER_MENU
             else:
+                if self._evdev_bridge is not None:
+                    self._evdev_bridge.stop()
+                run_shutdown_animation(screen=self.screen)
                 cmd = (
                     ["sudo", "poweroff"]
                     if self.power_action == "shutdown"

--- a/patch_browser/touch_browser_input.py
+++ b/patch_browser/touch_browser_input.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import subprocess
 import time
 
 import pygame
 
 from patch_browser.dsi_splash import (
-    SplashMode,
-    draw_splash_frame,
-    run_shutdown_animation,
+    run_browser_shutdown_hold,
     stop_getty_tty1,
 )
 from patch_browser.touch_ui_constants import (
@@ -278,28 +275,11 @@ class TouchBrowserInputMixin:
                 if self._evdev_bridge is not None:
                     self._evdev_bridge.stop()
                 stop_getty_tty1()
-                run_shutdown_animation(screen=self.screen)
-                cmd = (
-                    ["sudo", "poweroff"]
-                    if self.power_action == "shutdown"
-                    else ["sudo", "reboot"]
+                run_browser_shutdown_hold(
+                    self.screen,
+                    self.theme,
+                    power_action=self.power_action,
                 )
-                subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    start_new_session=True,
-                )
-                theme = self.theme
-                clock = pygame.time.Clock()
-                while True:
-                    draw_splash_frame(
-                        self.screen,
-                        mode=SplashMode.SHUTDOWN,
-                        theme=theme,
-                        progress=0.0,
-                    )
-                    clock.tick(10)
         self._clear_modal_pointer()
     def _handle_event(self, event: pygame.event.Event) -> None:
         if event.type == pygame.QUIT:

--- a/patch_browser/touch_browser_input.py
+++ b/patch_browser/touch_browser_input.py
@@ -7,7 +7,12 @@ import time
 
 import pygame
 
-from patch_browser.dsi_splash import run_shutdown_animation
+from patch_browser.dsi_splash import (
+    SplashMode,
+    draw_splash_frame,
+    run_shutdown_animation,
+    stop_getty_tty1,
+)
 from patch_browser.touch_ui_constants import (
     DEFAULT_BRIGHTNESS_PERCENT,
     MIXER_DOUBLE_TAP_MS,
@@ -272,13 +277,29 @@ class TouchBrowserInputMixin:
             else:
                 if self._evdev_bridge is not None:
                     self._evdev_bridge.stop()
+                stop_getty_tty1()
                 run_shutdown_animation(screen=self.screen)
                 cmd = (
                     ["sudo", "poweroff"]
                     if self.power_action == "shutdown"
                     else ["sudo", "reboot"]
                 )
-                subprocess.run(cmd, check=False)
+                subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+                theme = self.theme
+                clock = pygame.time.Clock()
+                while True:
+                    draw_splash_frame(
+                        self.screen,
+                        mode=SplashMode.SHUTDOWN,
+                        theme=theme,
+                        progress=0.0,
+                    )
+                    clock.tick(10)
         self._clear_modal_pointer()
     def _handle_event(self, event: pygame.event.Event) -> None:
         if event.type == pygame.QUIT:

--- a/patch_browser/touch_browser_normalization.py
+++ b/patch_browser/touch_browser_normalization.py
@@ -202,6 +202,7 @@ class TouchBrowserNormalizationMixin:
             theme=self.theme,
             progress=0.0,
         )
+        pygame.display.flip()
         os.environ[MPE_CALIB_FROM_BROWSER] = MPE_CALIB_FROM_BROWSER_ACTIVE
         try:
             os.execv(sys.executable, argv)

--- a/patch_browser/touch_browser_normalization.py
+++ b/patch_browser/touch_browser_normalization.py
@@ -11,10 +11,11 @@ from pathlib import Path
 import pygame
 
 from patch_browser.calibration_constants import (
-    CALIBRATE_WITH_LOADER_SCRIPT,
+    CALIBRATION_LOADER_SCRIPT,
     MPE_CALIB_FROM_BROWSER,
     MPE_CALIB_FROM_BROWSER_ACTIVE,
 )
+from patch_browser.dsi_splash import SplashMode, draw_splash_frame
 from patch_browser.geometry import Rect
 from patch_browser.touch_ui_constants import NORM_CHECKBOX_SIZE
 from patch_browser.touch_ui_enums import CalibrateMode
@@ -190,20 +191,25 @@ class TouchBrowserNormalizationMixin:
             f"({total - targets} already done)."
         )
     def _launch_calibration_loader(self) -> None:
-        args = ["bash", str(CALIBRATE_WITH_LOADER_SCRIPT)]
+        argv = [sys.executable, "-u", str(CALIBRATION_LOADER_SCRIPT)]
         if self._pending_calibrate_mode == CalibrateMode.FORCE_FULL:
-            args.append("--force")
+            argv.append("--force")
         if self._evdev_bridge is not None:
             self._evdev_bridge.stop()
+        draw_splash_frame(
+            self.screen,
+            mode=SplashMode.CAL_ENTER,
+            theme=self.theme,
+            progress=0.0,
+        )
         os.environ[MPE_CALIB_FROM_BROWSER] = MPE_CALIB_FROM_BROWSER_ACTIVE
-        pygame.quit()
         try:
-            os.execv("/bin/bash", args)
+            os.execv(sys.executable, argv)
         except OSError as exc:
             message = f"Failed to launch calibration loader: {exc}"
             print(message, file=sys.stderr)
             _write_calibration_execv_failure_report(
                 message,
-                script=CALIBRATE_WITH_LOADER_SCRIPT,
+                script=CALIBRATION_LOADER_SCRIPT,
             )
             sys.exit(1)

--- a/patch_browser/touch_browser_patches.py
+++ b/patch_browser/touch_browser_patches.py
@@ -6,6 +6,7 @@ import threading
 import time
 from pathlib import Path
 
+from patch_browser.dsi_splash import BOOT_MIN_SECONDS
 from patch_browser.patch_scanner import favorites_display_name
 from patch_browser.touch_ui_enums import LeftNavMode
 
@@ -77,10 +78,23 @@ class TouchBrowserPatchesMixin:
         if self.scanner.scan_complete.is_set():
             self._apply_scan_results()
             return
-        if self.scanner.wait_for_scan(timeout=5.0):
-            self._apply_scan_results()
-        else:
-            print("Patch scan still running — list will update when complete")
+
+        start = time.monotonic()
+        clock = pygame.time.Clock()
+        while not self.scanner.scan_complete.is_set():
+            elapsed = time.monotonic() - start
+            boot_elapsed = time.monotonic() - getattr(
+                self, "_boot_splash_started", start
+            )
+            progress = min(0.92, max(0.08, boot_elapsed / BOOT_MIN_SECONDS * 0.85))
+            if elapsed > 5.0:
+                progress = min(0.95, progress + (elapsed - 5.0) * 0.01)
+            self._paint_boot_splash_frame(progress=progress)
+            if self.scanner.wait_for_scan(timeout=0.15):
+                break
+            clock.tick(30)
+
+        self._apply_scan_results()
     def _browse_category_name(self) -> str:
         if not self.categories:
             return "(No patches)"

--- a/patch_browser/touch_browser_patches.py
+++ b/patch_browser/touch_browser_patches.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pygame
 
-from patch_browser.dsi_splash import BOOT_MIN_SECONDS
+from patch_browser.dsi_splash import boot_animation_phase
 from patch_browser.patch_scanner import favorites_display_name
 from patch_browser.touch_ui_enums import LeftNavMode
 
@@ -89,10 +89,9 @@ class TouchBrowserPatchesMixin:
             boot_elapsed = time.monotonic() - getattr(
                 self, "_boot_splash_started", start
             )
-            progress = min(0.92, max(0.08, boot_elapsed / BOOT_MIN_SECONDS * 0.85))
-            if elapsed > 5.0:
-                progress = min(0.95, progress + (elapsed - 5.0) * 0.01)
-            self._paint_boot_splash_frame(progress=progress)
+            self._paint_boot_splash_frame(
+                animation_phase=boot_animation_phase(boot_elapsed),
+            )
             if elapsed >= max_wait:
                 break
             if self.scanner.wait_for_scan(timeout=0.15):

--- a/patch_browser/touch_browser_patches.py
+++ b/patch_browser/touch_browser_patches.py
@@ -6,6 +6,8 @@ import threading
 import time
 from pathlib import Path
 
+import pygame
+
 from patch_browser.dsi_splash import BOOT_MIN_SECONDS
 from patch_browser.patch_scanner import favorites_display_name
 from patch_browser.touch_ui_enums import LeftNavMode

--- a/patch_browser/touch_browser_patches.py
+++ b/patch_browser/touch_browser_patches.py
@@ -83,6 +83,7 @@ class TouchBrowserPatchesMixin:
 
         start = time.monotonic()
         clock = pygame.time.Clock()
+        max_wait = 8.0
         while not self.scanner.scan_complete.is_set():
             elapsed = time.monotonic() - start
             boot_elapsed = time.monotonic() - getattr(
@@ -92,11 +93,16 @@ class TouchBrowserPatchesMixin:
             if elapsed > 5.0:
                 progress = min(0.95, progress + (elapsed - 5.0) * 0.01)
             self._paint_boot_splash_frame(progress=progress)
+            if elapsed >= max_wait:
+                break
             if self.scanner.wait_for_scan(timeout=0.15):
                 break
             clock.tick(30)
 
-        self._apply_scan_results()
+        if self.scanner.scan_complete.is_set():
+            self._apply_scan_results()
+        else:
+            print("Patch scan still running — list will update when complete")
     def _browse_category_name(self) -> str:
         if not self.categories:
             return "(No patches)"

--- a/scripts/apply-dsi-cmdline.sh
+++ b/scripts/apply-dsi-cmdline.sh
@@ -26,6 +26,17 @@ fi
 line="$(tr -d '\n' < "$CMDLINE")"
 changed=0
 
+remove_token() {
+    local token="$1"
+    if [[ " $line " != *" $token "* ]]; then
+        return
+    fi
+    line="${line// $token/}"
+    line="${line//$token /}"
+    line="${line//$token/}"
+    changed=1
+}
+
 add_token() {
     local token="$1"
     if [[ " $line " == *" $token "* ]]; then
@@ -36,6 +47,7 @@ add_token() {
 }
 
 # Prefer serial console; keep framebuffer console off the DSI.
+remove_token "console=tty1"
 add_token "console=serial0,115200"
 add_token "fbcon=map:0"
 

--- a/scripts/apply-dsi-cmdline.sh
+++ b/scripts/apply-dsi-cmdline.sh
@@ -9,6 +9,22 @@
 
 set -euo pipefail
 
+STRIP_TTY1=false
+for arg in "$@"; do
+    case "$arg" in
+        --strip-tty1) STRIP_TTY1=true ;;
+        -h|--help)
+            echo "Usage: sudo $0 [--strip-tty1]" >&2
+            echo "  --strip-tty1  Remove console=tty1 (aggressive DSI; keep serial attached)" >&2
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
 CMDLINE="/boot/firmware/cmdline.txt"
 if [ ! -f "$CMDLINE" ]; then
     CMDLINE="/boot/cmdline.txt"
@@ -47,9 +63,17 @@ add_token() {
 }
 
 # Prefer serial console; keep framebuffer console off the DSI.
-remove_token "console=tty1"
+# Do NOT remove console=tty1 by default — some Pi/firmware combos hang early boot
+# without it. Use --strip-tty1 only after you have serial console to recover.
 add_token "console=serial0,115200"
 add_token "fbcon=map:0"
+# Reduce kernel scroll noise on the panel without dropping tty1.
+add_token "loglevel=3"
+add_token "logo.nologo"
+
+if [ "$STRIP_TTY1" = true ]; then
+    remove_token "console=tty1"
+fi
 
 if [ "$changed" -eq 0 ]; then
     echo "cmdline already has DSI console flags — no change"

--- a/scripts/apply-dsi-cmdline.sh
+++ b/scripts/apply-dsi-cmdline.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Idempotently add DSI-friendly kernel cmdline flags on Raspberry Pi OS.
+#
+# Redirects boot console to serial and keeps fbcon off the panel so kernel
+# scroll does not flash on the SmartiPi DSI before touch-boot-animation starts.
+#
+# Usage (on Pi):
+#   sudo ./scripts/apply-dsi-cmdline.sh
+
+set -euo pipefail
+
+CMDLINE="/boot/firmware/cmdline.txt"
+if [ ! -f "$CMDLINE" ]; then
+    CMDLINE="/boot/cmdline.txt"
+fi
+if [ ! -f "$CMDLINE" ]; then
+    echo "ERROR: cmdline.txt not found under /boot/firmware or /boot" >&2
+    exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: run as root (sudo $0)" >&2
+    exit 1
+fi
+
+line="$(tr -d '\n' < "$CMDLINE")"
+changed=0
+
+add_token() {
+    local token="$1"
+    if [[ " $line " == *" $token "* ]]; then
+        return
+    fi
+    line="$line $token"
+    changed=1
+}
+
+# Prefer serial console; keep framebuffer console off the DSI.
+add_token "console=serial0,115200"
+add_token "fbcon=map:0"
+
+if [ "$changed" -eq 0 ]; then
+    echo "cmdline already has DSI console flags — no change"
+    exit 0
+fi
+
+cp "$CMDLINE" "${CMDLINE}.bak.$(date +%Y%m%d%H%M%S)"
+printf '%s\n' "$line" > "$CMDLINE"
+echo "Updated $CMDLINE (backup saved alongside)"
+echo "Reboot the Pi for cmdline changes to take effect."

--- a/scripts/configure-pi-paths.sh
+++ b/scripts/configure-pi-paths.sh
@@ -47,6 +47,7 @@ _run_on_pi() {
         echo "Writing /etc/mpe/mpe.env ..."
         sudo tee /etc/mpe/mpe.env > /dev/null <<EOF
 MPE_PI_USER=$MPE_PI_USER
+MPE_HOME=$HOME
 MPE_MODULE_REPO=$MPE_MODULE_REPO
 MPE_PERSONAL_REPO=${MPE_PERSONAL_REPO:-$HOME/MPE-Library}
 MPE_SURGE_ROOT=$MPE_SURGE_ROOT

--- a/scripts/lib/mpe-services.sh
+++ b/scripts/lib/mpe-services.sh
@@ -22,11 +22,13 @@ mpe_enable_patch_browser_ui() {
     if [ "$mode" = touch ]; then
         unit=touch-patch-browser.service
         other=patch-browser.service
-        sudo systemctl disable --now boot-animation.service 2>/dev/null || true
+        sudo systemctl disable --now boot-animation.service shutdown-animation.service 2>/dev/null || true
+        sudo systemctl enable touch-boot-animation.service touch-shutdown-animation.service 2>/dev/null || true
     else
         unit=patch-browser.service
         other=touch-patch-browser.service
-        sudo systemctl enable boot-animation.service 2>/dev/null || true
+        sudo systemctl disable --now touch-boot-animation.service touch-shutdown-animation.service 2>/dev/null || true
+        sudo systemctl enable boot-animation.service shutdown-animation.service 2>/dev/null || true
     fi
 
     sudo systemctl disable --now "$other" 2>/dev/null || true
@@ -57,6 +59,8 @@ mpe_restart_core_services() {
     sudo systemctl restart surge-xt-cli.service 2>/dev/null || true
     if [ "$(_mpe_ui_mode_normalized)" = oled ]; then
         sudo systemctl restart boot-animation.service 2>/dev/null || true
+    elif [ "$(_mpe_ui_mode_normalized)" = touch ]; then
+        sudo systemctl restart touch-boot-animation.service 2>/dev/null || true
     fi
     if systemctl is-enabled --quiet "$browser" 2>/dev/null; then
         sudo systemctl restart "$browser" 2>/dev/null || true

--- a/scripts/lib/paths.sh
+++ b/scripts/lib/paths.sh
@@ -23,6 +23,23 @@ fi
 
 MPE_MODULE_REPO="${MPE_MODULE_REPO:-$_MPE_MODULE_ROOT}"
 
+# systemd runs some oneshots as root; honor Pi user home for Surge/logs when set.
+mpe_apply_pi_home() {
+    if [ -n "${MPE_HOME:-}" ]; then
+        export HOME="$MPE_HOME"
+        return 0
+    fi
+    local u="${MPE_PI_USER:-}"
+    if [ -z "$u" ] && [ -f /etc/mpe/mpe.env ]; then
+        u="$(grep -E '^MPE_PI_USER=' /etc/mpe/mpe.env 2>/dev/null | cut -d= -f2- | tr -d '"' || true)"
+    fi
+    if [ "$(id -un 2>/dev/null || true)" = root ] && [ -n "$u" ] && [ -d "/home/$u" ]; then
+        export HOME="/home/$u"
+    fi
+}
+
+mpe_apply_pi_home
+
 MPE_PERSONAL_REPO="${MPE_PERSONAL_REPO:-}"
 if [ -n "$MPE_PERSONAL_REPO" ] && [ -d "$MPE_PERSONAL_REPO" ]; then
     MPE_PERSONAL_REPO="$(cd "$MPE_PERSONAL_REPO" && pwd)"

--- a/scripts/start-touch-patch-browser.sh
+++ b/scripts/start-touch-patch-browser.sh
@@ -24,24 +24,17 @@ fi
 #   MPE_TOUCH_WINDOWED=1 ./scripts/start-touch-patch-browser.sh
 
 if systemctl is-active --quiet boot-animation.service 2>/dev/null; then
-    echo "Stopping OLED boot animation..."
+    echo "Stopping OLED boot animation..." >&2
     sudo systemctl stop boot-animation.service
 fi
 
-if systemctl is-active --quiet touch-boot-animation.service 2>/dev/null; then
-    echo "Stopping touch boot splash..."
-    sudo systemctl stop touch-boot-animation.service
-fi
+# Keep touch-boot-animation running until the browser claims DRM (see touch_browser_app).
+# Do not clear the framebuffer here — that releases kmsdrm and flashes the console.
 
 if systemctl is-active --quiet patch-browser.service 2>/dev/null; then
-    echo "Stopping OLED patch browser (touch build uses a separate service)..."
+    echo "Stopping OLED patch browser (touch build uses a separate service)..." >&2
     sudo systemctl stop patch-browser.service
 fi
 
-# KMS/DRM keeps the last pygame frame on the panel until something redraws.
-# Clear immediately so an old UI never flashes during the python import/scan gap.
-python3 -u "$MPE_MODULE_REPO/scripts/clear-dsi-framebuffer.py" 2>/dev/null || true
-
-echo "Starting touch patch browser..."
 cd "$MPE_MODULE_REPO"
-python3 -u "$MPE_MODULE_REPO/touch_patch_browser.py"
+exec python3 -u "$MPE_MODULE_REPO/touch_patch_browser.py"

--- a/scripts/start-touch-patch-browser.sh
+++ b/scripts/start-touch-patch-browser.sh
@@ -24,8 +24,13 @@ fi
 #   MPE_TOUCH_WINDOWED=1 ./scripts/start-touch-patch-browser.sh
 
 if systemctl is-active --quiet boot-animation.service 2>/dev/null; then
-    echo "Stopping boot animation..."
+    echo "Stopping OLED boot animation..."
     sudo systemctl stop boot-animation.service
+fi
+
+if systemctl is-active --quiet touch-boot-animation.service 2>/dev/null; then
+    echo "Stopping touch boot splash..."
+    sudo systemctl stop touch-boot-animation.service
 fi
 
 if systemctl is-active --quiet patch-browser.service 2>/dev/null; then

--- a/tests/test_calibration_handoff.py
+++ b/tests/test_calibration_handoff.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import os
+import sys
 import unittest
 from pathlib import Path
 from unittest import mock
 
 from patch_browser import calibration_teardown as ct
 from patch_browser.calibration_constants import (
+    CALIBRATION_LOADER_SCRIPT,
     CALIBRATE_WITH_LOADER_SCRIPT,
     MPE_CALIB_FROM_BROWSER,
     REPO_ROOT,
@@ -97,41 +99,42 @@ class CalibrationLoaderLaunchTests(unittest.TestCase):
         self.assertTrue(CALIBRATE_WITH_LOADER_SCRIPT.is_file())
 
     @mock.patch("patch_browser.touch_browser_normalization.os.execv")
-    @mock.patch("patch_browser.touch_browser_normalization.pygame.quit")
-    def test_launch_calibration_loader_uses_repo_root_script(
+    def test_launch_calibration_loader_uses_python_loader(
         self,
-        _quit: mock.Mock,
         execv_mock: mock.Mock,
     ) -> None:
+        self.mixin.screen = mock.Mock()
+        self.mixin.theme = mock.Mock()
         self.mixin._launch_calibration_loader()
         execv_mock.assert_called_once()
         argv = execv_mock.call_args.args[1]
-        self.assertEqual(argv[0], "bash")
-        self.assertEqual(Path(argv[1]), CALIBRATE_WITH_LOADER_SCRIPT)
+        self.assertEqual(argv[0], sys.executable)
+        self.assertEqual(argv[1], "-u")
+        self.assertEqual(Path(argv[2]), CALIBRATION_LOADER_SCRIPT)
         self.assertNotIn("--force", argv)
 
     @mock.patch("patch_browser.touch_browser_normalization.os.execv")
-    @mock.patch("patch_browser.touch_browser_normalization.pygame.quit")
     def test_launch_calibration_loader_force_appends_flag(
         self,
-        _quit: mock.Mock,
         execv_mock: mock.Mock,
     ) -> None:
+        self.mixin.screen = mock.Mock()
+        self.mixin.theme = mock.Mock()
         self.mixin._pending_calibrate_mode = CalibrateMode.FORCE_FULL
         self.mixin._launch_calibration_loader()
         argv = execv_mock.call_args.args[1]
-        self.assertEqual(Path(argv[1]), CALIBRATE_WITH_LOADER_SCRIPT)
+        self.assertEqual(Path(argv[2]), CALIBRATION_LOADER_SCRIPT)
         self.assertEqual(argv[-1], "--force")
 
     @mock.patch("patch_browser.touch_browser_normalization.sys.exit")
     @mock.patch("patch_browser.touch_browser_normalization.os.execv")
-    @mock.patch("patch_browser.touch_browser_normalization.pygame.quit")
     def test_launch_calibration_loader_execv_failure_exits_cleanly(
         self,
-        _quit: mock.Mock,
         execv_mock: mock.Mock,
         exit_mock: mock.Mock,
     ) -> None:
+        self.mixin.screen = mock.Mock()
+        self.mixin.theme = mock.Mock()
         execv_mock.side_effect = OSError("exec failed")
         self.mixin._launch_calibration_loader()
         exit_mock.assert_called_once_with(1)

--- a/tests/test_dsi_splash_shutdown.py
+++ b/tests/test_dsi_splash_shutdown.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import unittest
 
 from patch_browser.dsi_splash import (
+    BOOT_SPINNER_PERIOD,
     SHUTDOWN_SLOW_HINT_SECONDS,
+    boot_animation_phase,
     shutdown_animation_phase,
     shutdown_subtitle,
 )
@@ -16,6 +18,11 @@ class ShutdownSplashHelperTests(unittest.TestCase):
         self.assertAlmostEqual(shutdown_animation_phase(0.0), 0.0)
         self.assertAlmostEqual(shutdown_animation_phase(0.6, period=1.2), 0.5)
         self.assertAlmostEqual(shutdown_animation_phase(1.2, period=1.2), 0.0)
+
+    def test_boot_animation_phase_cycles(self) -> None:
+        self.assertAlmostEqual(boot_animation_phase(0.0), 0.0)
+        self.assertAlmostEqual(boot_animation_phase(0.6, period=BOOT_SPINNER_PERIOD), 0.5)
+        self.assertAlmostEqual(boot_animation_phase(BOOT_SPINNER_PERIOD, period=BOOT_SPINNER_PERIOD), 0.0)
 
     def test_subtitle_before_slow_threshold(self) -> None:
         self.assertEqual(shutdown_subtitle(0.0), "Shutting down…")

--- a/tests/test_dsi_splash_shutdown.py
+++ b/tests/test_dsi_splash_shutdown.py
@@ -1,0 +1,36 @@
+"""Unit tests for shutdown splash helpers (no display required)."""
+
+from __future__ import annotations
+
+import unittest
+
+from patch_browser.dsi_splash import (
+    SHUTDOWN_SLOW_HINT_SECONDS,
+    shutdown_animation_phase,
+    shutdown_subtitle,
+)
+
+
+class ShutdownSplashHelperTests(unittest.TestCase):
+    def test_animation_phase_cycles(self) -> None:
+        self.assertAlmostEqual(shutdown_animation_phase(0.0), 0.0)
+        self.assertAlmostEqual(shutdown_animation_phase(0.6, period=1.2), 0.5)
+        self.assertAlmostEqual(shutdown_animation_phase(1.2, period=1.2), 0.0)
+
+    def test_subtitle_before_slow_threshold(self) -> None:
+        self.assertEqual(shutdown_subtitle(0.0), "Shutting down…")
+        self.assertEqual(
+            shutdown_subtitle(SHUTDOWN_SLOW_HINT_SECONDS - 0.1),
+            "Shutting down…",
+        )
+
+    def test_subtitle_after_slow_threshold(self) -> None:
+        self.assertEqual(
+            shutdown_subtitle(SHUTDOWN_SLOW_HINT_SECONDS),
+            "Still shutting down…",
+        )
+        self.assertEqual(shutdown_subtitle(60.0), "Still shutting down…")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_touch_browser_smoke.py
+++ b/tests/test_touch_browser_smoke.py
@@ -164,7 +164,7 @@ class TouchBrowserSmokeTests(unittest.TestCase):
             mock.patch("patch_browser.touch_browser_app.evdev_bridge_enabled", return_value=False),
             mock.patch.object(TouchPatchBrowser, "_start_background_scan"),
             mock.patch.object(TouchPatchBrowser, "_wait_for_initial_scan"),
-            mock.patch.object(TouchPatchBrowser, "_play_boot_splash_if_needed"),
+            mock.patch.object(TouchPatchBrowser, "_finish_boot_splash"),
             mock.patch.object(TouchPatchBrowser, "_start_evdev_touch_bridge"),
         ]
         for patcher in patches:

--- a/tests/test_touch_browser_smoke.py
+++ b/tests/test_touch_browser_smoke.py
@@ -164,6 +164,7 @@ class TouchBrowserSmokeTests(unittest.TestCase):
             mock.patch("patch_browser.touch_browser_app.evdev_bridge_enabled", return_value=False),
             mock.patch.object(TouchPatchBrowser, "_start_background_scan"),
             mock.patch.object(TouchPatchBrowser, "_wait_for_initial_scan"),
+            mock.patch.object(TouchPatchBrowser, "_play_boot_splash_if_needed"),
             mock.patch.object(TouchPatchBrowser, "_start_evdev_touch_bridge"),
         ]
         for patcher in patches:

--- a/tests/test_touch_browser_smoke.py
+++ b/tests/test_touch_browser_smoke.py
@@ -164,7 +164,7 @@ class TouchBrowserSmokeTests(unittest.TestCase):
             mock.patch("patch_browser.touch_browser_app.evdev_bridge_enabled", return_value=False),
             mock.patch.object(TouchPatchBrowser, "_start_background_scan"),
             mock.patch.object(TouchPatchBrowser, "_wait_for_initial_scan"),
-            mock.patch.object(TouchPatchBrowser, "_finish_boot_splash"),
+            mock.patch.object(TouchPatchBrowser, "_complete_boot_splash"),
             mock.patch.object(TouchPatchBrowser, "_start_evdev_touch_bridge"),
         ]
         for patcher in patches:

--- a/touch_boot_splash.py
+++ b/touch_boot_splash.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Early-boot DSI splash for touch mode (systemd touch-boot-animation.service)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from patch_browser.dsi_splash import (
+    paint_hold_black,
+    run_boot_animation,
+    run_hold_loop,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Touch DSI boot splash")
+    parser.add_argument(
+        "--mode",
+        choices=("hold", "animate", "black"),
+        default="hold",
+        help="hold=until stopped by browser start; animate=fixed duration; black=instant fill",
+    )
+    parser.add_argument("--duration", type=float, default=None, help="Seconds for --mode animate")
+    parser.add_argument(
+        "--no-debounce",
+        action="store_true",
+        help="Always run full animation (ignore fast-restart debounce)",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "black":
+        paint_hold_black()
+        return 0
+    if args.mode == "animate":
+        run_boot_animation(duration=args.duration, debounce=not args.no_debounce)
+        return 0
+    run_hold_loop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/touch_shutdown_splash.py
+++ b/touch_shutdown_splash.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Shutdown DSI splash for touch mode (systemd + standalone)."""
+
+from __future__ import annotations
+
+import sys
+
+from patch_browser.dsi_splash import run_shutdown_animation
+
+
+def main() -> int:
+    run_shutdown_animation()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/touch_shutdown_splash.py
+++ b/touch_shutdown_splash.py
@@ -3,13 +3,24 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 
-from patch_browser.dsi_splash import run_shutdown_animation
+from patch_browser.dsi_splash import hold_shutdown_frame, run_shutdown_animation
 
 
 def main() -> int:
-    run_shutdown_animation()
+    parser = argparse.ArgumentParser(description="Touch DSI shutdown splash")
+    parser.add_argument(
+        "--hold",
+        action="store_true",
+        help="Hold shutdown frame until systemd kills this unit (halt/reboot path)",
+    )
+    args = parser.parse_args()
+    if args.hold:
+        hold_shutdown_frame()
+    else:
+        run_shutdown_animation()
     return 0
 
 


### PR DESCRIPTION
## Summary
- Harden boot after aggressive DSI cmdline / USB gadget experiments: keep `console=tty1` by default (`--strip-tty1` opt-in), cap boot splash hold, set `MPE_HOME` for root systemd units.
- Adds `docs/PI-BOOT-RECOVERY.md` and related service/path fixes.
- Includes issue #9 boot/shutdown/cal splash work with recovery-safe defaults on top.

## Test plan
- [x] `python3 -m unittest discover -s tests` (on integration branch)
- [ ] Pi smoke: boot completes, touch-patch-browser starts, no hang on tty1 strip


Made with [Cursor](https://cursor.com)