### PR TITLE
Wire audio profile persistence into configure and profile toggle

### DIFF
--- a/scripts/configure-pi-paths.sh
+++ b/scripts/configure-pi-paths.sh
@@ -43,23 +43,37 @@ _run_on_pi() {
     echo ""
 
     sudo mkdir -p /etc/mpe
+    _preserved_audio_profile=""
+    _preserved_surge_buffer=""
+    if [ -f /etc/mpe/mpe.env ]; then
+        _preserved_audio_profile="$(mpe_read_appliance_env_var MPE_AUDIO_PROFILE 2>/dev/null || true)"
+        _preserved_surge_buffer="$(mpe_read_appliance_env_var MPE_SURGE_BUFFER_SIZE 2>/dev/null || true)"
+    fi
+    if [ -n "$_preserved_audio_profile" ]; then
+        MPE_AUDIO_PROFILE="$_preserved_audio_profile"
+    fi
     if [ "$FORCE" = true ] || [ ! -f /etc/mpe/mpe.env ]; then
         echo "Writing /etc/mpe/mpe.env ..."
-        sudo tee /etc/mpe/mpe.env > /dev/null <<EOF
-MPE_PI_USER=$MPE_PI_USER
-MPE_HOME=$HOME
-MPE_MODULE_REPO=$MPE_MODULE_REPO
-MPE_PERSONAL_REPO=${MPE_PERSONAL_REPO:-$HOME/MPE-Library}
-MPE_SURGE_ROOT=$MPE_SURGE_ROOT
-MPE_SURGE_DOCS="$MPE_SURGE_DOCS"
-MPE_SURGE_LOG=$LOG_FILE
-MPE_FAVORITES_NAME="$MPE_FAVORITES_NAME"
-MPE_UI_MODE="$MPE_UI_MODE"
-MPE_AUDIO_PROFILE=${MPE_AUDIO_PROFILE:-standalone}
-EOF
+        {
+            echo "MPE_PI_USER=$MPE_PI_USER"
+            echo "MPE_HOME=$HOME"
+            echo "MPE_MODULE_REPO=$MPE_MODULE_REPO"
+            echo "MPE_PERSONAL_REPO=${MPE_PERSONAL_REPO:-$HOME/MPE-Library}"
+            echo "MPE_SURGE_ROOT=$MPE_SURGE_ROOT"
+            echo "MPE_SURGE_DOCS=\"$MPE_SURGE_DOCS\""
+            echo "MPE_SURGE_LOG=$LOG_FILE"
+            echo "MPE_FAVORITES_NAME=\"$MPE_FAVORITES_NAME\""
+            echo "MPE_UI_MODE=\"$MPE_UI_MODE\""
+            echo "MPE_AUDIO_PROFILE=${MPE_AUDIO_PROFILE:-standalone}"
+            if [ -n "$_preserved_surge_buffer" ]; then
+                echo "MPE_SURGE_BUFFER_SIZE=$_preserved_surge_buffer"
+            fi
+        } | sudo tee /etc/mpe/mpe.env > /dev/null
     else
-        echo "Keeping existing /etc/mpe/mpe.env (use --force to rewrite)"
+        echo "Keeping existing /etc/mpe/mpe.env (use --force to rewrite paths; audio profile preserved on --force)"
     fi
+
+    mpe_source_appliance_env
 
     _install_service() {
         local src="$1"

--- a/scripts/lib/mpe-services.sh
+++ b/scripts/lib/mpe-services.sh
@@ -16,6 +16,27 @@ mpe_patch_browser_unit() {
     fi
 }
 
+# Read one KEY=value from /etc/mpe/mpe.env (appliance canon — not repo config/mpe.env).
+mpe_read_appliance_env_var() {
+    local key="$1"
+    local file="/etc/mpe/mpe.env"
+    [ -f "$file" ] || return 1
+    grep -E "^${key}=" "$file" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '"' | tr -d "'"
+}
+
+# Reload runtime profile from the appliance env file.
+mpe_source_appliance_env() {
+    if [ ! -f /etc/mpe/mpe.env ]; then
+        return 0
+    fi
+    # shellcheck disable=SC1091
+    set -a
+    source /etc/mpe/mpe.env
+    set +a
+    MPE_AUDIO_PROFILE="${MPE_AUDIO_PROFILE:-standalone}"
+    export MPE_AUDIO_PROFILE
+}
+
 mpe_retire_touch_shutdown_animation_unit() {
     local legacy=touch-shutdown-animation.service
     local shipped="${MPE_MODULE_REPO:-}/config/touch-shutdown-animation.service"
@@ -62,8 +83,13 @@ mpe_enable_usb_audio_gadget() {
     fi
 }
 
+mpe_enable_audio_profile_sync() {
+    sudo systemctl enable mpe-audio-profile-sync.service 2>/dev/null || true
+}
+
 mpe_enable_core_services() {
     mpe_enable_usb_audio_gadget
+    mpe_enable_audio_profile_sync
     sudo systemctl enable --now surge-xt-cli.service 2>/dev/null || true
     sudo systemctl enable surge-watchdog.service 2>/dev/null || true
     mpe_enable_patch_browser_ui

--- a/scripts/set-audio-profile.sh
+++ b/scripts/set-audio-profile.sh
@@ -38,6 +38,7 @@ rm -f "$tmp"
 
 export MPE_AUDIO_PROFILE="$PROFILE"
 mpe_enable_usb_audio_gadget
+mpe_enable_audio_profile_sync
 
 # shellcheck source=lib/wait-for-uac2-gadget.sh
 source "$SCRIPT_DIR/lib/wait-for-uac2-gadget.sh"


### PR DESCRIPTION
## Summary
- Add `mpe_read_appliance_env_var`, `mpe_source_appliance_env`, and `mpe_enable_audio_profile_sync` to `mpe-services.sh`
- `configure-pi-paths.sh --force` now preserves `MPE_AUDIO_PROFILE` and `MPE_SURGE_BUFFER_SIZE` from `/etc/mpe/mpe.env`
- `set-audio-profile.sh` enables `mpe-audio-profile-sync.service` on profile toggle

Completes PR #26 boot-sync wiring so `usb-host` survives reboot and `configure --force`.

## Test plan
- [x] `python3 -m unittest discover -s tests -q` (125 pass)
- [ ] Pi: `configure-pi-paths.sh --local --force` preserves `usb-host`
- [ ] Pi: reboot → gadget + watchdog enabled, profile unchanged

Made with [Cursor](https://cursor.com)