### PR TITLE
Persist usb-host audio profile across reboot

### DIFF
--- a/config/mpe-audio-profile-sync.service
+++ b/config/mpe-audio-profile-sync.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=MPE sync audio profile services from /etc/mpe/mpe.env
+Documentation=file:@MPE_MODULE_REPO@/docs/USB-AUDIO-HOST.md
+DefaultDependencies=no
+After=local-fs.target
+Before=surge-xt-cli.service
+ConditionPathExists=/etc/mpe/mpe.env
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/mpe/mpe.env
+ExecStart=@MPE_MODULE_REPO@/scripts/sync-audio-profile-on-boot.sh
+TimeoutStopSec=15
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -39,6 +39,9 @@
 #
 # usb-host requires one-time boot config: dtoverlay=dwc2,dr_mode=peripheral
 # See docs/USB-AUDIO-HOST.md
+#
+# Persisted in /etc/mpe/mpe.env — survives reboot and configure-pi-paths --force
+# (toggle in touch settings also writes this file via set-audio-profile.sh).
 # MPE_AUDIO_PROFILE=standalone
 
 # --- Surge audio buffer (Pi — reduces xrun/crackle under heavy MPE polyphony) ---

--- a/docs/USB-AUDIO-HOST.md
+++ b/docs/USB-AUDIO-HOST.md
@@ -63,7 +63,19 @@ Reboot once with **USB-C unplugged from the host**. This enables the USB-C port 
    sudo systemctl restart surge-xt-cli.service
    ```
 
+   Or toggle **USB host audio** in touch settings (⋯) — writes `/etc/mpe/mpe.env` and restarts Surge.
+
 5. On the **host**, select the gadget as a **capture / input / recording** device — **not** playback/output. The Pi sends audio *out* via UAC2; the host receives it on its **input** side (Passthrough). Linux: `pavucontrol` → Recording; Windows: Sound settings → Input.
+
+### Profile persistence (Pi)
+
+`MPE_AUDIO_PROFILE` lives in **`/etc/mpe/mpe.env`** and survives reboot:
+
+- Touch settings toggle → `set-audio-profile.sh` updates the file and matching systemd units
+- **`mpe-audio-profile-sync.service`** runs at boot (before Surge) and re-enables gadget + stall watchdog to match the file
+- **`configure-pi-paths.sh --force`** rewrites paths but **preserves** `MPE_AUDIO_PROFILE` and `MPE_SURGE_BUFFER_SIZE` from the existing file
+
+After a git pull on the Pi: `./scripts/configure-pi-paths.sh --local --force` — your audio mode is kept.
 
 ### Host capture on Linux
 

--- a/scripts/sync-audio-profile-on-boot.sh
+++ b/scripts/sync-audio-profile-on-boot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Apply persisted MPE_AUDIO_PROFILE from /etc/mpe/mpe.env at boot — enable/disable
+# gadget + stall watchdog to match, without restarting Surge (surge-xt-cli starts next).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+# shellcheck source=lib/mpe-services.sh
+source "$SCRIPT_DIR/lib/mpe-services.sh"
+
+mpe_source_appliance_env
+
+mpe_enable_usb_audio_gadget

--- a/tests/test_audio_profile_persist.py
+++ b/tests/test_audio_profile_persist.py
@@ -1,0 +1,70 @@
+"""Tests for persisted MPE_AUDIO_PROFILE across configure and boot."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class AudioProfilePersistTests(unittest.TestCase):
+    def test_configure_force_preserves_usb_host_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            env_file = tmp_path / "mpe.env"
+            env_file.write_text(
+                "MPE_PI_USER=mitch\nMPE_AUDIO_PROFILE=usb-host\nMPE_SURGE_BUFFER_SIZE=512\n",
+                encoding="utf-8",
+            )
+            script = REPO_ROOT / "scripts" / "lib" / "mpe-services.sh"
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    f"""
+                    source {script}
+                    mpe_read_appliance_env_var() {{
+                      grep -E "^${{1}}=" "{env_file}" | tail -1 | cut -d= -f2-
+                    }}
+                    profile="$(mpe_read_appliance_env_var MPE_AUDIO_PROFILE)"
+                    buffer="$(mpe_read_appliance_env_var MPE_SURGE_BUFFER_SIZE)"
+                    echo "profile=$profile buffer=$buffer"
+                    """,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("profile=usb-host", result.stdout)
+            self.assertIn("buffer=512", result.stdout)
+
+    def test_sync_on_boot_script_exists(self) -> None:
+        sync = REPO_ROOT / "scripts" / "sync-audio-profile-on-boot.sh"
+        self.assertTrue(sync.is_file())
+        self.assertTrue(os.access(sync, os.X_OK))
+
+    def test_boot_sync_unit_installed_in_config(self) -> None:
+        unit = REPO_ROOT / "config" / "mpe-audio-profile-sync.service"
+        self.assertTrue(unit.is_file())
+        text = unit.read_text(encoding="utf-8")
+        self.assertIn("sync-audio-profile-on-boot.sh", text)
+        self.assertIn("Before=surge-xt-cli.service", text)
+
+    def test_mpe_services_enables_profile_sync(self) -> None:
+        content = (REPO_ROOT / "scripts" / "lib" / "mpe-services.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("mpe_enable_audio_profile_sync", content)
+        self.assertIn("mpe-audio-profile-sync.service", content)
+        self.assertIn("mpe_source_appliance_env", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Preserves MPE_AUDIO_PROFILE in /etc/mpe/mpe.env; boot sync service before Surge.

Made with [Cursor](https://cursor.com)