### PR TITLE
Promote dev: latency experiment plan, buffer defaults, mpe-cli externalization

### DIFF
--- a/.cursor/permissions.json
+++ b/.cursor/permissions.json
@@ -1,0 +1,28 @@
+{
+  // Laptop → Pi ops via bounded mpe-cli (see AGENTS.md + OM-Repo Docs/appliance-cli-pattern.md).
+  // Defining terminalAllowlist here overrides the IDE terminal allowlist while this repo is in the workspace.
+  "terminalAllowlist": [
+    "mpe ping",
+    "mpe status",
+    "mpe logs",
+    "mpe osc-check",
+    "mpe diagnose",
+    "mpe pull-videos",
+    "mpe record",
+    "mpe restart",
+    "git",
+    "python3",
+    "gh"
+  ],
+  "autoRun": {
+    "allow_instructions": [
+      "mpe subcommands (ping, status, logs, osc-check, diagnose, pull-videos, record, restart) are the approved laptop → Pi path for MPE-Module work.",
+      "Read-only mpe ops (ping, status, logs, osc-check, diagnose, pull-videos without --delete-source) are safe without extra approval."
+    ],
+    "block_instructions": [
+      "Do not run raw ssh, scp, or rsync to the MPE Pi when an mpe subcommand exists.",
+      "Do not edit ~/.config/mpe/mpe.env or mpe-cli bin/commands/lib without explicit user approval.",
+      "mpe restart, mpe record, and mpe pull-videos --delete-source change device state — prefer read-only mpe ops first."
+    ]
+  }
+}

--- a/.cursor/permissions.json
+++ b/.cursor/permissions.json
@@ -7,6 +7,7 @@
     "mpe logs",
     "mpe osc-check",
     "mpe diagnose",
+    "mpe sysinfo",
     "mpe pull-videos",
     "mpe record",
     "mpe restart",
@@ -16,8 +17,8 @@
   ],
   "autoRun": {
     "allow_instructions": [
-      "mpe subcommands (ping, status, logs, osc-check, diagnose, pull-videos, record, restart) are the approved laptop → Pi path for MPE-Module work.",
-      "Read-only mpe ops (ping, status, logs, osc-check, diagnose, pull-videos without --delete-source) are safe without extra approval."
+      "mpe subcommands (ping, status, logs, osc-check, diagnose, sysinfo, pull-videos, record, restart) are the approved laptop → Pi path for MPE-Module work.",
+      "Read-only mpe ops (ping, status, logs, osc-check, diagnose, sysinfo, pull-videos without --delete-source) are safe without extra approval."
     ],
     "block_instructions": [
       "Do not run raw ssh, scp, or rsync to the MPE Pi when an mpe subcommand exists.",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,12 @@ Install once: clone `mpe-cli`, run `./install.sh`, edit `~/.config/mpe/mpe.env` 
 | `mpe logs surge\|touch\|watchdog [-n N]` | Recent logs (max 200 lines) |
 | `mpe osc-check` | Surge OSC ports + process |
 | `mpe diagnose` | Full read-only Pi diagnostics |
+| `mpe sysinfo` | Board, kernel/preempt, EEPROM, CPU governor, Surge RT limits, buffer latency |
 | `mpe record [file] [fps]` | Touch UI screen capture |
 | `mpe pull-videos [-o DIR] [--delete-source]` | Download demo videos |
 | `mpe restart surge\|touch\|all` | Restart fixed systemd units |
 
-**Agent-safe (read-only):** `ping`, `status`, `logs`, `osc-check`, `diagnose`, `pull-videos` (skip `--delete-source` for zero writes).
+**Agent-safe (read-only):** `ping`, `status`, `logs`, `osc-check`, `diagnose`, `sysinfo`, `pull-videos` (skip `--delete-source` for zero writes).
 
 **Writes / restarts:** `restart *`, `record`, `pull-videos --delete-source`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,37 @@
 # MPE-Module — agent orientation
 
-*Last updated: 2026-08-02 (America/Toronto)*
+*Last updated: 2026-08-10 (America/Toronto)*
 
 **Product:** Raspberry Pi MPE sound module (Surge XT headless + patch browser UI).
+
+---
+
+## Pi CLI (`mpe`)
+
+**Use the global `mpe` CLI** (separate [`mpe-cli`](https://github.com/MitchSchwartz/mpe-cli) repo) for laptop → Pi operations. Do not run raw `ssh`, `scp`, or `rsync` when a subcommand exists — Cursor allowlists fixed `mpe` entrypoints instead of open SSH.
+
+Install once: clone `mpe-cli`, run `./install.sh`, edit `~/.config/mpe/mpe.env` (`PI_HOST`, `PI_USER`, `SSH_KEY`). **Do not embed the CLI in this repo.**
+
+| Command | Purpose |
+|---------|---------|
+| `mpe ping` | Connectivity check |
+| `mpe status` | Service active/enabled summary |
+| `mpe logs surge\|touch\|watchdog [-n N]` | Recent logs (max 200 lines) |
+| `mpe osc-check` | Surge OSC ports + process |
+| `mpe diagnose` | Full read-only Pi diagnostics |
+| `mpe record [file] [fps]` | Touch UI screen capture |
+| `mpe pull-videos [-o DIR] [--delete-source]` | Download demo videos |
+| `mpe restart surge\|touch\|all` | Restart fixed systemd units |
+
+**Agent-safe (read-only):** `ping`, `status`, `logs`, `osc-check`, `diagnose`, `pull-videos` (skip `--delete-source` for zero writes).
+
+**Writes / restarts:** `restart *`, `record`, `pull-videos --delete-source`.
+
+**Do not allowlist for agents:** raw `ssh`/`scp`/`rsync`, `deploy-all.sh`, `set-audio-profile.sh`, `set-surge-audio.sh`, `set-midi-sync.sh`, poweroff/reboot.
+
+**Suggest new subcommands:** When you would SSH twice for the same fixed task, **propose a new `mpe` subcommand** in `mpe-cli` (name + behavior + allowlist strings) — do not improvise remote shell. **Editing `mpe-cli` or `~/.config/mpe/mpe.env` requires Mitch approval.**
+
+Pattern: [OM-Repo `Docs/appliance-cli-pattern.md`](https://github.com/opsMachine/OM-Repo/blob/main/Docs/appliance-cli-pattern.md) · [`COMMANDS.md`](COMMANDS.md)
 
 ---
 
@@ -39,7 +68,7 @@ Repo path on Pi: `~/MPE-Module` (override via `MPE_MODULE_REPO` in `/etc/mpe/mpe
 | Paths / env vars | [`docs/PATHS.md`](docs/PATHS.md) |
 | USB desk tether (`usb-host`) | [`docs/USB-AUDIO-HOST.md`](docs/USB-AUDIO-HOST.md) |
 | USB session record (`usb-host-session`) | [`docs/USB-SESSION-RECORD.md`](docs/USB-SESSION-RECORD.md) |
-| Touch UI demo screen record | [`docs/TOUCH_PATCH_BROWSER.md`](docs/TOUCH_PATCH_BROWSER.md) · `scripts/record-screen.sh` |
+| Touch UI demo screen record | [`docs/TOUCH_PATCH_BROWSER.md`](docs/TOUCH_PATCH_BROWSER.md) · `mpe record` (mpe-cli) |
 | Touch UI | [`docs/TOUCH_PATCH_BROWSER.md`](docs/TOUCH_PATCH_BROWSER.md) |
 | Boot recovery | [`docs/PI-BOOT-RECOVERY.md`](docs/PI-BOOT-RECOVERY.md) |
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -461,6 +461,7 @@ mpe status
 mpe logs touch -n 80
 mpe osc-check
 mpe diagnose
+mpe sysinfo                # board, kernel, governor, Surge RT limits, block latency
 mpe restart surge          # or touch | all
 
 mpe record                  # SSH to Pi, record until Ctrl+C

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -451,4 +451,28 @@ backup          # Sync from device
 
 ---
 
+## Demo capture (touch UI)
+
+From your laptop — install **mpe-cli** (`./install.sh`), config in `~/.config/mpe/mpe.env`:
+
+```bash
+mpe ping
+mpe status
+mpe logs touch -n 80
+mpe osc-check
+mpe diagnose
+mpe restart surge          # or touch | all
+
+mpe record                  # SSH to Pi, record until Ctrl+C
+mpe record ~/mpe-demo.mkv 15
+mpe pull-videos               # → ./recordings/
+mpe pull-videos -o ~/Videos --delete-source
+```
+
+On the Pi directly: `./scripts/record-screen.sh` (see [docs/TOUCH_PATCH_BROWSER.md](docs/TOUCH_PATCH_BROWSER.md)).
+
+Allowlist / pattern: [OM-Repo appliance-cli-pattern](https://github.com/opsMachine/OM-Repo/blob/main/Docs/appliance-cli-pattern.md) · [MPE-Module AGENTS.md](AGENTS.md) § Pi CLI.
+
+---
+
 See [docs/BACKUP_GUIDE.md](docs/BACKUP_GUIDE.md) for detailed backup procedures and troubleshooting.

--- a/config/mpe-cpu-governor.service
+++ b/config/mpe-cpu-governor.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=MPE pin CPU frequency governor from /etc/mpe/mpe.env
+Documentation=file:@MPE_MODULE_REPO@/docs/LATENCY-SPIKE.md
+DefaultDependencies=no
+After=local-fs.target
+Before=surge-xt-cli.service
+ConditionPathExists=/etc/mpe/mpe.env
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/mpe/mpe.env
+ExecStart=@MPE_MODULE_REPO@/scripts/set-cpu-governor.sh
+TimeoutStartSec=30
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -11,12 +11,15 @@
 # --- PC: Surge XT install (optional — defaults to ~/Documents/Surge XT) ---
 # SURGE_XT_DIR=/path/to/Documents/Surge XT
 
-# --- Pi SSH (laptop-side) ---
-# Canonical for the mpe CLI: ~/.config/mpe/mpe.env (see mpe-cli repo).
-# Optional override below for deploy scripts that source this file:
+# --- Pi SSH (laptop-side deploy scripts) ---
 # PI_HOST=raspberrypi2.local
+# REQUIRED — no safe default. Raspberry Pi Imager makes you set a custom
+# username per device (there's no more shipped "pi" default), so this must
+# match whatever username you set when you flashed the SD card.
 # PI_USER=your-pi-username
 # SSH_KEY=$HOME/.ssh/your_pi_key
+
+# --- Pi: clone locations (only if not in $HOME) ---
 # PI_MPE_MODULE=/home/your-pi-username/MPE-Module
 # PI_MPE_PERSONAL=/home/your-pi-username/mpe-assets
 
@@ -49,9 +52,10 @@
 # MPE_USB_GADGET_PERSIST=1
 
 # --- Surge audio buffer (Pi — reduces xrun/crackle under heavy MPE polyphony) ---
-# Default in start-surge-cli.sh: 768 samples (~16 ms @ 48 kHz). Non-power-of-2 is fine for ALSA/JUCE.
-# Increase if crackle persists (more latency); decrease only for latency experiments (512 choked on Pi 4).
-# MPE_SURGE_BUFFER_SIZE=768
+# Default in start-surge-cli.sh: 1024 samples (~21 ms @ 48 kHz). Non-power-of-2 is fine for ALSA/JUCE.
+# 1024 is the stability floor on Pi 4: 768 drops voices under heavy MPE polyphony, 512 choked outright.
+# Increase if crackle persists (more latency); decrease only for latency experiments (see docs/LATENCY-SPIKE.md).
+# MPE_SURGE_BUFFER_SIZE=1024
 # MPE_SURGE_BUFFER_SIZE=2048
 
 # --- Surge sample rate (Pi — ALSA + UAC2 gadget must match) ---

--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -58,6 +58,22 @@
 # MPE_SURGE_BUFFER_SIZE=1024
 # MPE_SURGE_BUFFER_SIZE=2048
 
+# --- Latency experiment knobs (Pi — see docs/LATENCY-SPIKE.md, Arm A½) ---
+# Both default to OFF so existing appliances are unchanged. Change ONE at a time.
+#
+# Pin the CPU frequency governor (mpe-cpu-governor.service runs at boot).
+# Stock Pi OS uses "ondemand", which ramps clock on demand and can drop voices
+# on polyphony spikes. "performance" removes the ramp at the cost of power/heat.
+# Unset = leave the distro default alone.
+# MPE_CPU_GOVERNOR=performance
+#
+# Force SCHED_FIFO on the whole Surge process at this priority (1-99).
+# Usually unnecessary: surge-xt-cli.service sets LimitRTPRIO so JUCE can elevate
+# just its audio thread. Only use this if `chrt -p $(pgrep -f surge-xt-cli)`
+# still reports SCHED_OTHER. Keep it modest — a spinning FIFO thread can starve
+# the touch UI and network stack.
+# MPE_SURGE_RT_PRIORITY=20
+
 # --- Surge sample rate (Pi — ALSA + UAC2 gadget must match) ---
 # Default: 48000 Hz. usb-host gadget p_srate uses the same value.
 # MPE_SURGE_SAMPLE_RATE=48000

--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -11,15 +11,12 @@
 # --- PC: Surge XT install (optional — defaults to ~/Documents/Surge XT) ---
 # SURGE_XT_DIR=/path/to/Documents/Surge XT
 
-# --- Pi SSH (laptop-side deploy scripts) ---
+# --- Pi SSH (laptop-side) ---
+# Canonical for the mpe CLI: ~/.config/mpe/mpe.env (see mpe-cli repo).
+# Optional override below for deploy scripts that source this file:
 # PI_HOST=raspberrypi2.local
-# REQUIRED — no safe default. Raspberry Pi Imager makes you set a custom
-# username per device (there's no more shipped "pi" default), so this must
-# match whatever username you set when you flashed the SD card.
 # PI_USER=your-pi-username
 # SSH_KEY=$HOME/.ssh/your_pi_key
-
-# --- Pi: clone locations (only if not in $HOME) ---
 # PI_MPE_MODULE=/home/your-pi-username/MPE-Module
 # PI_MPE_PERSONAL=/home/your-pi-username/mpe-assets
 

--- a/config/surge-xt-cli.service
+++ b/config/surge-xt-cli.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Surge XT CLI Synthesizer (Headless)
-After=sound.target network.target usb-audio-gadget.service mpe-pressure-remap.service
+After=sound.target network.target usb-audio-gadget.service mpe-pressure-remap.service mpe-cpu-governor.service
 Wants=sound.target mpe-pressure-remap.service
 
 [Service]
@@ -8,6 +8,10 @@ Type=forking
 User=@MPE_PI_USER@
 WorkingDirectory=@MPE_MODULE_REPO@
 EnvironmentFile=-/etc/mpe/mpe.env
+# Permit (do not force) realtime scheduling for the JUCE audio thread.
+# systemd units bypass PAM, so /etc/security/limits.d does not apply here.
+LimitRTPRIO=95
+LimitMEMLOCK=infinity
 ExecStart=@MPE_MODULE_REPO@/scripts/start-surge-cli.sh
 ExecStartPost=+@MPE_MODULE_REPO@/scripts/start-uac2-watchdog-if-needed.sh
 ExecStop=/usr/bin/pkill -TERM -f surge-xt-cli

--- a/docs/LATENCY-SPIKE.md
+++ b/docs/LATENCY-SPIKE.md
@@ -1,0 +1,180 @@
+# Surge latency — RT vs buffer floor experiment
+
+*Last updated: 2026-08-10 17:12 (America/Toronto)*
+
+**The experiment, in one line:** *Does enabling PREEMPT_RT let us run a smaller Surge buffer than 1024 without losing voices?*
+
+Everything else in this doc is control-arm bookkeeping for that one question.
+
+**Related:** [#44 Buffer size in settings](https://github.com/MitchSchwartz/MPE-Sound-Module/issues/44) · `FAQ.md` · `docs/PATCH_NORMALIZATION.md`
+
+**Status:** Arm A not started. Arm B **blocked** — see §Open questions. Repo buffer defaults corrected to 1024 (below).
+
+---
+
+## Why this is the only experiment left
+
+Buffer tuning on the stock kernel is **exhausted**:
+
+| Buffer @ 48 kHz | Block latency | Result today |
+|---|---|---|
+| **1024** | ~21 ms | **Production floor** — voices hold under real MPE load |
+| **768** | ~16 ms | **Loses too many voices** (governor/CPU pressure) |
+| **512 and below** | ~11 ms | Historical xrun/crackle on heavy patches |
+
+The binding constraint is **CPU headroom per callback**, not block math. RT changes **scheduling jitter**, which is the plausible mechanism for surviving a shorter callback. Nothing else in the current stack moves this — direct ALSA is already the thin path, and there's no JACK/PipeWire layer to remove.
+
+**So:** either RT buys a smaller buffer, or **1024 is the permanent floor** and any Pi-side software looper is dead (looper buffers stack on top of ~21 ms).
+
+---
+
+## Independent variable
+
+**RT kernel: on / off.** That is the *only* thing that changes between arms.
+
+**Held constant** — changing any of these invalidates the comparison:
+
+- Sample rate **48000**
+- Patch set (same 3–5 CPU-heavy MPE patches, same order)
+- Poly governor setting and `MPE_POLY_*` values
+- Normalization on/off state
+- Audio profile: **`standalone`** → Sound Blaster USB DAC → headphones
+- Controller: Roli only
+- Touch browser running or not — pick one, keep it
+
+**Deliberately excluded from the rig** (each is a confounder):
+
+- RC-5 / any looper pedal, and `midi-clock-in` (sync quantize alters note timing)
+- `usb-host` / UAC2 gadget path (adds host buffers; documented as not a monitor path)
+- Multi-FX pedal in the audio chain
+
+---
+
+## Dependent variable (what "success" means)
+
+**Voice count under load** — not milliseconds, not xrun count alone.
+
+A buffer "passes" only if, over a **10-minute** MPE jam:
+
+1. Voices hold as well as **1024 does today** (no audible dropped/stolen notes beyond baseline), **and**
+2. **Zero** xruns/underruns in `~/surge-cli.log`, **and**
+3. It still passes with the **worst-case** patch, not just average ones.
+
+Latency is then simply `buffer × 1000 / 48000` ms — arithmetic, not a measurement.
+
+---
+
+## Procedure
+
+### Arm A — control (stock kernel, ~1 hour)
+
+Purpose: put the thing we already believe on the record, so Arm B has something to compare to.
+
+| Step | Action |
+|---|---|
+| A.1 | Confirm `MPE_SURGE_BUFFER_SIZE=1024` in `/etc/mpe/mpe.env` and in touch **Audio → Buffer** |
+| A.2 | Build the rig above (no pedal, no gadget, Roli only) |
+| A.3 | 10 min jam @ **1024** — note voice behavior, grep log for xrun |
+| A.4 | Brief pass @ **768** — **document the failure mode concretely** (which patches, how many voices, how fast it degrades) |
+| A.5 | Record `uname -a`, Pi model, patch list used |
+| A.6 | Validation Log row: control arm result |
+
+A.4 matters more than it looks: "loses voices" needs to be specific enough that Arm B can be judged against it rather than against memory.
+
+### Arm A½ — scheduling priority, no kernel change (do this before Arm B)
+
+`SCHED_FIFO` on the audio thread plus `rtprio`/`memlock` limits and a pinned CPU governor address the *same* mechanism as RT — scheduler jitter — at a fraction of the risk, with no kernel swap and no rollback exposure. If this alone buys 768, the RT arm may never be needed.
+
+Scope to be set by the feasibility research (see §Open questions) before any config lands. Same 10-minute protocol and same pass criteria as Arm A.
+
+### Arm B — RT kernel (1–2 days) — blocked
+
+**Gates:** feasibility research answered · `tryboot` rehearsed (§Rollback) · Mitch approves the kernel install.
+
+| Step | Action |
+|---|---|
+| B.0 | Confirm board revision, kernel, and OS release via `mpe sysinfo` — RT choice depends on all three |
+| B.1 | Obtain an RT kernel that **keeps** `vc4`/DSI, dtoverlays, and `dwc2` UAC2 gadget working. Install **alongside** the stock kernel, never replacing it |
+| B.2 | Select it via `tryboot.txt` only — not `config.txt` |
+| B.3 | Confirm RT is actually active (`uname -a`) and Surge is actually running at elevated priority — a kernel that boots but doesn't schedule differently proves nothing |
+| B.4 | Re-run the **identical** A.3 protocol @ **1024** — sanity check that RT didn't regress the known-good config |
+| B.5 | Step down: **768**, then **512** — same 10 min protocol, same patches, same pass criteria |
+| B.6 | Reliability soak at the best passing buffer: touch UI, USB hotplug, Wi-Fi scan running |
+| B.7 | Only after a clean soak, promote the RT kernel into `config.txt`. Validation Log: adopted or rejected + lowest buffer that held voices |
+
+B.4 is the step that's easy to skip and shouldn't be — if RT changes behavior at 1024, the step-down results mean something different.
+
+---
+
+## Outcomes and what each one decides
+
+| Result | Production buffer | Pi software looper |
+|---|---|---|
+| RT holds voices @ **512** | Consider 512 (~11 ms) | **Reopen** — architecture spike worth doing |
+| RT holds voices @ **768** | Consider 768 (~16 ms) | **Marginal** — only without a monitored record path |
+| RT no better than stock | Stay **1024** (~21 ms) | **Closed** — hardware pedal stays the loop engine |
+| RT hurts reliability | Stay **1024**, stock kernel | **Closed** |
+
+Reliability outranks latency: a smaller buffer that survives 10 minutes but fails a set is a regression, not a win.
+
+---
+
+## Fixed alongside this plan: repo defaults said 768
+
+Surfaced while building the plan, and arguably more urgent than the experiment: **every buffer default in the repo was 768** — the config that drops voices. `PATCH_NORMALIZATION.md` records that 1024 *was* the prior default and was lowered to 768 to fix 512-era choppiness, so 768 looks like a regression the gig Pi only escaped because `/etc/mpe/mpe.env` overrides it locally.
+
+Nine locations, now aligned to 1024:
+
+| Location | Why it mattered |
+|---|---|
+| `scripts/configure-pi-paths.sh:73` | **Writes `/etc/mpe/mpe.env` on a fresh Pi** — the actual path by which a rebuild lands on 768 |
+| `scripts/start-surge-cli.sh:63` | Runtime fallback when the env var is unset |
+| `patch_browser/surge_audio.py` | `DEFAULT_BUFFER`, now the single Python source of truth |
+| `patch_browser/midi_sync.py` | Output-offset fallback — **was computing MIDI compensation for ~16 ms while Surge ran ~21 ms blocks** |
+| `scripts/calibrate-patch-normalization.py` (×2) | Calibration ran at a different buffer than production |
+| `scripts/set-surge-audio.sh:72` | Old-value fallback when deciding whether a restart is needed |
+| `config/mpe.env.example`, `docs/PATCH_NORMALIZATION.md`, `docs/USB-AUDIO-PASSTHROUGH-PLAN.md` | Documented the wrong default |
+
+The Python copies now import `DEFAULT_BUFFER` / `DEFAULT_SAMPLE_RATE` from `surge_audio` rather than repeating literals, so this class of drift can only recur in the shell scripts (flagged by comment in `surge_audio.py`).
+
+**Note:** this changes nothing on the current gig Pi, whose env file already pins 1024. It changes fresh builds, `configure-pi-paths.sh` on a Pi with no existing env, and the MIDI offset math.
+
+---
+
+## Rollback without pulling the SD card
+
+The live Pi's card is behind the display ribbon and impractical to remove, so there is no spare-card A/B and no image backup. That makes a **software rollback path mandatory** before the kernel is touched.
+
+**Mechanism: `tryboot`.** The Pi bootloader supports a one-shot flag — `sudo reboot '0 tryboot'` makes the firmware load `tryboot.txt` instead of `config.txt` for exactly one boot. The flag is cleared *before* the firmware starts, so a crash or hang means the next boot returns to `config.txt` and the stock kernel ([Raspberry Pi bootflow docs](https://github.com/raspberrypi/documentation/blob/master/documentation/asciidoc/computers/raspberry-pi/bootflow-eeprom.adoc)).
+
+Rules for this experiment:
+
+1. **Rehearse first.** Run one `tryboot` cycle with a `tryboot.txt` that is just a copy of `config.txt`. Confirm it boots and reverts *before* an RT kernel is involved. Five minutes, zero stakes, and it proves the escape hatch on this specific board.
+2. **Install the RT kernel alongside** the stock one under a distinct filename — never replace it. `config.txt` must always point at a known-good kernel.
+3. **Never put the RT kernel in `config.txt`** until it has survived a full soak via `tryboot`.
+4. **Caveat:** on Pi 4 Model B rev 1.0/1.1 the EEPROM must not be write-protected, since those boards store tryboot state in EEPROM rather than a register. Confirm board revision first.
+
+---
+
+## Open questions blocking Arm B
+
+| Question | Why it blocks |
+|---|---|
+| **Which board and OS release?** | Diagnostics point to a **Pi 4** (BCM2711 `emmc2bus` path) while `README.md` claims a Pi 5 reference stack; package versions suggest a **trixie**-based OS, not bookworm. RT kernel choice depends on both. `diagnose-pi-state.sh` reports neither — needs an `mpe sysinfo` subcommand. |
+| **Is PREEMPT_RT even obtainable?** | Raspberry Pi ships no `-rt` kernel flavor. A generic Debian arm64 RT kernel risks breaking the things this appliance depends on — DSI panel via `vc4`/kmsdrm, `dwc2` UAC2 gadget, dtoverlays. If so, B.1 means *building a kernel*, not installing one. |
+| **Is RT even the cheapest test of the hypothesis?** | Much of `PREEMPT_RT` landed in mainline 6.12, and `SCHED_FIFO` + `rtprio`/`memlock` limits + CPU governor pinning may deliver most of the jitter reduction **with no kernel change at all**. If so, do that first and RT may never be needed. |
+
+Until these are answered, **do not write RT config** into `config/surge-xt-cli.service` or a `limits.d` drop-in.
+
+---
+
+## Human gates
+
+- **Any kernel install on the gig SD** — Mitch only, and only after `tryboot` is rehearsed
+- **Promoting a kernel into `config.txt`** — Mitch only, and only after a clean soak
+- **Production buffer change** in `/etc/mpe/mpe.env` on the live Pi — Mitch only
+- Reopening the software looper question — only on a written Arm B pass
+
+## Deploys
+
+Repo changes reach the Pi **through GitHub only** — land on `dev`, promote to `main`, then pull on the Pi. No direct `scp`/`rsync` of experiment config.

--- a/docs/LATENCY-SPIKE.md
+++ b/docs/LATENCY-SPIKE.md
@@ -1,6 +1,6 @@
 # Surge latency — can the buffer floor come down?
 
-*Last updated: 2026-08-10 17:23 (America/Toronto)*
+*Last updated: 2026-08-10 17:56 (America/Toronto)*
 
 **The question, in one line:** *Can we run a smaller Surge buffer than 1024 without losing voices — and what's the cheapest change that gets us there?*
 
@@ -8,7 +8,7 @@ Originally scoped as "enable PREEMPT_RT and turn the buffer down." Measured base
 
 **Related:** [#44 Buffer size in settings](https://github.com/MitchSchwartz/MPE-Sound-Module/issues/44) · `FAQ.md` · `docs/PATCH_NORMALIZATION.md`
 
-**Status:** Arm A not started. **Arm B is probably unnecessary** — `mpe sysinfo` shows the cheap scheduling wins were never applied (see §Measured baseline). Repo buffer defaults corrected to 1024 (below).
+**Status:** Arm A not started. **Arm B is probably unnecessary** — cheap scheduling wins were never applied (§Measured baseline), and voice loss at 768 may be CPU throughput, not scheduler jitter (§RT feasibility). Repo buffer defaults corrected to 1024 (below).
 
 > **Headline:** Surge currently runs `SCHED_OTHER` at priority 0 with an `rtprio` hard limit of **0**, on the `ondemand` CPU governor. It has never had realtime scheduling available to it. Chasing an RT *kernel* before fixing that is optimizing the wrong layer.
 
@@ -52,7 +52,7 @@ Either something in that layer buys a smaller buffer, or **1024 is the permanent
 
 ## Independent variable
 
-**One change per arm**, in ascending order of risk: CPU governor → RT scheduling for Surge → RT kernel. Do not bundle them; if governor plus `SCHED_FIFO` land together and 768 starts passing, we won't know which one mattered or whether the kernel arm is needed at all.
+**One change per arm**, in ascending order of risk: diagnose → CPU governor → `threadirqs` → RT scheduling for Surge → RT kernel. Do not bundle them; if governor plus `SCHED_FIFO` land together and 768 starts passing, we won't know which one mattered or whether the kernel arm is needed at all.
 
 **Held constant** — changing any of these invalidates the comparison:
 
@@ -110,6 +110,7 @@ Purpose: put the thing we already believe on the record, so the later arms have 
 | A.2 | Build the rig above — switch profile to **`standalone`** (currently `usb-host`), no pedal, no gadget, Roli only |
 | A.3 | 10 min jam @ **1024** — note voice behavior, grep log for xrun |
 | A.4 | Brief pass @ **768** — **document the failure mode concretely** (which patches, how many voices, how fast it degrades) |
+| A.4b | **Diagnose the failure mode** while reproducing A.4: grep `~/surge-cli.log` for xrun/underrun; check `/proc/asound/card*/pcm*/sub*/status` for `xrun`; run `rtla timerlat top` or `cyclictest` under the same load. If max scheduling latency is **well under 16 ms** and there are **no xruns**, the 768 failure is Surge voice-stealing (CPU throughput), not scheduler jitter — **stop here; RT will not help and may make it worse** |
 | A.5 | Capture `mpe sysinfo` output and the patch list used |
 | A.6 | Validation Log row: control arm result |
 
@@ -137,6 +138,15 @@ This is now the **most promising arm**, and the cheapest: nothing here needs a k
 | A½.5 | If still `SCHED_OTHER`, JUCE isn't asking. Set `MPE_SURGE_RT_PRIORITY=20` to wrap the launch in `chrt --fifo` and re-check |
 | A½.6 | Re-run A.3 @ 1024, then step to 768 |
 
+**Sub-arm 3 — `threadirqs` (stock kernel only, no RT package)**
+
+The stock Raspberry Pi arm64 kernel already supports forced threaded IRQs (`CONFIG_IRQ_FORCED_THREADING`). Adding `threadirqs` to `/boot/firmware/cmdline.txt` is reversible and often cited as removing the need for an RT kernel on less powerful systems — but linuxaudio.org still lists Raspberry Pi as a case where RT *can* matter at very low buffers.
+
+| Step | Action |
+|---|---|
+| A½.7 | Add `threadirqs` to `cmdline.txt`, reboot, confirm with `cat /proc/cmdline` |
+| A½.8 | Re-run A.3 @ 1024, then step to 768 — **only if A.4b showed actual xruns or scheduling latency near one buffer period** |
+
 **Note on `limits.d`:** systemd services bypass PAM, so `/etc/security/limits.d/` has **no effect** on `surge-xt-cli.service` — the unit's `Limit*` directives are the correct mechanism. A `limits.d` file would only matter for Surge launched manually over SSH (e.g. calibration), so it's deliberately not part of this arm.
 
 Everything here is **repo-managed** and deploys through GitHub — no hand-editing on the Pi.
@@ -145,22 +155,32 @@ Everything here is **repo-managed** and deploys through GitHub — no hand-editi
 
 If 768 passes here, **Arm B is cancelled** and the looper question reopens with no kernel risk at all.
 
-### Arm B — RT kernel (1–2 days) — blocked
+### Arm B — RT kernel (~1 hour install + soak) — last resort
 
-**Gates:** feasibility research answered · `tryboot` rehearsed (§Rollback) · Mitch approves the kernel install.
+**Gates:** A.4b shows xruns or scheduling latency near one buffer period (not voice-stealing alone) · A½ exhausted · `tryboot` rehearsed (§Rollback) · Mitch approves.
+
+**Feasibility is resolved:** Raspberry Pi ships **`linux-image-rpi-v8-rt`** in the trixie archive, version-locked to the stock `rpi-v8` kernel and built from the same `raspberrypi/linux` tree with only preemption changed (`bcm2711_rt_defconfig` — six-line diff from stock). `vc4`/DSI, touch panels (`ili9881c`, official 5"/7"), `dwc2`, and UAC2 gadget are all present. **No `linux-image-rpi-2712-rt`** exists — irrelevant here since the live unit is Pi 4 Rev 1.5, where `v8` → `v8-rt` changes exactly one variable.
+
+**Rejected paths:** generic Debian `linux-image-rt-arm64` (breaks downstream dtoverlays and DSI drivers); `preempt=full` boot param (not `PREEMPT_RT`, and `PREEMPT_DYNAMIC` is off on Pi kernels anyway); building from source (only if the packaged RT kernel is close but insufficient).
+
+**Caveats before installing:**
+
+- Labelled **experimental** by Raspberry Pi — not in official docs, but apt-packaged and version-matched.
+- RT trades **throughput for tail latency**. If 768 fails from voice-stealing, RT may lower the voice ceiling further even as jitter improves.
+- **No published measurement** of RT with the `dwc2` UAC2 gadget path — irrelevant for the `standalone` test rig, but matters if you later re-test in `usb-host`.
+- **10.1" Touch Display 2** (`ili79600` overlay) is missing from the RT defconfig; the 5"/7" SmartiPi panels are fine. Confirm `dtoverlay=` in `config.txt` if unsure.
 
 | Step | Action |
 |---|---|
-| B.0 | Re-run `mpe sysinfo` to re-confirm board, kernel, and OS before choosing a kernel |
-| B.1 | Obtain an RT kernel that **keeps** `vc4`/DSI, dtoverlays, and `dwc2` UAC2 gadget working. Install **alongside** the stock kernel, never replacing it |
-| B.2 | Select it via `tryboot.txt` only — not `config.txt` |
-| B.3 | Confirm RT is actually active (`uname -a`) and Surge is actually running at elevated priority — a kernel that boots but doesn't schedule differently proves nothing |
-| B.4 | Re-run the **identical** A.3 protocol @ **1024** — sanity check that RT didn't regress the known-good config |
-| B.5 | Step down: **768**, then **512** — same 10 min protocol, same patches, same pass criteria |
-| B.6 | Reliability soak at the best passing buffer: touch UI, USB hotplug, Wi-Fi scan running |
-| B.7 | Only after a clean soak, promote the RT kernel into `config.txt`. Validation Log: adopted or rejected + lowest buffer that held voices |
-
-B.4 is the step that's easy to skip and shouldn't be — if RT changes behavior at 1024, the step-down results mean something different.
+| B.0 | Re-run `mpe sysinfo`; confirm A.4b outcome justifies continuing |
+| B.1 | `sudo apt install linux-image-rpi-v8-rt` — installs alongside stock kernel as `kernel8_rt.img` |
+| B.2 | Copy `/boot/firmware/config.txt` → `/boot/firmware/tryboot.txt`; add `kernel=kernel8_rt.img` to **tryboot.txt only** |
+| B.3 | Rehearse empty tryboot first (§Rollback), then `sudo reboot '0 tryboot'` |
+| B.4 | Confirm RT active: `uname -a` shows `-rt`; `cat /sys/kernel/realtime` = 1 |
+| B.5 | Re-run A.3 @ **1024** — sanity check RT didn't regress the known-good config |
+| B.6 | Step down: **768**, then **512** — same 10 min protocol, same patches, same pass criteria |
+| B.7 | Reliability soak at the best passing buffer: touch UI, USB hotplug, Wi-Fi scan |
+| B.8 | Only after a clean soak, promote RT kernel into `config.txt`. Validation Log: adopted or rejected + lowest buffer that held voices |
 
 ---
 
@@ -171,6 +191,7 @@ Ordered cheapest-first. Stop at the first arm that passes — there's no prize f
 | Result | Production buffer | Pi software looper |
 |---|---|---|
 | **A0** — under-voltage was the real cause | Retest everything after the PSU fix | Re-ask once the board is stable |
+| **A.4b** — voice-stealing with no xruns, latency ≪ buffer period | Stay **1024** — CPU throughput bound | **Closed** — RT won't help; lighter patches or accept 21 ms |
 | **A½** governor and/or `SCHED_FIFO` holds **512** | Consider 512 (~11 ms), no kernel change | **Reopen** — best case, zero kernel risk |
 | **A½** holds **768** | Consider 768 (~16 ms), no kernel change | **Marginal** — only without a monitored record path |
 | A½ no help, **RT** holds voices @ **512** | Consider 512 (~11 ms) | **Reopen** — architecture spike worth doing |
@@ -219,19 +240,42 @@ Rules for this experiment:
 
 ---
 
+## RT feasibility (research, 2026-08-10)
+
+Web research only — no Pi changes made. Full report from the feasibility pass is linked in [PR #46](https://github.com/MitchSchwartz/MPE-Sound-Module/pull/46#issuecomment-5246232296).
+
+### Resolved
+
+| Question | Answer for this unit |
+|---|---|
+| Is PREEMPT_RT obtainable on trixie? | **Yes** — `sudo apt install linux-image-rpi-v8-rt`, same version stream as stock. Experimental, not documented on raspberrypi.com, but built from the Pi tree. |
+| Generic Debian RT kernel? | **Rejected** — breaks downstream dtoverlays, DSI panel drivers, and Pi 5 isn't mainline-ready anyway. |
+| `preempt=full` without RT? | **Dead end** — not the same as `PREEMPT_RT`; `PREEMPT_DYNAMIC` is off on Pi arm64 kernels, so the boot param is ignored. Stock kernel is already `CONFIG_PREEMPT=y`. |
+| Does RT help Pi audio? | **Mixed.** Academic Pi 4 work shows RT holding 64-sample buffers under load; forum evidence on Pi 5 shows worse tail latency under memory stress. RT compresses scheduling tails but can cost throughput — the wrong trade if voice-stealing is the failure mode. |
+| Pi 4 vs Pi 5 for this test? | **Pi 4 Rev 1.5 confirmed** — `v8` → `v8-rt` is a clean one-variable swap. No `rpi-2712-rt` package exists. |
+
+### Still to check on the live Pi (before Arm B)
+
+| Check | Why |
+|---|---|
+| **A.4b diagnosis** | Distinguish xruns from Surge voice-stealing. If no xruns and scheduling latency ≪ 16 ms, RT is the wrong lever. |
+| **`dtoverlay=` in config.txt** | Only matters if using the 10.1" panel (`ili79600`) — missing from RT defconfig. SmartiPi 5" is `ili9881c`, fine. |
+| **HVS / display load** | Pi engineer note: hardware compositor runs at very high priority and affects latency measurements — continuous touch UI animation during the jam is a confounder RT cannot fix. |
+
+### Cheapest RT test path (if A½ fails and A.4b justifies it)
+
+```bash
+sudo apt install linux-image-rpi-v8-rt
+cp /boot/firmware/config.txt /boot/firmware/tryboot.txt
+# add to tryboot.txt only:  kernel=kernel8_rt.img
+sudo reboot '0 tryboot'    # failed boot → power cycle rolls back to stock
+```
+
+---
+
 ## Open questions
 
-**Resolved** by `mpe sysinfo`: board is Pi 4 Model B Rev 1.5, OS is Debian 13 trixie, kernel 6.18.34 plain `PREEMPT`. `README.md`'s "Pi 5 reference stack" claim does not describe the live unit and should be corrected separately.
-
-Still open, and all of them now gate **Arm B only** — not Arm A0 or A½:
-
-| Question | Why it matters |
-|---|---|
-| **Is PREEMPT_RT obtainable for rpi-6.18 on trixie?** | Raspberry Pi ships no `-rt` flavor. A generic Debian arm64 RT kernel risks breaking `vc4`/DSI, dtoverlays, and the `dwc2` UAC2 gadget — which would take the touch UI and USB audio path with it. If there's no Pi-patched RT kernel, B.1 means *building* one. |
-| **Would enabling `PREEMPT_DYNAMIC` be enough?** | The running kernel is plain `PREEMPT`, so `preempt=full` at boot is not available. Whether an rpt kernel config could enable it more cheaply than full RT is worth knowing — but it is still a kernel rebuild. |
-| **Does RT measurably help Pi audio?** | Need real-world evidence that RT lets people run smaller ALSA periods on Pi 4/5 without xruns, including counter-evidence. Not worth the risk on theory alone. |
-
-Until these are answered, **do not write RT kernel config**. `limits.d` and `SCHED_FIFO` (Arm A½) are explicitly *not* blocked by them — those need no kernel change.
+**None blocking Arm A0, A, or A½.** Arm B is gated on A.4b outcome and A½ exhaustion, not on kernel availability.
 
 ---
 

--- a/docs/LATENCY-SPIKE.md
+++ b/docs/LATENCY-SPIKE.md
@@ -1,36 +1,58 @@
-# Surge latency — RT vs buffer floor experiment
+# Surge latency — can the buffer floor come down?
 
-*Last updated: 2026-08-10 17:12 (America/Toronto)*
+*Last updated: 2026-08-10 17:23 (America/Toronto)*
 
-**The experiment, in one line:** *Does enabling PREEMPT_RT let us run a smaller Surge buffer than 1024 without losing voices?*
+**The question, in one line:** *Can we run a smaller Surge buffer than 1024 without losing voices — and what's the cheapest change that gets us there?*
 
-Everything else in this doc is control-arm bookkeeping for that one question.
+Originally scoped as "enable PREEMPT_RT and turn the buffer down." Measured baseline says start further up the stack: realtime scheduling was never enabled for Surge in the first place.
 
 **Related:** [#44 Buffer size in settings](https://github.com/MitchSchwartz/MPE-Sound-Module/issues/44) · `FAQ.md` · `docs/PATCH_NORMALIZATION.md`
 
-**Status:** Arm A not started. Arm B **blocked** — see §Open questions. Repo buffer defaults corrected to 1024 (below).
+**Status:** Arm A not started. **Arm B is probably unnecessary** — `mpe sysinfo` shows the cheap scheduling wins were never applied (see §Measured baseline). Repo buffer defaults corrected to 1024 (below).
+
+> **Headline:** Surge currently runs `SCHED_OTHER` at priority 0 with an `rtprio` hard limit of **0**, on the `ondemand` CPU governor. It has never had realtime scheduling available to it. Chasing an RT *kernel* before fixing that is optimizing the wrong layer.
 
 ---
 
-## Why this is the only experiment left
-
-Buffer tuning on the stock kernel is **exhausted**:
+## Why buffer tuning alone is exhausted
 
 | Buffer @ 48 kHz | Block latency | Result today |
 |---|---|---|
 | **1024** | ~21 ms | **Production floor** — voices hold under real MPE load |
-| **768** | ~16 ms | **Loses too many voices** (governor/CPU pressure) |
+| **768** | ~16 ms | **Loses too many voices** |
 | **512 and below** | ~11 ms | Historical xrun/crackle on heavy patches |
 
-The binding constraint is **CPU headroom per callback**, not block math. RT changes **scheduling jitter**, which is the plausible mechanism for surviving a shorter callback. Nothing else in the current stack moves this — direct ALSA is already the thin path, and there's no JACK/PipeWire layer to remove.
+The binding constraint is **CPU headroom per callback**, not block math. Direct ALSA is already the thin path and there's no JACK/PipeWire layer to remove, so the remaining levers are all about **when the audio thread gets the CPU** — scheduling policy, priority, and clock speed.
 
-**So:** either RT buys a smaller buffer, or **1024 is the permanent floor** and any Pi-side software looper is dead (looper buffers stack on top of ~21 ms).
+Either something in that layer buys a smaller buffer, or **1024 is the permanent floor** and any Pi-side software looper is dead (looper buffers stack on top of ~21 ms).
+
+---
+
+## Measured baseline (`mpe sysinfo`, 2026-08-10)
+
+| Fact | Value | Consequence |
+|---|---|---|
+| Board | **Pi 4 Model B Rev 1.5** (BCM2711, aarch64) | Not rev 1.0/1.1, so the `tryboot` EEPROM write-protect caveat **does not apply** |
+| OS | **Debian 13 (trixie) 13.5** | Not bookworm — narrows RT kernel options |
+| Kernel | **6.18.34+rpt-rpi-v8**, build string `SMP PREEMPT` | Past 6.12 (where `PREEMPT_RT` mainlined) but built plain `PREEMPT` — **no `PREEMPT_DYNAMIC`**, so `preempt=full` at boot is likely unavailable without a rebuild |
+| CPU governor | **`ondemand`** | ⚠️ Not `performance`. Clock ramps on demand, which is a classic cause of dropouts on transient polyphony spikes |
+| Surge scheduling | **`SCHED_OTHER`, priority 0** | ⚠️ Audio thread runs at *normal* priority — no realtime scheduling at all |
+| `Max realtime priority` | **0** (soft and hard) | ⚠️ Surge **cannot** request RT priority even if it tries; JUCE's attempt fails silently |
+| `Max locked memory` | 8 MB | Default, not raised for audio |
+| `/etc/security/limits.d/` | only `10-coredump-debian.conf` | ⚠️ **No audio limits file exists** |
+| `vcgencmd get_throttled` | **`0x50000`** | ⚠️ Under-voltage **has occurred** and throttling **has occurred** (historic, not active) |
+| Audio profile | **`usb-host`** | Not the `standalone` rig this plan specifies — must be switched before measuring |
+| Buffer / rate | 1024 @ 48000 → **21.33 ms** | Confirms the production floor |
+
+**This changes the plan.** The hypothesis was "the stock kernel's scheduler jitter is the ceiling." But Surge isn't being scheduled as a realtime task *at all*, and the CPU governor isn't pinned. Those are the standard prerequisites for low-latency audio on Linux and neither is in place, so the 768 failure has a much cheaper candidate explanation than kernel preemption model.
+
+**Also a genuine confounder:** under-voltage and throttling have both occurred on this Pi. The repo's own USB-audio notes call out undervoltage as a cause of audio glitches. If the board browns out or thermally throttles during a jam, buffer experiments are measuring a moving target — this needs ruling out *before* Arm A is trusted.
 
 ---
 
 ## Independent variable
 
-**RT kernel: on / off.** That is the *only* thing that changes between arms.
+**One change per arm**, in ascending order of risk: CPU governor → RT scheduling for Surge → RT kernel. Do not bundle them; if governor plus `SCHED_FIFO` land together and 768 starts passing, we won't know which one mattered or whether the kernel arm is needed at all.
 
 **Held constant** — changing any of these invalidates the comparison:
 
@@ -66,26 +88,49 @@ Latency is then simply `buffer × 1000 / 48000` ms — arithmetic, not a measure
 
 ## Procedure
 
-### Arm A — control (stock kernel, ~1 hour)
+Run in order. Stop as soon as an arm passes.
 
-Purpose: put the thing we already believe on the record, so Arm B has something to compare to.
+### Arm A0 — rule out power and thermal (~30 min)
+
+`get_throttled = 0x50000` says this board has browned out **and** throttled at some point. Until that's excluded, every other result is suspect — a Pi that dips below voltage mid-jam will drop voices regardless of buffer size or scheduler.
+
+| Step | Action |
+|---|---|
+| A0.1 | Reboot to clear the sticky bits, run the A.3 jam, then re-read `vcgencmd get_throttled` |
+| A0.2 | If under-voltage recurs: official PSU, powered hub for the Sound Blaster + Roli, re-test. This is a **hardware fix, not a buffer problem** |
+| A0.3 | Log SoC temperature across the jam; confirm no thermal cap under sustained load |
+
+### Arm A — control (stock config, ~1 hour)
+
+Purpose: put the thing we already believe on the record, so the later arms have something to compare against.
 
 | Step | Action |
 |---|---|
 | A.1 | Confirm `MPE_SURGE_BUFFER_SIZE=1024` in `/etc/mpe/mpe.env` and in touch **Audio → Buffer** |
-| A.2 | Build the rig above (no pedal, no gadget, Roli only) |
+| A.2 | Build the rig above — switch profile to **`standalone`** (currently `usb-host`), no pedal, no gadget, Roli only |
 | A.3 | 10 min jam @ **1024** — note voice behavior, grep log for xrun |
 | A.4 | Brief pass @ **768** — **document the failure mode concretely** (which patches, how many voices, how fast it degrades) |
-| A.5 | Record `uname -a`, Pi model, patch list used |
+| A.5 | Capture `mpe sysinfo` output and the patch list used |
 | A.6 | Validation Log row: control arm result |
 
-A.4 matters more than it looks: "loses voices" needs to be specific enough that Arm B can be judged against it rather than against memory.
+A.4 matters more than it looks: "loses voices" needs to be specific enough that later arms can be judged against it rather than against memory.
 
-### Arm A½ — scheduling priority, no kernel change (do this before Arm B)
+### Arm A½ — scheduling and clock, no kernel change (before Arm B)
 
-`SCHED_FIFO` on the audio thread plus `rtprio`/`memlock` limits and a pinned CPU governor address the *same* mechanism as RT — scheduler jitter — at a fraction of the risk, with no kernel swap and no rollback exposure. If this alone buys 768, the RT arm may never be needed.
+This is now the **most promising arm**, and the cheapest: nothing here needs a kernel, a card pull, or a rollback plan. Two independent sub-arms, run separately.
 
-Scope to be set by the feasibility research (see §Open questions) before any config lands. Same 10-minute protocol and same pass criteria as Arm A.
+| Step | Change | Rationale |
+|---|---|---|
+| A½.1 | CPU governor `ondemand` → **`performance`** | Removes clock ramp-up latency on polyphony spikes. Costs power and heat — watch A0.3 |
+| A½.2 | Re-run A.3 @ 1024, then step to 768 | Governor effect in isolation |
+| A½.3 | `limits.d` drop-in: `rtprio` and `memlock` for the audio user | Surge currently has `Max realtime priority 0` — it **cannot** ask for RT |
+| A½.4 | `CPUSchedulingPolicy=fifo` + a modest priority on `surge-xt-cli.service` | Confirm with `chrt -p` that it actually took, then repeat A.3 and the 768 step |
+
+Both sub-arms are **repo-managed** (`config/surge-xt-cli.service` is templated and deployed by `configure-pi-paths.sh`), so they ship as normal PRs through GitHub — no hand-editing on the Pi.
+
+**Do not set an extreme RT priority.** A `SCHED_FIFO` thread that spins can lock up the box; the touch UI and network stack still need to run. Start modest and soak.
+
+If 768 passes here, **Arm B is cancelled** and the looper question reopens without any kernel risk at all.
 
 ### Arm B — RT kernel (1–2 days) — blocked
 
@@ -93,7 +138,7 @@ Scope to be set by the feasibility research (see §Open questions) before any co
 
 | Step | Action |
 |---|---|
-| B.0 | Confirm board revision, kernel, and OS release via `mpe sysinfo` — RT choice depends on all three |
+| B.0 | Re-run `mpe sysinfo` to re-confirm board, kernel, and OS before choosing a kernel |
 | B.1 | Obtain an RT kernel that **keeps** `vc4`/DSI, dtoverlays, and `dwc2` UAC2 gadget working. Install **alongside** the stock kernel, never replacing it |
 | B.2 | Select it via `tryboot.txt` only — not `config.txt` |
 | B.3 | Confirm RT is actually active (`uname -a`) and Surge is actually running at elevated priority — a kernel that boots but doesn't schedule differently proves nothing |
@@ -108,10 +153,15 @@ B.4 is the step that's easy to skip and shouldn't be — if RT changes behavior 
 
 ## Outcomes and what each one decides
 
+Ordered cheapest-first. Stop at the first arm that passes — there's no prize for reaching Arm B.
+
 | Result | Production buffer | Pi software looper |
 |---|---|---|
-| RT holds voices @ **512** | Consider 512 (~11 ms) | **Reopen** — architecture spike worth doing |
-| RT holds voices @ **768** | Consider 768 (~16 ms) | **Marginal** — only without a monitored record path |
+| **A0** — under-voltage was the real cause | Retest everything after the PSU fix | Re-ask once the board is stable |
+| **A½** governor and/or `SCHED_FIFO` holds **512** | Consider 512 (~11 ms), no kernel change | **Reopen** — best case, zero kernel risk |
+| **A½** holds **768** | Consider 768 (~16 ms), no kernel change | **Marginal** — only without a monitored record path |
+| A½ no help, **RT** holds voices @ **512** | Consider 512 (~11 ms) | **Reopen** — architecture spike worth doing |
+| A½ no help, **RT** holds voices @ **768** | Consider 768 (~16 ms) | **Marginal** — only without a monitored record path |
 | RT no better than stock | Stay **1024** (~21 ms) | **Closed** — hardware pedal stays the loop engine |
 | RT hurts reliability | Stay **1024**, stock kernel | **Closed** |
 
@@ -152,19 +202,23 @@ Rules for this experiment:
 1. **Rehearse first.** Run one `tryboot` cycle with a `tryboot.txt` that is just a copy of `config.txt`. Confirm it boots and reverts *before* an RT kernel is involved. Five minutes, zero stakes, and it proves the escape hatch on this specific board.
 2. **Install the RT kernel alongside** the stock one under a distinct filename — never replace it. `config.txt` must always point at a known-good kernel.
 3. **Never put the RT kernel in `config.txt`** until it has survived a full soak via `tryboot`.
-4. **Caveat:** on Pi 4 Model B rev 1.0/1.1 the EEPROM must not be write-protected, since those boards store tryboot state in EEPROM rather than a register. Confirm board revision first.
+4. **Rev caveat — resolved.** On Pi 4 Model B rev 1.0/1.1 the EEPROM must not be write-protected, since those boards store tryboot state in EEPROM rather than a register. This unit is **Rev 1.5**, so the caveat does not apply.
 
 ---
 
-## Open questions blocking Arm B
+## Open questions
 
-| Question | Why it blocks |
+**Resolved** by `mpe sysinfo`: board is Pi 4 Model B Rev 1.5, OS is Debian 13 trixie, kernel 6.18.34 plain `PREEMPT`. `README.md`'s "Pi 5 reference stack" claim does not describe the live unit and should be corrected separately.
+
+Still open, and all of them now gate **Arm B only** — not Arm A0 or A½:
+
+| Question | Why it matters |
 |---|---|
-| **Which board and OS release?** | Diagnostics point to a **Pi 4** (BCM2711 `emmc2bus` path) while `README.md` claims a Pi 5 reference stack; package versions suggest a **trixie**-based OS, not bookworm. RT kernel choice depends on both. `diagnose-pi-state.sh` reports neither — needs an `mpe sysinfo` subcommand. |
-| **Is PREEMPT_RT even obtainable?** | Raspberry Pi ships no `-rt` kernel flavor. A generic Debian arm64 RT kernel risks breaking the things this appliance depends on — DSI panel via `vc4`/kmsdrm, `dwc2` UAC2 gadget, dtoverlays. If so, B.1 means *building a kernel*, not installing one. |
-| **Is RT even the cheapest test of the hypothesis?** | Much of `PREEMPT_RT` landed in mainline 6.12, and `SCHED_FIFO` + `rtprio`/`memlock` limits + CPU governor pinning may deliver most of the jitter reduction **with no kernel change at all**. If so, do that first and RT may never be needed. |
+| **Is PREEMPT_RT obtainable for rpi-6.18 on trixie?** | Raspberry Pi ships no `-rt` flavor. A generic Debian arm64 RT kernel risks breaking `vc4`/DSI, dtoverlays, and the `dwc2` UAC2 gadget — which would take the touch UI and USB audio path with it. If there's no Pi-patched RT kernel, B.1 means *building* one. |
+| **Would enabling `PREEMPT_DYNAMIC` be enough?** | The running kernel is plain `PREEMPT`, so `preempt=full` at boot is not available. Whether an rpt kernel config could enable it more cheaply than full RT is worth knowing — but it is still a kernel rebuild. |
+| **Does RT measurably help Pi audio?** | Need real-world evidence that RT lets people run smaller ALSA periods on Pi 4/5 without xruns, including counter-evidence. Not worth the risk on theory alone. |
 
-Until these are answered, **do not write RT config** into `config/surge-xt-cli.service` or a `limits.d` drop-in.
+Until these are answered, **do not write RT kernel config**. `limits.d` and `SCHED_FIFO` (Arm A½) are explicitly *not* blocked by them — those need no kernel change.
 
 ---
 
@@ -173,7 +227,7 @@ Until these are answered, **do not write RT config** into `config/surge-xt-cli.s
 - **Any kernel install on the gig SD** — Mitch only, and only after `tryboot` is rehearsed
 - **Promoting a kernel into `config.txt`** — Mitch only, and only after a clean soak
 - **Production buffer change** in `/etc/mpe/mpe.env` on the live Pi — Mitch only
-- Reopening the software looper question — only on a written Arm B pass
+- Reopening the software looper question — only on a written Arm A½ or Arm B pass
 
 ## Deploys
 

--- a/docs/LATENCY-SPIKE.md
+++ b/docs/LATENCY-SPIKE.md
@@ -117,20 +117,33 @@ A.4 matters more than it looks: "loses voices" needs to be specific enough that 
 
 ### Arm A½ — scheduling and clock, no kernel change (before Arm B)
 
-This is now the **most promising arm**, and the cheapest: nothing here needs a kernel, a card pull, or a rollback plan. Two independent sub-arms, run separately.
+This is now the **most promising arm**, and the cheapest: nothing here needs a kernel, a card pull, or a rollback plan. Both knobs ship **off by default** so pulling the branch changes nothing until opted into.
 
-| Step | Change | Rationale |
-|---|---|---|
-| A½.1 | CPU governor `ondemand` → **`performance`** | Removes clock ramp-up latency on polyphony spikes. Costs power and heat — watch A0.3 |
-| A½.2 | Re-run A.3 @ 1024, then step to 768 | Governor effect in isolation |
-| A½.3 | `limits.d` drop-in: `rtprio` and `memlock` for the audio user | Surge currently has `Max realtime priority 0` — it **cannot** ask for RT |
-| A½.4 | `CPUSchedulingPolicy=fifo` + a modest priority on `surge-xt-cli.service` | Confirm with `chrt -p` that it actually took, then repeat A.3 and the 768 step |
+**Sub-arm 1 — CPU governor**
 
-Both sub-arms are **repo-managed** (`config/surge-xt-cli.service` is templated and deployed by `configure-pi-paths.sh`), so they ship as normal PRs through GitHub — no hand-editing on the Pi.
+| Step | Action |
+|---|---|
+| A½.1 | Set `MPE_CPU_GOVERNOR=performance` in `/etc/mpe/mpe.env`, reboot, confirm via `mpe sysinfo` |
+| A½.2 | Re-run A.3 @ 1024, then step to 768 — governor effect in isolation |
+| A½.3 | Re-check `get_throttled` and temperature: `performance` costs power and heat, so it could *worsen* an under-voltage problem |
 
-**Do not set an extreme RT priority.** A `SCHED_FIFO` thread that spins can lock up the box; the touch UI and network stack still need to run. Start modest and soak.
+**Sub-arm 2 — realtime scheduling**
 
-If 768 passes here, **Arm B is cancelled** and the looper question reopens without any kernel risk at all.
+`surge-xt-cli.service` now sets `LimitRTPRIO=95` and `LimitMEMLOCK=infinity`, which **permits** rather than forces RT: JUCE can elevate just its audio callback thread while the rest of the process stays normal. That is safer than making the whole process `SCHED_FIFO`.
+
+| Step | Action |
+|---|---|
+| A½.4 | Restart Surge, then `chrt -p $(pgrep -f surge-xt-cli)`. If it now shows `SCHED_FIFO`, JUCE self-elevated — go to A½.6 |
+| A½.5 | If still `SCHED_OTHER`, JUCE isn't asking. Set `MPE_SURGE_RT_PRIORITY=20` to wrap the launch in `chrt --fifo` and re-check |
+| A½.6 | Re-run A.3 @ 1024, then step to 768 |
+
+**Note on `limits.d`:** systemd services bypass PAM, so `/etc/security/limits.d/` has **no effect** on `surge-xt-cli.service` — the unit's `Limit*` directives are the correct mechanism. A `limits.d` file would only matter for Surge launched manually over SSH (e.g. calibration), so it's deliberately not part of this arm.
+
+Everything here is **repo-managed** and deploys through GitHub — no hand-editing on the Pi.
+
+**Do not raise the RT priority aggressively.** A `SCHED_FIFO` thread that spins can lock up the box; the touch UI and network stack still need to run.
+
+If 768 passes here, **Arm B is cancelled** and the looper question reopens with no kernel risk at all.
 
 ### Arm B — RT kernel (1–2 days) — blocked
 

--- a/docs/PATCH_NORMALIZATION.md
+++ b/docs/PATCH_NORMALIZATION.md
@@ -84,7 +84,7 @@ Static or crackle under **many held keys** is usually **ALSA buffer underrun (xr
 |--------|--------|
 | **Norm ON** | Quiet patches get large `gain_db` boosts; runtime cap now matches norm-off (**1.5**, was 0.85 — see 2026-08-01 fix below). |
 | **Norm OFF** | Unity baseline; user trim up to **1.5** — more headroom for solo, less for dense chords. |
-| **ALSA buffer** | `surge-xt-cli` starts with **`MPE_SURGE_BUFFER_SIZE`** (default **768** samples @ **48 kHz** ≈ 16 ms). **512** caused choppery/governor on heavy Pi 4 patches; **1024** was the prior default. |
+| **ALSA buffer** | `surge-xt-cli` starts with **`MPE_SURGE_BUFFER_SIZE`** (default **1024** samples @ **48 kHz** ≈ 21 ms). **768** drops voices under heavy MPE polyphony and **512** caused choppery/governor on heavy Pi 4 patches — 1024 is the stability floor (see [LATENCY-SPIKE.md](LATENCY-SPIKE.md)). |
 | **snd-aloop** | Loaded only during calibration loopback. Unloaded on Surge start and after `calibrate-with-loader.sh` if refcount is 0. |
 
 **Calibration capture path (default: loopback):** Stops production Surge, starts a **cal-only** Surge instance routed through `snd-aloop` (`calibration_loopback.py` dynamically resolves the interface/capture device — no hardcoded card index). Headphones/Sound Blaster are silent during cal; that is expected. Launch from **System → Calibrate** (`calibrate-with-loader.sh`).

--- a/docs/USB-AUDIO-PASSTHROUGH-PLAN.md
+++ b/docs/USB-AUDIO-PASSTHROUGH-PLAN.md
@@ -44,7 +44,7 @@ The MPE Sound Module today outputs audio only through a **Creative Sound Blaster
                               [Sound Blaster Play! 3] ──USB host (Pi USB-A)──► 3.5 mm analog out
 ```
 
-**Key scripts:** `scripts/detect-audio-device.sh` (tiered output selection), `scripts/start-surge-cli.sh` (`--audio-interface`, `MPE_SURGE_BUFFER_SIZE` default 768, `MPE_SURGE_SAMPLE_RATE` default 48000 Hz), `config/99-usb-audio.rules` (restart Surge on USB sound card hot-plug).
+**Key scripts:** `scripts/detect-audio-device.sh` (tiered output selection), `scripts/start-surge-cli.sh` (`--audio-interface`, `MPE_SURGE_BUFFER_SIZE` default 1024, `MPE_SURGE_SAMPLE_RATE` default 48000 Hz), `config/99-usb-audio.rules` (restart Surge on USB sound card hot-plug).
 
 **Sample rate:** Surge/ALSA path tuned for **48 kHz** (see `docs/PATCH_NORMALIZATION.md`). Gadget should advertise **48000** as primary rate to avoid resampling on host or Pi.
 
@@ -125,10 +125,10 @@ When switching profiles, **restart `surge-xt-cli`** (same pattern as `99-usb-aud
 
 | Stage | Approx. contribution @ 48 kHz |
 |-------|----------------------------------|
-| Surge buffer (`MPE_SURGE_BUFFER_SIZE=768`, standalone default) | ~16 ms |
+| Surge buffer (`MPE_SURGE_BUFFER_SIZE=1024`, standalone default) | ~21 ms |
 | ALSA → gadget | Part of Surge callback (same buffer if direct) |
 | USB isochronous + host buffer | ~10–30 ms typical (host-dependent) |
-| **Desk tether total (estimate)** | **~35–60 ms** |
+| **Desk tether total (estimate)** | **~40–65 ms** |
 
 **Implication:** Fine for patch editing, demos, recording, casual listening at desk. **Do not position as low-latency MPE monitor path through laptop speakers** — standalone Sound Blaster remains the performance path.
 

--- a/patch_browser/midi_sync.py
+++ b/patch_browser/midi_sync.py
@@ -6,6 +6,7 @@ import os
 from typing import Any
 
 from patch_browser.midi_clock import PPQN, normalize_midi_bytes
+from patch_browser.surge_audio import DEFAULT_BUFFER, DEFAULT_SAMPLE_RATE
 
 MIDI_CLOCK = 0xF8
 MIDI_START = 0xFA
@@ -54,8 +55,10 @@ def buffer_latency_ms(
     buffer: int | None = None,
     sample_rate: int | None = None,
 ) -> float:
-    buf = buffer if buffer is not None else int(os.environ.get("MPE_SURGE_BUFFER_SIZE", "768"))
-    rate = sample_rate if sample_rate is not None else int(os.environ.get("MPE_SURGE_SAMPLE_RATE", "48000"))
+    buf = buffer if buffer is not None else int(os.environ.get("MPE_SURGE_BUFFER_SIZE", str(DEFAULT_BUFFER)))
+    rate = sample_rate if sample_rate is not None else int(
+        os.environ.get("MPE_SURGE_SAMPLE_RATE", str(DEFAULT_SAMPLE_RATE))
+    )
     if rate <= 0:
         return 0.0
     return 1000.0 * buf / rate

--- a/patch_browser/screen_recorder.py
+++ b/patch_browser/screen_recorder.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import errno
 import os
+import queue
 import sys
+import threading
 import time
 from typing import TYPE_CHECKING
 
@@ -13,6 +15,8 @@ if TYPE_CHECKING:
 
 DEFAULT_ENV_FILE = "/tmp/mpe-screen-record.env"
 DEFAULT_PIPE = "/tmp/mpe-screen-record.pipe"
+_FRAME_QUEUE_MAX = 2
+_STOP = object()
 
 
 def _env_flag(name: str) -> bool:
@@ -66,6 +70,10 @@ class ScreenRecorder:
         self._last_frame_at = 0.0
         self._fd: int | None = None
         self._disabled_reason: str | None = None
+        self._frame_queue: queue.Queue[bytes | object] = queue.Queue(maxsize=_FRAME_QUEUE_MAX)
+        self._writer_thread = threading.Thread(target=self._writer_loop, name="mpe-screen-record", daemon=True)
+        self._writer_started = False
+        self._writer_lock = threading.Lock()
 
     @classmethod
     def from_env(cls) -> ScreenRecorder | None:
@@ -106,20 +114,34 @@ class ScreenRecorder:
         return self._enabled and self._disabled_reason is None
 
     def close(self) -> None:
-        if self._fd is not None:
+        self._enabled = False
+        if self._writer_started:
             try:
-                os.close(self._fd)
-            except OSError:
-                pass
-            self._fd = None
+                self._frame_queue.put_nowait(_STOP)
+            except queue.Full:
+                try:
+                    self._frame_queue.get_nowait()
+                except queue.Empty:
+                    pass
+                try:
+                    self._frame_queue.put_nowait(_STOP)
+                except queue.Full:
+                    pass
+            self._writer_thread.join(timeout=3.0)
+            self._writer_started = False
+        with self._writer_lock:
+            if self._fd is not None:
+                try:
+                    os.close(self._fd)
+                except OSError:
+                    pass
+                self._fd = None
 
     def write_frame(self, surface: pygame.Surface, *, now: float | None = None) -> None:
         if not self.active:
             return
         ts = time.monotonic() if now is None else now
         if ts - self._last_frame_at < self._frame_interval:
-            return
-        if not self._ensure_open():
             return
         size = surface.get_size()
         if size != (self._width, self._height):
@@ -132,12 +154,39 @@ class ScreenRecorder:
 
         try:
             payload = pygame.image.tostring(surface, "RGB")
-            self._write_all(payload)
+        except pygame.error as exc:
+            self._disable(f"frame capture failed: {exc}")
+            return
+        self._ensure_writer_started()
+        try:
+            self._frame_queue.put_nowait(payload)
             self._last_frame_at = ts
-        except BrokenPipeError:
-            self._disable("ffmpeg reader closed the pipe")
-        except OSError as exc:
-            self._disable(f"pipe write failed: {exc}")
+        except queue.Full:
+            pass
+
+    def _ensure_writer_started(self) -> None:
+        if self._writer_started:
+            return
+        self._writer_thread.start()
+        self._writer_started = True
+
+    def _writer_loop(self) -> None:
+        while True:
+            item = self._frame_queue.get()
+            if item is _STOP:
+                break
+            if not isinstance(item, (bytes, bytearray)):
+                continue
+            if not self._ensure_open():
+                continue
+            try:
+                self._write_all(bytes(item))
+            except BrokenPipeError:
+                self._disable("ffmpeg reader closed the pipe")
+                break
+            except OSError as exc:
+                self._disable(f"pipe write failed: {exc}")
+                break
 
     def _write_all(self, payload: bytes) -> None:
         if self._fd is None:
@@ -156,26 +205,32 @@ class ScreenRecorder:
             view = view[wrote:]
 
     def _ensure_open(self) -> bool:
-        if self._fd is not None:
-            return True
-        try:
-            # Blocking writer — ffmpeg opens the read end before SIGUSR1 enables capture.
-            self._fd = os.open(self._pipe_path, os.O_WRONLY)
-            print(
-                f"Screen record → {self._pipe_path} @ {self._fps}fps "
-                f"({self._width}x{self._height} rgb24)",
-                file=sys.stderr,
-            )
-            return True
-        except OSError as exc:
-            if exc.errno in (errno.ENXIO, errno.ENOENT):
+        with self._writer_lock:
+            if self._fd is not None:
+                return True
+            try:
+                self._fd = os.open(self._pipe_path, os.O_WRONLY)
+                print(
+                    f"Screen record → {self._pipe_path} @ {self._fps}fps "
+                    f"({self._width}x{self._height} rgb24)",
+                    file=sys.stderr,
+                )
+                return True
+            except OSError as exc:
+                if exc.errno in (errno.ENXIO, errno.ENOENT):
+                    return False
+                self._disable(f"cannot open {self._pipe_path}: {exc}")
                 return False
-            self._disable(f"cannot open {self._pipe_path}: {exc}")
-            return False
 
     def _disable(self, reason: str) -> None:
         if self._disabled_reason is None:
             print(f"Screen record stopped: {reason}", file=sys.stderr)
         self._disabled_reason = reason
-        self.close()
         self._enabled = False
+        with self._writer_lock:
+            if self._fd is not None:
+                try:
+                    os.close(self._fd)
+                except OSError:
+                    pass
+                self._fd = None

--- a/patch_browser/surge_audio.py
+++ b/patch_browser/surge_audio.py
@@ -13,7 +13,9 @@ SET_SURGE_AUDIO_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "set-
 BUFFER_PRESETS: tuple[int, ...] = (32, 64, 128, 256, 512, 768, 1024, 2048)
 SAMPLE_RATE_PRESETS: tuple[int, ...] = (44100, 48000)
 
-DEFAULT_BUFFER = 768
+# Must stay in sync with the fallback in scripts/start-surge-cli.sh.
+# 768 drops voices under heavy MPE polyphony on Pi 4; 512 choked outright.
+DEFAULT_BUFFER = 1024
 DEFAULT_SAMPLE_RATE = 48000
 
 AUDIO_SWITCH_TIMEOUT_S = 45.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,7 +27,7 @@
 - **check-surge-mode.sh** - Verify CLI/GUI mode state
 
 ### Capture Scripts
-- **record-screen.sh** - Record touch UI via in-app RGB pipe to ffmpeg (see [`docs/TOUCH_PATCH_BROWSER.md`](../docs/TOUCH_PATCH_BROWSER.md#screen-recording-for-demos))
+- **record-screen.sh** - On-Pi touch UI capture (laptop: use **`mpe record`** from [mpe-cli](https://github.com/MitchSchwartz/mpe-cli))
 - **build-patch-metadata-baseline.py** - Regenerate `data/patch_metadata_baseline.json` from local Surge patch dirs (auto-uses sibling `../MPE-Library` when present; else `~/surge` paths)
 
 ### Setup Scripts

--- a/scripts/calibrate-patch-normalization.py
+++ b/scripts/calibrate-patch-normalization.py
@@ -92,6 +92,7 @@ from patch_browser.patch_pressure import (  # noqa: E402
     resolve_light_touch_target,
 )
 from patch_browser.patch_loader import PatchLoader
+from patch_browser.surge_audio import DEFAULT_BUFFER, DEFAULT_SAMPLE_RATE  # noqa: E402
 from patch_browser.patch_scanner import (
     FAVORITES_NAME,
     PatchScanner,
@@ -412,8 +413,8 @@ def start_surge_loopback() -> str:
         raise RuntimeError(f"Surge CLI not found: {cli}")
     ensure_snd_aloop()
     interface = resolve_surge_loopback_interface(cli)
-    buffer_size = os.environ.get("MPE_SURGE_BUFFER_SIZE", "768")
-    sample_rate = os.environ.get("MPE_SURGE_SAMPLE_RATE", "48000")
+    buffer_size = os.environ.get("MPE_SURGE_BUFFER_SIZE", str(DEFAULT_BUFFER))
+    sample_rate = os.environ.get("MPE_SURGE_SAMPLE_RATE", str(DEFAULT_SAMPLE_RATE))
     log_path = Path.home() / "surge-cli-calibration.log"
     with log_path.open("a") as log:
         log.write(
@@ -447,8 +448,8 @@ def start_surge_standalone() -> str:
     if not script.is_file():
         raise RuntimeError(f"detect-audio-device.sh not found: {script}")
     interface = resolve_surge_standalone_interface(cli, detect_script=script)
-    buffer_size = os.environ.get("MPE_SURGE_BUFFER_SIZE", "768")
-    sample_rate = os.environ.get("MPE_SURGE_SAMPLE_RATE", "48000")
+    buffer_size = os.environ.get("MPE_SURGE_BUFFER_SIZE", str(DEFAULT_BUFFER))
+    sample_rate = os.environ.get("MPE_SURGE_SAMPLE_RATE", str(DEFAULT_SAMPLE_RATE))
     log_path = Path.home() / "surge-cli-calibration.log"
     with log_path.open("a") as log:
         log.write(

--- a/scripts/configure-pi-paths.sh
+++ b/scripts/configure-pi-paths.sh
@@ -70,7 +70,7 @@ _run_on_pi() {
             if [ -n "$_preserved_surge_buffer" ]; then
                 echo "MPE_SURGE_BUFFER_SIZE=$_preserved_surge_buffer"
             else
-                echo "MPE_SURGE_BUFFER_SIZE=768"
+                echo "MPE_SURGE_BUFFER_SIZE=1024"
             fi
             if [ -n "$_preserved_surge_sample_rate" ]; then
                 echo "MPE_SURGE_SAMPLE_RATE=$_preserved_surge_sample_rate"

--- a/scripts/lib/mpe-services.sh
+++ b/scripts/lib/mpe-services.sh
@@ -103,6 +103,7 @@ mpe_enable_audio_profile_sync() {
 mpe_enable_core_services() {
     mpe_enable_usb_audio_gadget
     mpe_enable_audio_profile_sync
+    sudo systemctl enable mpe-cpu-governor.service 2>/dev/null || true
     sudo systemctl enable --now mpe-pressure-remap.service 2>/dev/null || true
     if [ "$(mpe_read_appliance_env_var MPE_MIDI_CLOCK_IN_ENABLED 2>/dev/null || echo 1)" = "1" ]; then
         sudo systemctl enable --now midi-clock-in.service 2>/dev/null || true

--- a/scripts/record-screen.sh
+++ b/scripts/record-screen.sh
@@ -53,8 +53,17 @@ fi
 cleanup() {
     local code=$?
     stop_browser_recorder
+    sleep 0.3
     if [ -n "$FFPID" ] && kill -0 "$FFPID" 2>/dev/null; then
         kill -INT "$FFPID" 2>/dev/null || true
+        local i=0
+        while kill -0 "$FFPID" 2>/dev/null && [ "$i" -lt 20 ]; do
+            sleep 0.25
+            i=$((i + 1))
+        done
+        if kill -0 "$FFPID" 2>/dev/null; then
+            kill -KILL "$FFPID" 2>/dev/null || true
+        fi
         wait "$FFPID" 2>/dev/null || true
     fi
     rm -f "$ENV_FILE" "$PIPE" 2>/dev/null || true

--- a/scripts/set-cpu-governor.sh
+++ b/scripts/set-cpu-governor.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Pin the CPU frequency governor (latency experiment support — see docs/LATENCY-SPIKE.md).
+#
+# No-op unless MPE_CPU_GOVERNOR is set in /etc/mpe/mpe.env, so existing
+# appliances keep the distro default until the change is opted into.
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+# shellcheck source=lib/paths.sh
+source "$SCRIPT_DIR/lib/paths.sh"
+
+TARGET="${MPE_CPU_GOVERNOR:-}"
+
+if [ -z "$TARGET" ]; then
+    echo "MPE_CPU_GOVERNOR unset — leaving governor at distro default"
+    exit 0
+fi
+
+CPU0_DIR=/sys/devices/system/cpu/cpu0/cpufreq
+if [ ! -d "$CPU0_DIR" ]; then
+    echo "WARNING: no cpufreq support on this board — skipping" >&2
+    exit 0
+fi
+
+AVAILABLE="$(cat "$CPU0_DIR/scaling_available_governors" 2>/dev/null)"
+case " $AVAILABLE " in
+    *" $TARGET "*) ;;
+    *)
+        echo "ERROR: governor '$TARGET' not available. Options: $AVAILABLE" >&2
+        exit 1
+        ;;
+esac
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: must run as root (systemd unit does; use sudo for manual runs)" >&2
+    exit 1
+fi
+
+_failed=0
+for _gov in /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor; do
+    [ -w "$_gov" ] || continue
+    if ! echo "$TARGET" > "$_gov" 2>/dev/null; then
+        echo "WARNING: could not write $_gov" >&2
+        _failed=1
+    fi
+done
+
+echo "CPU governor: $(cat "$CPU0_DIR/scaling_governor" 2>/dev/null) (requested $TARGET)"
+exit "$_failed"

--- a/scripts/set-surge-audio.sh
+++ b/scripts/set-surge-audio.sh
@@ -69,7 +69,7 @@ fi
 
 mpe_source_appliance_env
 _old_rate="${MPE_SURGE_SAMPLE_RATE:-48000}"
-_old_buffer="${MPE_SURGE_BUFFER_SIZE:-768}"
+_old_buffer="${MPE_SURGE_BUFFER_SIZE:-1024}"
 
 _update_env_var() {
     local key="$1"

--- a/scripts/start-surge-cli.sh
+++ b/scripts/start-surge-cli.sh
@@ -87,7 +87,27 @@ else
   echo "$(date): Surge MIDI all inputs (remapper disabled)" >> "$LOG_FILE"
 fi
 
-"$SURGE_CLI" \
+# Optional SCHED_FIFO for the whole Surge process. Off by default: LimitRTPRIO in
+# surge-xt-cli.service already lets JUCE elevate just its audio thread, which is
+# safer. Use this only if `chrt -p <pid>` still shows SCHED_OTHER under load.
+# See docs/LATENCY-SPIKE.md (Arm A½).
+SURGE_LAUNCH_PREFIX=()
+case "${MPE_SURGE_RT_PRIORITY:-0}" in
+  '' | 0) ;;
+  *[!0-9]*)
+    echo "$(date): WARNING: MPE_SURGE_RT_PRIORITY not a number — ignoring" >> "$LOG_FILE"
+    ;;
+  *)
+    if command -v chrt > /dev/null 2>&1; then
+      SURGE_LAUNCH_PREFIX=(chrt --fifo "$MPE_SURGE_RT_PRIORITY")
+      echo "$(date): SCHED_FIFO priority $MPE_SURGE_RT_PRIORITY" >> "$LOG_FILE"
+    else
+      echo "$(date): WARNING: chrt not found — staying SCHED_OTHER" >> "$LOG_FILE"
+    fi
+    ;;
+esac
+
+"${SURGE_LAUNCH_PREFIX[@]}" "$SURGE_CLI" \
   "${SURGE_MIDI_ARGS[@]}" \
   --mpe-enable \
   --mpe-pitch-bend-range=48 \

--- a/scripts/start-surge-cli.sh
+++ b/scripts/start-surge-cli.sh
@@ -60,7 +60,7 @@ lsusb 2>&1 | grep -i "midi\|roli\|seaboard" >> "$LOG_FILE" || echo "  No USB MID
 # shellcheck source=lib/unload-snd-aloop.sh
 source "$SCRIPT_DIR/lib/unload-snd-aloop.sh"
 
-SURGE_BUFFER_SIZE="${MPE_SURGE_BUFFER_SIZE:-768}"
+SURGE_BUFFER_SIZE="${MPE_SURGE_BUFFER_SIZE:-1024}"
 SURGE_SAMPLE_RATE="${MPE_SURGE_SAMPLE_RATE:-48000}"
 echo "$(date): ALSA buffer size: $SURGE_BUFFER_SIZE samples" >> "$LOG_FILE"
 echo "$(date): Sample rate: $SURGE_SAMPLE_RATE Hz" >> "$LOG_FILE"

--- a/tests/test_cpu_governor.py
+++ b/tests/test_cpu_governor.py
@@ -13,6 +13,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 GOVERNOR_SCRIPT = REPO_ROOT / "scripts" / "set-cpu-governor.sh"
 
 
+CPU0_CPUFREQ = Path("/sys/devices/system/cpu/cpu0/cpufreq")
+
+
 def _run_governor(env_value: str | None) -> subprocess.CompletedProcess[str]:
     env = {"PATH": "/usr/bin:/bin", "HOME": str(Path.home())}
     if env_value is not None:
@@ -38,6 +41,10 @@ class CpuGovernorScriptTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("unset", result.stdout)
 
+    @unittest.skipUnless(
+        CPU0_CPUFREQ.is_dir(),
+        "no cpufreq sysfs on this host (e.g. GitHub Actions)",
+    )
     def test_unavailable_governor_fails_loudly(self) -> None:
         """A typo must not silently leave the governor unchanged."""
         result = _run_governor("no-such-governor")

--- a/tests/test_cpu_governor.py
+++ b/tests/test_cpu_governor.py
@@ -1,0 +1,81 @@
+"""Tests for CPU governor pinning and Surge realtime scheduling config.
+
+See docs/LATENCY-SPIKE.md (Arm A½) for why these knobs exist.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOVERNOR_SCRIPT = REPO_ROOT / "scripts" / "set-cpu-governor.sh"
+
+
+def _run_governor(env_value: str | None) -> subprocess.CompletedProcess[str]:
+    env = {"PATH": "/usr/bin:/bin", "HOME": str(Path.home())}
+    if env_value is not None:
+        env["MPE_CPU_GOVERNOR"] = env_value
+    return subprocess.run(
+        ["bash", str(GOVERNOR_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+class CpuGovernorScriptTests(unittest.TestCase):
+    def test_noop_when_unset(self) -> None:
+        """Existing appliances must be unaffected until the knob is opted into."""
+        result = _run_governor(None)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("unset", result.stdout)
+
+    def test_empty_value_is_noop(self) -> None:
+        result = _run_governor("")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("unset", result.stdout)
+
+    def test_unavailable_governor_fails_loudly(self) -> None:
+        """A typo must not silently leave the governor unchanged."""
+        result = _run_governor("no-such-governor")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not available", result.stderr)
+
+
+class SurgeRealtimeUnitTests(unittest.TestCase):
+    """The RT permission is the whole point of Arm A½ — guard it from silent removal."""
+
+    def setUp(self) -> None:
+        self.unit = (REPO_ROOT / "config" / "surge-xt-cli.service").read_text(encoding="utf-8")
+
+    def test_unit_permits_realtime_priority(self) -> None:
+        self.assertIn("LimitRTPRIO=", self.unit)
+
+    def test_unit_allows_locked_memory(self) -> None:
+        self.assertIn("LimitMEMLOCK=", self.unit)
+
+    def test_unit_does_not_force_fifo_on_whole_process(self) -> None:
+        """Forcing SCHED_FIFO process-wide can starve the touch UI; opt in via env instead."""
+        self.assertNotIn("CPUSchedulingPolicy=", self.unit)
+
+    def test_unit_orders_after_governor(self) -> None:
+        self.assertIn("mpe-cpu-governor.service", self.unit)
+
+
+class GovernorUnitFileTests(unittest.TestCase):
+    def test_unit_reads_appliance_env(self) -> None:
+        unit = (REPO_ROOT / "config" / "mpe-cpu-governor.service").read_text(encoding="utf-8")
+        self.assertIn("EnvironmentFile=-/etc/mpe/mpe.env", unit)
+        self.assertIn("Before=surge-xt-cli.service", unit)
+
+    def test_env_example_documents_both_knobs(self) -> None:
+        example = (REPO_ROOT / "config" / "mpe.env.example").read_text(encoding="utf-8")
+        self.assertIn("MPE_CPU_GOVERNOR", example)
+        self.assertIn("MPE_SURGE_RT_PRIORITY", example)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_screen_recorder.py
+++ b/tests/test_screen_recorder.py
@@ -9,7 +9,7 @@ import threading
 import unittest
 from unittest import mock
 
-from patch_browser.screen_recorder import ScreenRecorder
+from patch_browser.screen_recorder import ScreenRecorder, _FRAME_QUEUE_MAX
 
 
 class _FakeSurface:
@@ -49,17 +49,15 @@ class ScreenRecorderTests(unittest.TestCase):
             width=800,
             height=480,
         )
-        rec._fd = 999
         rec._last_frame_at = -1.0
         surface = _FakeSurface((800, 480))
         with mock.patch.dict(sys.modules, {"pygame": mock.MagicMock()}):
             fake_pygame = sys.modules["pygame"]
             fake_pygame.image.tostring.return_value = b"x" * (800 * 480 * 3)
-            with mock.patch("os.write", return_value=800 * 480 * 3) as write_mock:
-                rec.write_frame(surface, now=0.0)
-                rec.write_frame(surface, now=0.01)
-                self.assertEqual(write_mock.call_count, 1)
-                fake_pygame.image.tostring.assert_called_once()
+            rec.write_frame(surface, now=0.0)
+            rec.write_frame(surface, now=0.01)
+            fake_pygame.image.tostring.assert_called_once()
+            self.assertEqual(rec._frame_queue.qsize(), 1)
 
     def test_write_frame_size_mismatch_disables(self) -> None:
         rec = ScreenRecorder(
@@ -69,7 +67,6 @@ class ScreenRecorderTests(unittest.TestCase):
             width=800,
             height=480,
         )
-        rec._fd = 999
         rec._last_frame_at = -1.0
         rec.write_frame(_FakeSurface((640, 480)), now=0.0)
         self.assertFalse(rec.active)
@@ -152,6 +149,24 @@ class ScreenRecorderTests(unittest.TestCase):
             with mock.patch("time.sleep"):
                 rec._write_all(payload)
         self.assertTrue(rec.active)
+
+    def test_write_frame_does_not_block_on_full_queue(self) -> None:
+        rec = ScreenRecorder(
+            enabled=True,
+            pipe_path="/tmp/nope",
+            fps=30,
+            width=800,
+            height=480,
+        )
+        rec._writer_started = True
+        rec._last_frame_at = -1.0
+        for _ in range(_FRAME_QUEUE_MAX):
+            rec._frame_queue.put_nowait(b"x")
+        surface = _FakeSurface((800, 480))
+        with mock.patch.dict(sys.modules, {"pygame": mock.MagicMock()}):
+            sys.modules["pygame"].image.tostring.return_value = b"y" * 12
+            rec.write_frame(surface, now=0.0)
+        self.assertEqual(rec._frame_queue.qsize(), _FRAME_QUEUE_MAX)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Promote integration branch to release line for Pi pull.

- **Latency experiment** — `docs/LATENCY-SPIKE.md`, Arm A½ knobs (governor + RT scheduling, off by default), `mpe sysinfo` docs
- **Buffer defaults** — align repo defaults from 768 → 1024 (stability floor)
- **mpe-cli** — remove embedded `scripts/mpe`; document external orchestrator; Cursor allowlist
- **Touch UI** — screen recording fix without freezing browser

## Test plan

- [x] CI green on merged PR #46 (381 unit tests + shell tests)
- [ ] Pi pull + `configure-pi-paths.sh --local --force` after merge
- [ ] Arm A0 power check (human, next step)

Made with [Cursor](https://cursor.com)