### PR TITLE
Gate C prep: review fixes (udev, watchdog, jackd -P, UI drift)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Shellcheck scripts
+        run: shellcheck scripts/*.sh scripts/lib/*.sh
       - name: Run shell tests
         run: |
-          bash tests/test_gadget_persist.sh
-          bash tests/test_prepare_dsi_display.sh
+          for t in tests/test_*.sh; do
+            bash "$t"
+          done

--- a/Documents/reviews/grumpy-review-kimi-2026-08-13.md
+++ b/Documents/reviews/grumpy-review-kimi-2026-08-13.md
@@ -1,0 +1,215 @@
+# Grumpy Dev review — MPE-Module (JACK audio engine, post-Phase-1)
+
+*Review date: 2026-08-13 (America/Toronto)*
+*Reviewer: Kimi (grumpy senior dev mode), full-codebase pass*
+*Branch under review: `yolo/jack-drop-alsa-fallback` @ `1ab9f55`, one commit on top of `dev` @ `daac891` (PR #49, JACK Phase 1 merge).*
+*Scope: this repo only. `mpe-cli` excluded per instructions. No code modified.*
+
+**What I read:** both audio specs in full (`Documents/specs/jack-audio-engine-spec.md`, `looper-jack-client-spec.md`), the three touch specs (browse spec in full, browse-UX and favorites specs skimmed), `AGENTS.md`, `README.md`, `docs/GIT-WORKFLOW.md`, `docs/PATHS.md`, `docs/STABLE-SETUP.md`, `CHANGELOG.md`, git history (`dev`, `main`, branch topology). Code: all of `scripts/lib/audio-engine.sh`, `engine-guard.sh`, `paths.sh`, `mpe-services.sh`; `start-surge-cli.sh`, `start-jackd.sh`, `jackd-prestart.sh`, `restart-audio-graph.sh`, `surge-watchdog.sh`, `uac2-stall-watchdog.sh`, `mic-to-uac2-bridge.sh`, `set-audio-profile.sh`, `set-surge-audio.sh`, `configure-pi-paths.sh`, `detect-audio-device.sh`, `detect-jack-device.sh`, `start-uac2-watchdog-if-needed.sh`; systemd units (`mpe-jackd`, `surge-xt-cli`, `surge-watchdog`) and `99-usb-audio.rules`; Python side: `audio_engine.py`, `engine_state_monitor.py`, `surge_audio.py`, `audio_profile.py`, `session_capture.py`, `surge_monitor.py`, `mixer.py`, `mixer_controls.py`, `touch_browser_mixer.py`, `json_store.py`, `looper_clock_monitor.py`, the touch app orchestrator and HUD draw paths; `tests/test_audio_engine.py` structure; `.github/workflows/test.yml`; `config/mpe.env.example`.
+**What I sampled rather than read line-by-line:** the remaining ~40 `patch_browser/` modules (calibration, scanner, sidecars, pressure, WiFi, MIDI clock — read headers/greps only), the 60-odd other test files (structure and names, not bodies), `patch_browser_ui.py` (1456-line legacy encoder UI — headers only), deploy/setup scripts not on the audio path. Full-repo greps for `MPE_AUDIO_ENGINE`, `degraded`, `arecord`/`aplay`/`snd-aloop`, merge conflict markers, and duplicate function definitions back the drift claims.
+
+---
+
+## 1. First Impressions (The Gut Check)
+
+This does not look like a codebase that "got twisted up." It looks like a codebase that survived a twist and *documented the scar tissue*. The phase structure is intact, the ALSA removal is genuinely complete (I grepped for every deleted symbol — they're gone, and there are static guard tests keeping them gone), the test suite is green (440 tests, 0 failures), and the spec amendment is unusually honest engineering writing — `RETIRED 2026-08-13` markers instead of rewriting history, with the soak log explicitly quarantined as evidence for a design that no longer exists.
+
+The twist is real, but it's in the *branch topology and the plan's forward path*, not in the merged tree: `yolo/looper-phase0` (PR #48) is 76 commits ahead / 1 behind `dev` with a merge-base *before* Phase 1, the Phase 2 spec depends on files that only exist there, and the replacement spec (`looper-jack-client-spec.md`) is sitting **untracked in the working tree** while contradicting the amendment its sibling spec landed yesterday. The merged code is coherent. The *pipeline* is where the risk lives.
+
+## 2. Architecture & Structure
+
+The Phase 1 architecture is sound and, frankly, better argued than most commercial embedded audio work I've reviewed:
+
+- **Single-engine state machine** (`ok | recovering | failed`) with state in `/run/mpe` tmpfs, atomic writes, and `RuntimeDirectoryPreserve=yes` — the spec's reasoning about *why* state can't live in the watchdog's memory (the watchdog is `BindsTo` the service it restarts) is correct and is implemented exactly as reasoned. `scripts/lib/audio-engine.sh:88-122`, `config/surge-xt-cli.service:13-14`.
+- **Supervisor cooldown math is done against systemd's actual knobs** — 90 s cooldown / max 3 restarts sized to stay under `StartLimitBurst=5 / StartLimitIntervalSec=300`. Somebody did the arithmetic instead of picking a number. `patch_browser/audio_engine.py:52-76` with a bash parity twin at `scripts/lib/audio-engine.sh:369-392`, and parity *tests* proving they agree.
+- **D2's "restart jackd, not Surge" rule is actually followed** in the callers I read: `set-audio-profile.sh:57`, `set-surge-audio.sh:129`, `uac2-stall-watchdog.sh:64-68`, `99-usb-audio.rules:26-27` all route through `mpe_restart_audio_graph`.
+- **The `BindsTo` rejection rationale** (surge must start to *report* failure) is the kind of reasoning that separates a state machine from a pile of shell.
+
+Structural concerns:
+
+- The `mpe_jackd.service` ↔ `surge-xt-cli.service` ↔ `surge-watchdog.service` triangle is now the single most load-bearing thing in the product, and its correctness rests on bash sourced libraries with stringly-typed state files. It works, it's tested, and it's one distracted refactor away from subtle breakage. The `NoAlsaPathTests` grep-guards are the right instinct — extend that pattern, don't relax it.
+- `main` is **42 commits behind `dev`** (`git rev-list --count main..dev`), meaning the entire JACK engine, the governor work, and months of touch UI are absent from the release line the "stable appliance" tracks. That's expected mid-phase, but the gap is now large enough that a emergency gig rollback to `main` would be a *different product*. Plan the `dev`→`main` promotion as its own tested event.
+- Phase 2's entire dependency chain runs through PR #48, which predates Phase 1 and touches the three files Phase 1 rewrote most (`start-surge-cli.sh`, `detect-audio-device.sh`, `99-usb-audio.rules`). The looper spec's Task 0 (rebase) is correctly identified as the gate. Until it lands, "sound module + analog-esque mixer" is a one-client graph — a mixer with one channel.
+
+## 3. Code Quality
+
+The good, concretely:
+
+- `patch_browser/json_store.py:24-43` — atomic write with `fsync` on file *and* directory. Most projects half-do this. This one doesn't.
+- `scripts/lib/audio-engine.sh:160-179` — `mpe_engine_state_write` uses `${2:-unknown}` instead of `${2:?}` with a comment explaining that a status publisher killed its caller and left the instrument unsupervised. That's a bug someone *found*, and the fix carries its own rationale.
+- `patch_browser/audio_engine.py` is 140 lines, readable, and every constant carries its provenance (why 5 s, why 90 s, why 3).
+- Bash/Python parity is enforced by tests (`BashReconcileParityTests`), not by hope.
+- Shell quoting is disciplined throughout the scripts I read; `set -uo pipefail` (and `set -e` where safe) is consistent; enum validation on every env knob (`mpe_jack_period`, `mpe_jack_rate`, `set-surge-audio.sh`) keeps the sudo/NOPASSWD surface sane.
+
+The mediocre:
+
+- The touch UI is a **19-mixin Frankenclass** (`patch_browser/touch_browser_app.py:67-87`). It works and it's split along sensible seams, but the mixins reach into each other's attributes freely, which is why `touch_browser_draw.py:485-489` needs defensive `getattr(self, "engine_hud_rect", Rect(0,0,0,0))` chains — the compiler of last resort is runtime attribute roulette. Not urgent; worth a "who owns which attrs" pass before the next big UI feature.
+- Stringly-typed state files (`engine.state`, `surge.state`, `jack.state`, `engine-reconcile.state`) parsed by grep/cut in bash and `str.partition` in Python. Two parsers, one format, zero schema. It has held so far; the day someone writes a value containing `=` or a newline, both parsers degrade differently.
+
+## 4. Code Smells (The Hall of Shame)
+
+**🔴 1. jackd's duplex open almost certainly breaks the usb-host-session mic bridge — and nobody can know, because the soak row is BLOCKED.**
+
+`scripts/start-jackd.sh:43-44`:
+
+```bash
+exec jackd -R -P"$JACK_PRIO" -s \
+    -d alsa -d "$HW_DEV" -r "$JACK_RATE" -p "$JACK_BUFFER" -n "$JACK_PERIODS"
+```
+
+No `-P` (playback-only) flag. jackd's ALSA backend opens the device **duplex** by default, which means it holds the Sound Blaster's *capture* stream too. Meanwhile `scripts/mic-to-uac2-bridge.sh:54` — the entire point of the `usb-host-session` profile ("Surge on Sound Blaster; mic → USB when PC captures", per `config/mpe.env.example:39`) — does:
+
+```bash
+arecord -D "$CAP_DEV" -f S16_LE -r "$RATE" -c 2 -t raw --buffer-size="$BUF" |
+```
+
+where `resolve_blaster_mic_capture_device()` (`patch_browser/session_capture.py:66-89`) resolves `plughw:CARD=<Play3>,DEV=0` — the same card jackd now holds. ALSA `hw` opens are exclusive: pre-JACK this worked because Surge's JUCE ALSA open was playback-only ("Front output"); post-JACK the capture side is busy and the bridge will fail with `Device or resource busy`, likely in a restart loop (`mic-to-uac2-bridge.service`). Criteria 5b and 14's session-capture half are both marked **BLOCKED — physical rewire** in the Gate B log, so this regression window has never been exercised. *Fix direction:* add `-P` (playback-only) to the jackd line — or explicitly split `-P/-C` — then actually run the blocked 5b/14 soak rows; if capture on the same card is ever wanted by a future client, that decision belongs in the spec, not in a default.
+
+**🟡 2. The touch UI sells you a buffer size the engine doesn't use.**
+
+`patch_browser/surge_audio.py:16-19`:
+
+```python
+# Must stay in sync with the fallback in scripts/start-surge-cli.sh.
+# 768 drops voices under heavy MPE polyphony on Pi 4; 512 choked outright.
+DEFAULT_BUFFER = 1024
+```
+
+There is no fallback in `start-surge-cli.sh` anymore — the comment is a ghost, and worse, the whole module treats `MPE_SURGE_BUFFER_SIZE` as the buffer. The graph actually runs `MPE_JACK_BUFFER` (default 256). A fresh appliance displays "Audio buffer — 1024 · 21 ms" while playing at 256×3 = 16 ms. The seeder makes it official — `scripts/configure-pi-paths.sh:70-74`:
+
+```bash
+if [ -n "$_preserved_surge_buffer" ]; then
+    echo "MPE_SURGE_BUFFER_SIZE=$_preserved_surge_buffer"
+else
+    echo "MPE_SURGE_BUFFER_SIZE=1024"
+fi
+```
+
+writes the legacy key into every fresh `/etc/mpe/mpe.env` and never writes the JACK keys. (The Gate B soak already saw this: `mpe test pi audio` reported 12 "touch buffer label / env drift" failures, dismissed as "pre-existing.") `set-surge-audio.sh:125-128` doubles down by writing *both* keys on `--buffer`, coupling the two knobs D6 explicitly separated. *Fix:* point `surge_audio.py`'s read-back and labels at `MPE_JACK_BUFFER`/`MPE_JACK_PERIODS` (and multiply by periods in the latency label), stop seeding `MPE_SURGE_BUFFER_SIZE` in `configure-pi-paths.sh`, and have `set-surge-audio.sh --buffer` write the JACK key only.
+
+**🟡 3. The watchdog's "bounded" wait isn't, when jackd hangs instead of dying.**
+
+`scripts/surge-watchdog.sh:73-86`:
+
+```bash
+if ! mpe_jack_server_ready; then
+    waited=0
+    while [ "$waited" -lt "$RECONCILE_BUDGET" ]; do
+        if mpe_jack_server_ready; then
+            break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+```
+
+`mpe_jack_server_ready` internally runs `timeout 3 jack_lsp` (`scripts/lib/audio-engine.sh:208-216`). When jackd is *running but hung* (process exists, never answers), each probe burns up to 3 s, so the "15 s budget" loop is really up to ~15 × (3 + 1) = **60 s** of watchdog blockage — during which the crash-recovery arm at the top of the main loop doesn't run. The same probe is also executed up to three times per reconcile pass (`_reconcile_engine` calls `mpe_surge_on_jack_graph` → `mpe_jack_server_ready`, then `mpe_jack_server_ready` again twice). *Fix:* probe once per pass into a variable, and count wall-clock (`SECONDS` or epoch deltas) instead of loop iterations.
+
+**🟡 4. The Phase 2 spec contradicts the amendment — and isn't committed.**
+
+`Documents/specs/looper-jack-client-spec.md` is **untracked** (`git status`: `?? Documents/specs/looper-jack-client-spec.md`) and stale in at least four places against the 2026-08-13 amendment: §D.5 still scopes "keep `MPE_AUDIO_ENGINE=alsa` as an explicit operator choice" (the amendment deleted the variable outright); criterion 11's verification boots "with `MPE_AUDIO_ENGINE=jack` unset (default)" — a variable that no longer exists; §D.5.2 describes the guard message advising `mpe engine set alsa` (the message was rewritten); §D.5.3 analyzes `looper_guard_blocked` keying on the configured engine (the parameter was dropped). This is exactly how "the spec said so" bugs get reintroduced by a future session reading the newest-looking document. *Fix:* amend the looper spec's §D.5/criterion 11 to the JACK-only reality and commit the file — a spec that isn't in git isn't a spec, it's a rumor.
+
+**🟡 5. One predicate, three implementations.**
+
+The looper-guard decision — "is `MPE_LOOPER_ENABLED=1`" — exists as `mpe_looper_engine_blocked()` (`scripts/lib/engine-guard.sh:24-26`), `mpe_looper_state_label()` (`scripts/lib/audio-engine.sh:189-195`), and `looper_guard_blocked()` (`patch_browser/audio_engine.py:36-38`). The spec's own D5 rationale was "a guard per call site would rot," and then the guard itself got three homes. Today they're trivially identical; after Phase 2 lifts the guard they become three places to half-delete (criterion 11 even greps for `LOOPER_GUARD` — it won't catch `mpe_looper_state_label`). *Fix:* make `engine-guard.sh` the single bash source (have `mpe_looper_state_label` call it or move both into `audio-engine.sh`), and keep the Python twin only because the HUD needs it — with the parity test extended to cover all three.
+
+**🟢 6. Stale comment parade.** `config/99-usb-audio.rules:1-5` still says "Automatically restart Surge XT CLI when USB audio devices are connected/disconnected" (it restarts the graph now); `scripts/uac2-stall-watchdog.sh:4-6` still says "restart Surge on the gadget" (it calls `restart_audio_graph`); `scripts/lib/engine-guard.sh:7` dates the ALSA removal "2026-08-12" (the amendment is 2026-08-13); `scripts/set-surge-audio.sh:72` assigns `_old_buffer` and never uses it. *Fix:* one comment-hygiene pass; these are the lies the next incident report will trip over.
+
+## 5. Logic & Business Rules
+
+- **The hard-failure design is correctly wired end to end.** `start-surge-cli.sh:147-154` publishes `state=failed` with a named reason and exits non-zero; `surge-xt-cli.service` retries on its own; the supervisor's budget caps the loop and escalates once (`surge-watchdog.sh:39-47` announces `failed` a single time, not every 5 s poll). The `BindsTo` rejection logic in the spec is implemented as specified — I verified the unit graph rather than trusting the doc.
+- **The failed-state reason gets overwritten.** When the supervisor escalates with reason `supervisor-exhausted`, Surge's own `Restart=on-failure` keeps re-running `start-surge-cli.sh`, which re-publishes `state=failed reason=no-server` (`start-surge-cli.sh:151`). The HUD shows the right state but the journal/status reason loses the escalation history. Cosmetic; one line in `mpe_engine_state_write` callers ("don't downgrade reason") fixes it.
+- **Rule-serving edge case done right:** `start-jackd.sh:33-41` only publishes `recovering` if nothing more specific (`ok`/`failed`) is already published — a jackd restart must not clobber Surge's state. That's the kind of multi-writer discipline state files usually don't get.
+- **Profile-switch flag lifecycle is sound but subtle:** `set-audio-profile.sh:54-60` marks the flag, and it persists until Surge next starts — which, post-Phase-1, happens on the *supervisor's* schedule, not the operator's. The comment acknowledges it. Behavior is correct; the UX consequence (MIDI wait skipped possibly minutes later) is worth one sentence in `docs/PATHS.md`.
+- **Business-rule drift, minor:** `set-surge-audio.sh` accepts only 44100/48000 sample rates while `mpe_jack_rate()` also accepts 96000 (`scripts/lib/audio-engine.sh:60-65`). Either 96k is a supported rate (let the UI offer it) or it isn't (remove it from the validator). Pick one.
+- **HUD label vs. retired states:** `engine_hud_label` (`patch_browser/audio_engine.py:110-125`) would render a stale pre-upgrade state file carrying `active=alsa state=degraded` as an "ALSA" badge — `degraded` is correctly unrecognized (tested), but the `active` value is passed through untrusted. Harmless (tmpfs clears on reboot), one `active not in ("jack", "none")` check fixes it.
+
+## 6. Test Strategy & Execution
+
+**Actual run:** `python3 -m unittest discover -s` is hook-blocked on this machine; ran the project's own harness, `mpe test local all` (same discover + shell suites):
+
+```
+Ran 440 tests in 42.076s
+OK
+OK test_gadget_persist.sh
+All prepare-dsi-display shell tests passed
+```
+
+440 tests, **0 failures**. (CHANGELOG claims 438 for the amendment commit; two have been added since or the count drifted — immaterial, but the doc and the suite should agree.)
+
+What's genuinely good:
+
+- **`tests/test_audio_engine.py` (704 lines) is the model test file**: pure-decision unit tests, bash-parity tests that execute the real shell functions, static `NoAlsaPathTests` that grep the tree to make the ALSA removal *irreversible-by-accident*, and unit-file content assertions (RuntimeDirectoryPreserve, StartLimit keys in `[Unit]` not `[Service]` — a bug class they actually hit).
+- CI (`.github/workflows/test.yml`) runs the same discover plus the two shell harnesses on `dev`/`main` pushes and PRs, and the pygame-dependent tests mock the display, so the minimal CI environment (`pip install python-osc` only) is sufficient. Local green == CI green is plausible here.
+
+The gaps:
+
+- **Criterion 16 has no executable test.** `mpe_jack_period` / `mpe_jack_periods` / `mpe_jack_rate` — the enum validators guarding the server's period — have zero test coverage (`grep MPE_JACK_BUFFER tests/` → nothing). The D6 separation is asserted in docs and violated in practice by the UI layer (Hall of Shame #2), which is exactly what a test would have caught.
+- The heavy UI surface (1400-line draw mixin, 19 mixins) is covered by smoke/wiring tests, not behavior tests. Acceptable for a single-user appliance; don't let it grow further without a seam.
+- The integration tests that matter most (2\*, 2b/2b2 at the new 5 s settle, 15-from-`failed`, 12 stale-env) are **Pi-only by design and currently unrun** — see Spec Conformance below. The unit suite cannot substitute for them; the branch is correctly labeled REQUIRES PI SOAK BEFORE MERGE. Hold that line.
+
+## 7. Security & Performance
+
+**Security** — this is a single-user appliance with no network surface (OSC bound to `127.0.0.1:53280`, confirmed in `patch_browser/patch_loader.py` and the spec), and the review found no holes:
+
+- Privilege boundaries are sane: units run as the appliance user, `LimitRTPRIO=95` *permits* RT without forcing it, `sudo -n` is used everywhere in libraries, and every sudo-exposed script (`set-surge-audio.sh`, `set-audio-profile.sh`) validates against fixed enums before touching `/etc/mpe/mpe.env`. The `_update_env_var` sed writes only validated values. `paths.sh` sources env files as root in some unit contexts — standard risk, mitigated by root-owned `/etc/mpe`.
+- No secrets in the repo; `.gitignore` covers SSH keys explicitly.
+
+**Performance:**
+
+- The reconcile-probe worst case (Hall of Shame #3) is the one real perf defect: up to ~60 s of watchdog blockage against a hung jackd, which also delays the crash-recovery arm.
+- Otherwise the hot paths are thoughtfully cheap: HUD reads `engine.state` via a 0.5 s cached background monitor (`patch_browser/engine_state_monitor.py`), not per-frame disk hits; patch scanning is indexed; the state writers are O(lines) greps on tiny tmpfs files.
+- One free win: `start-surge-cli.sh` invokes `"$SURGE_CLI" --list-devices` up to three times per boot (JACK index, MIDI index, and detection downstream). Each Surge CLI invocation is seconds of boot time on a Pi 4. Cache one listing per boot and parse it three ways.
+
+## 8. Developer Experience
+
+- **Documentation is a genuine strength.** `AGENTS.md`, `COMMANDS.md`, `docs/PATHS.md`, `docs/GIT-WORKFLOW.md`, and `docs/STABLE-SETUP.md` are current, cross-linked, and opinionated ("Pi runs from git clone only — no loose copies"). The spec cites `file:line` for its claims; I spot-checked a dozen citations and they resolved.
+- The spec's self-flagellation sections (Falsification Analysis, "this threshold is a decision on incomplete data," honest BLOCKED rows in the soak log) are the best thing in the repo. Keep that culture; it's rarer than any code here.
+- **The twist shows in DX, not code:** an untracked governing spec, a 76-commit unmerged prerequisite branch, and a same-day amendment landing on a fresh branch mean the next session's orientation cost is high. The `CHANGELOG.md` discipline (dated, per-session, with branch names) is what's saving you.
+- Minor housekeeping: `ENCODER_BUTTON_REVIEW.md` sits at repo root instead of `docs/`; `README.md:75` says reference stack is "Raspberry Pi 5" while both specs say Pi 4B (two appliances may exist — then say so); `logs/shutdown-trace.jsonl` is an untracked runtime artifact in the working tree (fine, but consider ignoring `logs/`).
+
+---
+
+## Spec Conformance: Phase One vs Plan
+
+Mapping each `jack-audio-engine-spec.md` Phase 1 commitment to the merged state (`dev` @ `daac891` + amendment branch `1ab9f55`):
+
+| # | Criterion (as amended) | Status | Evidence |
+|---|---|---|---|
+| 1 | Cold boot → Surge a JACK client | **Landed, soaked PASS** | `config/mpe-jackd.service` + `jackd-prestart.sh` + `surge-xt-cli.service:3-4`; Gate B log |
+| 2a/2c/2d | ALSA fallback states | **Retired by amendment; removal verified** | symbols gone (grep), `NoAlsaPathTests` guard reintroduction |
+| 2\* | jackd fails → silent + `state=failed`, promote on unmask | **Landed in code, NOT soak-verified** | `start-surge-cli.sh:147-154`, watchdog promote arm `surge-watchdog.sh:88-90`; Gate C soak pending |
+| 2b / 2b2 | jackd death recovery / repeated-death budget | **Landed; soaked PASS at 15 s settle; 5 s settle UNVERIFIED** | `surge-watchdog.sh:62-91`, `audio_engine.py:52-76`; Gate C item 2 |
+| 3 | ALSA regression path | **Retired** | — |
+| 4 | Engine survives reboot, readable | **Landed (trivially — static constant)** | `MPE_ENGINE_NAME="jack"`, `scripts/lib/audio-engine.sh:18` |
+| 5a | Profile switch restarts jackd | **Landed, soaked PASS** | `set-audio-profile.sh:57` → `restart_audio_graph` |
+| 5b | UAC2 host capture re-points graph | **BLOCKED (rewire) + likely-broken dependency found** | Hall of Shame #1 — mic bridge vs jackd duplex open |
+| 6 | Surge audio thread SCHED_FIFO via jackd, no `chrt` | **Landed, soaked PASS** | no `chrt` anywhere in `start-surge-cli.sh` |
+| 10 | Looper guard at one chokepoint | **Partially landed by design** | policy in `engine-guard.sh` + `audio_engine.py` (unit-tested); the authoritative `mpe-looper.py main()` guard lives on unmerged `yolo/looper-phase0` — deferred per spec |
+| 12 | Stale `MPE_AUDIO_ENGINE=alsa` is inert | **Landed in code; boot path unverified** | variable read nowhere (grep-verified); Gate C item 4 |
+| 13 | HUD surfaces engine state + `looper=guarded` | **Landed; partial soak PASS** | `audio_engine.py:99-139` + `touch_browser_draw.py:392-405`; full guarded badge needs an `MPE_LOOPER_ENABLED=1` boot (still pending) |
+| 14 | Direct-ALSA consumers coexist with jackd | **Half: calibration PASS, session capture BLOCKED** | Gate B log; same duplex-open concern as #1 applies to `session_capture.py` |
+| 15 | DAC replug restarts jackd from any prior state | **Landed; soaked PASS from `ok`; from `failed` UNVERIFIED** | `99-usb-audio.rules:26-27` → `restart-audio-graph.sh` (does `reset-failed` first — correct); Gate C item 3 |
+| 16 | `MPE_JACK_BUFFER`/`PERIODS` independent of Surge key | **DRIFTED** | bash side correct; but `set-surge-audio.sh:125-128` writes both keys, UI reads the Surge key, `configure-pi-paths.sh` seeds it; no tests (Hall of Shame #2) |
+| 17 | `mpe engine status` documented interface | **Landed (mpe-cli side, out of scope here), soaked PASS** | spec + Gate B log |
+
+**Surprises:**
+
+- *Specced-but-missing:* nothing in the phase-one code scope is missing outright — the gaps are all **verification** gaps (Gate C soak: 2\*, 2b/2b2 at 5 s, 15-from-`failed`, 12) plus the criterion 16 UI drift and the untested JACK buffer validators.
+- *Landed-but-unspecced:* `mpe_restart_audio_graph` resets the supervisor budget on every graph restart (`scripts/lib/audio-engine.sh:311-314`) — sensible, but it's a behavioral rule (operator action clears escalation) that exists only in a code comment; and the `NoAlsaPathTests` static guards go beyond anything the spec asked for (good surprise).
+- *Cross-spec:* `looper-jack-client-spec.md` (untracked) still plans around `MPE_AUDIO_ENGINE=alsa` as an operator escape hatch that the amendment abolished yesterday (Hall of Shame #4).
+
+---
+
+## Verdict
+
+The merged phase-one state **is** coherent with the spec's phase structure — impressively so, because the spec was amended in lockstep with the code and the ALSA removal is genuinely total (grep-verified, guard-tested, 440/440 green). Whatever felt "twisted up" in the merge did not leave damage in the tree: no conflict artifacts, no dead fallback arms, no duplicate engine paths. The real risks to the "sound module + analog-esque mixer" goal are forward-looking, not residual: the hard-failure redesign has never been soaked (and must not merge without Gate C); jackd's default duplex open very likely breaks the `usb-host-session` mic bridge and session capture — a shipped profile regression hiding behind a BLOCKED soak row; the touch UI still presents the retired Surge buffer key as truth; and the entire mixer half of the product vision is gated on rebasing a 76-commit branch that predates the architecture it must join, culminating in a Python-callback kill criterion that may yet answer "Phase 1 + HAT." The codebase isn't at risk from what the merge did. It's at risk from what hasn't been verified since.
+
+## Priority backlog (🔴 items)
+
+1. **Verify and fix the jackd duplex-open conflict with the `usb-host-session` mic bridge and session capture** — add playback-only (`-P`) or an explicit `-P/-C` split to `scripts/start-jackd.sh:43-44` if capture must stay free, then run the physically-blocked 5b/14 soak rows. This is a probable shipped-profile regression (mic return to host dies with `EBUSY`) introduced by Phase 1 and never exercised.
+2. **Do not merge `yolo/jack-drop-alsa-fallback` without the Gate C soak** — the branch converts every jackd failure into a silent instrument by design; 2\* (mask-at-boot → `state=failed` → unmask promotes), 2b/2b2 at the new 5 s settle, DAC replug from `state=failed` (15), and stale-`MPE_AUDIO_ENGINE` inertness (12) are all unverified on hardware. The spec already mandates this; treat any pressure to skip it as the actual incident.
+
+---
+
+*Finding tally: 🔴 2 · 🟡 5 · 🟢 6+ (minor nits grouped). Test suite: 440 pass / 0 fail (`mpe test local all`, 2026-08-13).*

--- a/Documents/reviews/grumpy-review-opus-2026-08-13.md
+++ b/Documents/reviews/grumpy-review-opus-2026-08-13.md
@@ -1,0 +1,458 @@
+# Grumpy Dev review — MPE-Module (full codebase, JACK Phase 1 post-merge)
+
+*Review date: 2026-08-13 (America/Toronto)*
+
+**Repo:** `/home/mitch/Documents/GitHub/MPE-Module`
+**Branch reviewed:** `yolo/jack-drop-alsa-fallback` @ `1ab9f55` (= `dev` @ `daac891` + 1 commit)
+**Scope:** this repo only. The separate `mpe-cli` repo and all CLI tooling are **out of scope** by instruction.
+**Reviewer stance:** grumpy, fair, evidence-only. No code was modified.
+
+## What I read, and what I didn't
+
+**Read in full:** `Documents/specs/jack-audio-engine-spec.md` (559 lines), `Documents/specs/looper-jack-client-spec.md` (869 lines), `patch_browser/audio_engine.py`, `patch_browser/engine_state_monitor.py`, `patch_browser/looper_clock_monitor.py`, `patch_browser/calibration_teardown.py`, `patch_browser/mixer.py`, `scripts/lib/audio-engine.sh`, `scripts/lib/engine-guard.sh`, `scripts/start-surge-cli.sh`, `scripts/start-jackd.sh`, `scripts/jackd-prestart.sh`, `scripts/detect-jack-device.sh`, `scripts/surge-watchdog.sh`, `scripts/restart-audio-graph.sh`, `config/mpe-jackd.service`, `config/surge-xt-cli.service`, `config/surge-watchdog.service`, `config/99-usb-audio.rules`, `tests/test_audio_engine.py`, `.github/workflows/test.yml`, `CHANGELOG.md` (top 80 lines).
+
+**Skimmed / sampled:** `README.md`, `AGENTS.md`, `docs/GIT-WORKFLOW.md`, `docs/PATHS.md`, `docs/refactor-touch-browser-plan.md`, `patch_browser/touch_browser_draw.py` (lines 380–520 of 1419), `patch_browser/touch_browser_app.py` (constructor), `patch_browser/wifi_manager.py`, `config/mpe.env.example`, `requirements.txt`, git history (last 40 commits, `dev..HEAD`, `main..dev`), full file inventory of `patch_browser/`, `scripts/`, `config/`, `tests/`.
+
+**Did NOT read:** the other three touch-browser specs beyond their titles and grep hits; `patch_browser_ui.py` beyond its import/class structure (1456 lines, OLED front-end); the bulk of `touch_browser_draw.py`, `touch_browser_input.py`, `touch_browser_settings.py`; ~50 of the 60 test modules individually (I ran them all instead); most of `scripts/` (deploy, setup, UAC2, MIDI-clock, pedal, DSI); the APC control-surface layer (spec declares it out of scope and in good shape); `patch_browser/calibration_*.py` beyond teardown and loopback grep hits.
+
+**Cannot verify from a laptop:** anything requiring the Pi — jackd behaviour, udev event delivery, RT scheduling, xruns. Where I reason about those, I say so and name the mechanism.
+
+---
+
+## 1. First Impressions (The Gut Check)
+
+The specs in this repo are better than the specs in most funded companies I have reviewed. `jack-audio-engine-spec.md` contains a falsification table that names the conditions under which the whole plan is wrong, a cooldown design that anticipates the supervisor being worse than the fault it responds to, and — the part I genuinely did not expect — an amendment that retires half its own acceptance criteria with inline `RETIRED 2026-08-13` markers rather than rewriting history, explicitly so a soak log stays honest. Someone here understands that a spec whose criteria get quietly reinterpreted is a spec that has stopped meaning anything.
+
+So my gut check is not "is this a mess." It isn't. My gut check is: **the engineering discipline is concentrated in the documents, and the verification has not caught up to the code.**
+
+The specific shape of the problem: Phase 1 merged to `dev` (PR #49) after a real Pi soak. Then, one commit later, the team reversed Phase 1's second-highest goal — "the instrument never boots silent" became "the instrument is silent and says so." That reversal deleted the entire fallback arm that the soak log had spent a day proving. What is on `HEAD` right now is a *design-level reversal of a soaked design, verified by unit tests and prose*. The spec says so itself, in bold, twice: **REQUIRES PI SOAK BEFORE MERGE**. It is right, and the fact that it says so is the strongest signal in the repo that this team is not fooling itself.
+
+Was the merge "twisted up"? Less than you fear. I went looking for orphans and duplicated engines and found remarkably little: one misnamed file, no surviving ALSA branch, no dual state machine, the D2 call-site inventory actually honoured in code. The debris from that merge is not the risk here.
+
+The risks are three, and none of them is the merge:
+
+1. The most detailed design document in the repo — 869 lines of Phase 2 architecture — **is not committed to git.**
+2. The failure path that the appliance now depends on has never run on hardware.
+3. Half of the stated product goal ("analog-esque mixer") has no spec, no code, and no plan.
+
+And one honest-to-goodness bug in `99-usb-audio.rules` that has been sitting there since before this work started.
+
+---
+
+## 2. Architecture & Structure
+
+**The audio engine is well shaped.** The Phase 1 + amendment design is a single graph server (`config/mpe-jackd.service`), a client (`config/surge-xt-cli.service`), and a reconciler (`scripts/surge-watchdog.sh`), with all shared state in tmpfs (`scripts/lib/audio-engine.sh:88-141`) rather than in shell variables. The reason given for tmpfs is the correct one and is written down: `surge-watchdog.service` is `BindsTo=surge-xt-cli.service`, so the supervisor is restarted by the very event its rate-limiter exists to count (`scripts/lib/audio-engine.sh:9-12`). That is a class of bug most teams ship twice before noticing.
+
+**`BindsTo` is rejected for the right reason, and the reason was updated when the design changed.** The original rationale ("it makes `degraded` unreachable") went moot with the amendment; the spec replaced it with a reason that survives — `BindsTo` would stop Surge from starting, and Surge *must* start in order to detect the absent server and publish `state=failed` (`Documents/specs/jack-audio-engine-spec.md:298-310`). The units match: `Wants=` + `After=`, no `Requires`.
+
+**The bash↔Python duplication is deliberate and pinned.** `mpe_engine_reconcile_decision()` (`scripts/lib/audio-engine.sh:369-392`) and `reconcile_cooldown_decide()` (`patch_browser/audio_engine.py:52-76`) implement the same table twice, in two languages, because one runs in the supervisor and one runs in the touch UI. Normally I'd call that a maintenance trap. Here it is covered by `BashReconcileParityTests` (`tests/test_audio_engine.py:172-186`), which runs the same five cases through both. That is the correct answer to unavoidable duplication.
+
+**The D2 inventory is real, not aspirational.** The spec claims six call sites that must restart jackd rather than Surge, and says the rule needed an inventory because three were missed in the first draft. I checked all of them. `set-audio-profile.sh:57`, `set-surge-audio.sh:129`, `uac2-stall-watchdog.sh:67`, and `config/99-usb-audio.rules:26-27` (via `restart-audio-graph.sh`) all restart the graph. Nothing in `scripts/` or `patch_browser/` restarts `surge-xt-cli` on a device-changing path. This is the single most common place a design document diverges from a codebase, and it hasn't.
+
+**Where the architecture is weak: the touch UI.** `TouchPatchBrowser` composes **19 mixins** (`patch_browser/touch_browser_app.py:67-87`) and its `__init__` performs **133 `self.*` assignments**. `docs/refactor-touch-browser-plan.md` describes this as a deliberate choice — *"Mixin composition keeps method bodies identical to pre-refactor behavior; no protocol/lazy-import indirection."* That was a defensible call for a mechanical split of a 2656-line file. But the refactor moved the lines and did not reduce the coupling: every mixin can still read and write every attribute, and the file layout now *hides* that fact instead of making it obvious. Section 4 has the receipt.
+
+**Two front-ends, one model layer — correctly done.** `patch_browser_ui.py` (OLED + rotary encoder, 1456 lines, repo root) and `touch_patch_browser.py` → `patch_browser/` (5" touch panel) are two separate hardware UIs. I went in expecting duplicated `PatchScanner`/`PatchLoader` implementations, because `docs/TOUCH_PATCH_BROWSER.md:47` says the touch UI "borrowed patterns" from the OLED one. It didn't borrow — it imports: `patch_browser_ui.py:30-40` pulls `PatchLoader`, `PatchScanner`, and `SurgeMonitor` from the shared package. Credit where due; that is the outcome you want and rarely get.
+
+---
+
+## 3. Code Quality
+
+**Shell quality is high, which is not a sentence I write often.** Every state write goes through `mpe_state_write_atomic()` (`scripts/lib/audio-engine.sh:102-122`) — temp file, chmod, `mv -f`, with a warning and non-zero return on failure rather than a silent partial write. Every environment variable read is validated through a `case` allowlist with a documented default and a `WARNING:` on garbage (`mpe_jack_period`, `mpe_jack_periods`, `mpe_jack_rate`, `mpe_engine_cooldown_seconds` — `audio-engine.sh:36-79, 344-363`). Readiness is a bounded poll loop, never `sleep N` (`mpe_wait_for_jack_server`, `:219-237`), and the spec explicitly demands that (`D3` boot ordering).
+
+**The comments explain decisions, not mechanics.** `config/mpe-jackd.service:6-13` does not say "disable the start limit"; it says *why* — jackd exits immediately when its card is absent, so the default burst would put the unit in permanent start-limit failure within ~15s of an unplugged DAC and then refuse to start when the DAC came back. That is a comment written by someone who got bitten and wanted the next reader not to be.
+
+**Two comments are load-bearing bug postmortems, and I want them preserved verbatim.** `scripts/lib/audio-engine.sh:161-165`: *"a status publisher must never kill its caller"* — `${2:?}` in `mpe_engine_state_write` was exiting `surge-watchdog.sh` mid-restart, leaving Surge crashed and unsupervised. And `scripts/start-surge-cli.sh:41-42`: Surge may exit non-zero while still printing a usable device list, so a noisy exit must not be read as "no JACK device." Both are covered by tests.
+
+**Python quality is uneven by layer.** `patch_browser/audio_engine.py` is 140 lines of pure functions with no I/O in the decision path, `Literal` return types, and a docstring per function. `patch_browser/engine_state_monitor.py` and `looper_clock_monitor.py` are correct little threaded pollers with proper `Event`-based shutdown and lock-guarded snapshots. Then `patch_browser/touch_browser_draw.py` (1419 lines) and `touch_browser_app.py`'s constructor are the opposite end. The good code and the bad code are in the same package, which suggests the difference is *when* it was written, not who wrote it.
+
+**Type hints are present and meaningful where they matter** (`ReconcileAction = Literal[...]`, `patch_browser/audio_engine.py:13`) and absent in the UI layer. There is no mypy in CI; `docs/refactor-touch-browser-plan.md` lists "typed host protocol for mixin `self` if mypy is added later" under *Deferred*, which is at least honest bookkeeping.
+
+---
+
+## 4. Code Smells (The Hall of Shame)
+
+### 🔴 4.1 — The Phase 2 spec is not in git
+
+```
+$ git status --short Documents/
+?? Documents/specs/looper-jack-client-spec.md
+```
+
+869 lines. It contains the `audioop` bit-exactness analysis measured from `_audioop.c` (the `floor()`-not-`rint()` trap, the clip-at-every-pairwise-add fold), the decision that acceptance criterion 9 **cannot pass as written** because `JACK-Client`'s `get_array()` allocates per callback, the replacement 9a–9e criteria, the kill-criterion table with the reasoning for 20% and 50% of period, and a 13-task breakdown with human gates. It is the highest-value artifact produced in this effort and it exists only in one working tree, unversioned, one `git clean -fd` from oblivion. No other session, agent, or reviewer can see it. CI cannot see it. The `dev` branch has never heard of it.
+
+**Fix:** `git add Documents/specs/looper-jack-client-spec.md` and commit it, today, before anything else in this document gets acted on.
+
+### 🔴 4.2 — The appliance's silent-failure behaviour has never run on hardware
+
+`Documents/specs/jack-audio-engine-spec.md:102-108` states it plainly:
+
+> **Pi soak required before merge.** §Gate B soak log below verified the *retired* fallback design (2a, 2d, 3, and the `degraded` half of 2c). None of it verifies the hard-failure behaviour this amendment introduces […] This branch is marked **REQUIRES PI SOAK BEFORE MERGE** for exactly this reason.
+
+The Gate B log has four PASS rows (`2a`, `2d`, `3`, half of `2c`) that tested code paths which no longer exist in the tree. What replaced them — criterion `2*`, "jackd fails at boot → appliance is silent and says so" — is covered by `StartSurgeCliFailureTests` (see 4.5 for why that coverage is thinner than it looks) and by nothing else. Five named Gate C scenarios are listed at `:452-459`; zero have run.
+
+This is not a code defect. It is the review's central risk finding: **the instrument's behaviour on its most important failure is currently a hypothesis.**
+
+**Fix:** run Gate C's five scenarios before this branch merges to `dev`. The spec already lists them in order; no new thinking required.
+
+### 🔴 4.3 — `99-usb-audio.rules` skip guards silently do not apply to `remove` events
+
+```udev
+# Skip snd-aloop (calibration loads/unloads this; must not restart production Surge mid-run)
+ACTION=="add|remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", ATTR{id}=="Loopback", GOTO="mpe_usb_audio_end"
+...
+ACTION=="remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", RUN+="@MPE_MODULE_REPO@/scripts/restart-audio-graph.sh"
+```
+— `config/99-usb-audio.rules:19, 27`
+
+`ATTR{id}` reads sysfs. On a `remove` event the sysfs node is already unlinked, so `ATTR{}` matches cannot succeed — this is standard udev behaviour, not a quirk of this rule. All four skip guards (`vc4hdmi*`, `UAC2Gadget`, `UAC2`, `Loopback`) therefore filter `add` correctly and filter `remove` **not at all**. Every `remove` falls through to the generic rule and restarts jackd.
+
+The concrete path: `unload_snd_aloop_if_idle()` runs `modprobe -r snd_aloop` (`patch_browser/calibration_teardown.py:35`) at the end of every calibration run. That fires a sound-card `remove`, which restarts the graph. The comment on line 19 states the exact invariant being violated. Gate B recorded criterion 14 (calibration with jackd up) as PASS, but the restart happens during *teardown*, after the calibration result is already written — precisely where nobody was looking. The same blind spot fires on UAC2 gadget unbind during profile switches.
+
+Cost per occurrence is a jackd restart plus supervisor reconcile — the same path Gate B measured at ~30–39s of silence.
+
+**Fix:** filter on kernel-supplied `ENV{}` properties (available on `remove`) instead of `ATTR{}`, or move the card-identity check into `restart-audio-graph.sh`, which can consult `/proc/asound/cards` and decline. The second option keeps one filter instead of four and is testable from a laptop.
+
+### 🔴 4.4 — A jackd outage makes the watchdog throw away Surge's user defaults
+
+```bash
+if systemctl is-failed "$SURGE_SERVICE" &>/dev/null; then
+    log "ALERT: Surge service failed, cleaning user defaults"
+
+    if [ -f "$USER_DEFAULTS" ]; then
+        BACKUP="${USER_DEFAULTS}.corrupted_$(date +%Y%m%d_%H%M%S)"
+        mv "$USER_DEFAULTS" "$BACKUP"
+        log "Backed up corrupted file to: $BACKUP"
+    fi
+```
+— `scripts/surge-watchdog.sh:97-105`
+
+This arm assumes `surge-xt-cli` reaching `failed` means a corrupt defaults file. That assumption held before the amendment, when an ALSA fallback meant Surge almost always started. It does not hold now. Post-amendment, `start-surge-cli.sh` **exits 1 by design** when there is no graph server (`:147-154`), the unit is `Restart=on-failure` with `RestartSec=10` and `StartLimitBurst=5` / `StartLimitIntervalSec=300` (`config/surge-xt-cli.service:6-7, 27-28`) — so roughly 100s into any jackd outage, `is-failed` becomes true and this arm fires, attributing a missing DAC to file corruption and moving the user's accumulated Surge defaults aside. `start-surge-cli.sh:60-66` then writes a fresh empty skeleton in its place.
+
+Two consequences: the diagnostics actively mislead (a log line saying "corrupted" during what is actually a cable problem), and `.corrupted_<timestamp>` files accumulate in the defaults directory with no cleanup anywhere in the repo — `grep -rn corrupted` returns exactly these two lines and nothing that ever removes them.
+
+This is the clearest instance of the amendment changing a precondition that a distant piece of code was silently relying on.
+
+**Fix:** gate the corrupt-defaults arm on the engine state — skip it when `mpe_engine_state_get state` is `failed` with `reason=no-server` / `no-jack-device`, since that is a known-good explanation for the failure that has nothing to do with the file.
+
+### 🟡 4.5 — A test that re-implements the script it claims to test
+
+```python
+def _run_start_surge_cli(self, *, env: dict[str, str], stubs: str) -> ...:
+    # start-surge-cli.sh is a script, not a sourceable library, and needs a
+    # real SURGE_CLI binary + USER_DEFAULTS setup to run end-to-end. This
+    # exercises the exact state-publishing sequence its failure branch
+    # runs (spec D3 hard failure), matching the real script line-for-line;
+    # NoAlsaPathTests statically confirms the real script has no other branch.
+    body = f"""
+...
+mpe_engine_state_write "$MPE_ENGINE_NAME" none failed "$ENGINE_REASON" "$(mpe_looper_state_label)"
+mpe_surge_state_write none ""
+exit 1
+"""
+```
+— `tests/test_audio_engine.py:486-504`
+
+`test_jack_failure_exits_nonzero_and_publishes_failed` asserts that *this test's copy* of the failure branch works. Change the argument order in `start-surge-cli.sh:151`, drop the `mpe_surge_state_write` call, or swap `none` for `unknown`, and the test still passes green. The docstring is honest about the compromise, which is why this is 🟡 and not 🔴 — but honesty in a docstring does not add coverage. Criterion `2*`'s only automated evidence is this plus the string-absence assertions in `NoAlsaPathTests` (`:423-481`), several of which are fragile in their own right: `assertNotIn('detect-audio-device.sh"', text)` (`:524`) matches only when the path happens to be followed by a double quote.
+
+**Fix:** make the script testable rather than copied — extract the engine-resolution + state-publish sequence into a sourceable function in `scripts/lib/audio-engine.sh` and have `start-surge-cli.sh` call it, then test the real function.
+
+### 🟡 4.6 — 19 mixins, 133 constructor assignments, one namespace
+
+```python
+class TouchPatchBrowser(
+    TouchBrowserEvdevMixin,
+    TouchBrowserPrefsMixin,
+    TouchBrowserSettingsMixin,
+    TouchBrowserBrightnessModalMixin,
+    # … 15 more …
+    TouchBrowserInputMixin,
+):
+```
+— `patch_browser/touch_browser_app.py:67-87`
+
+`sed -n '60,300p' … | grep -c '^        self\.'` → **133**. Nineteen classes share one flat attribute namespace with no declared interface between them. The refactor plan is candid that this was chosen to keep method bodies byte-identical during the split, which was the right risk trade for the split itself. It is not a resting place: nothing here is checkable, and the next symptom is directly below.
+
+**Fix:** give the mixins a `Protocol` for the attributes they read off `self` (already listed as Deferred in the plan) and start moving cohesive state into small owned objects — `engine_monitor`, `looper_monitor`, `cpu_monitor` already show the pattern working.
+
+### 🟡 4.7 — Defensive `getattr` chains standing in for an interface
+
+```python
+title_x = getattr(self, "status_title_x", self.status_rect.x + 12)
+widget_left = getattr(self, "engine_hud_rect", getattr(self, "looper_hud_rect", self.audio_profile_badge_rect)).x
+if widget_left <= title_x or getattr(self, "engine_hud_rect", Rect(0, 0, 0, 0)).w <= 0:
+    widget_left = getattr(self, "looper_hud_rect", self.audio_profile_badge_rect).x
+if widget_left <= title_x:
+    widget_left = self.audio_profile_badge_rect.x
+```
+— `patch_browser/touch_browser_draw.py:484-489`
+
+Six `getattr` defaults and three cascading fallbacks in six lines, because the draw mixin cannot know whether the layout mixin has run. This is 4.6's bill arriving. It is also unreadable: nobody can tell from this code which of the three widgets is *supposed* to be there. Same pattern again at `:503-505`.
+
+**Fix:** initialise all HUD rects to `Rect(0, 0, 0, 0)` in `__init__` (some already are, at `:154-157`) and delete every `getattr` default here; a zero-width rect is already the "not present" signal that `_draw_engine_hud` checks at `:393`.
+
+### 🟡 4.8 — Three header badges, three polling threads, an SD card underneath
+
+`EngineStateMonitor` polls `/run/mpe/engine.state` every **0.5s** (`patch_browser/engine_state_monitor.py:10`) — tmpfs, fine. `LooperClockMonitor` polls `~/.mpe_midi_clock_state.json` every **0.2s** (`patch_browser/looper_clock_monitor.py:10`) — five reads per second, forever, of a file in `$HOME` on the SD card, to drive one BPM badge. `SurgeCpuMonitor` adds a third thread. `grep -rn 'threading.Thread' patch_browser/` returns 20 hits across the package.
+
+On a Pi 4B whose whole purpose is now holding a 256-frame JACK deadline, an unaudited 5 Hz filesystem poller is the kind of thing that shows up later as an unexplained xrun and takes a day to find.
+
+**Fix:** move the MIDI clock state file to `/run/mpe/` alongside `engine.state` (it is ephemeral runtime state, not user data), and drop the poll to 0.5s to match its sibling.
+
+### 🟡 4.9 — CI is materially weaker than the local gate
+
+```yaml
+      - name: Install test dependencies
+        run: pip install python-osc
+      - name: Run unit tests
+        run: python3 -m unittest discover -s tests
+...
+      - name: Run shell tests
+        run: |
+          bash tests/test_gadget_persist.sh
+          bash tests/test_prepare_dsi_display.sh
+```
+— `.github/workflows/test.yml:18-31`
+
+Three problems. Dependencies are one hand-picked package rather than `requirements.txt`. The two shell tests are hardcoded, so `mpe test coverage`'s reassuring *"CI runs every shell test"* holds only by the accident that there are currently two. And there is **no shellcheck anywhere** — not in CI, not in `.cursor/`, nowhere — despite the entire audio engine being bash and the scripts themselves carrying `# shellcheck disable=` directives that imply somebody once ran it locally.
+
+The evidence that this gap is live: the ALSA-removal commit shipped `set-surge-audio.sh` still calling the just-deleted `mpe_audio_engine()`. It was caught by a hand-written grep assertion added in the same commit (`tests/test_audio_engine.py:464-471`, whose docstring says *"a real bug caught by this sweep, not a hypothetical"*). Catching it was good. Needing a bespoke test per deleted function is not a strategy.
+
+**Fix:** add a shellcheck job over `scripts/` and `config/*.service`, glob the shell tests (`for f in tests/test_*.sh`), and install from `requirements.txt`.
+
+### 🟡 4.10 — Calibration teardown restarts Surge without restarting jackd
+
+```python
+subprocess.run(["sudo", "pkill", "-f", "surge-xt-cli"], check=False)
+time.sleep(0.5)
+unload_snd_aloop_if_idle()
+subprocess.run(["sudo", "systemctl", "start", "mpe-pressure-remap.service"], check=False)
+subprocess.run(["sudo", "systemctl", "start", "surge-poly-governor.service"], check=False)
+subprocess.run(["sudo", "systemctl", "start", "surge-xt-cli.service"], check=False)
+```
+— `patch_browser/calibration_teardown.py:67-72`
+
+`mpe-jackd.service` is never started or verified here. Standing alone that is defensible — calibration doesn't stop jackd. Composed with 4.3 it is not: line 69 triggers the udev `remove` that restarts jackd, and line 72 then races Surge's 10s readiness wait (`mpe_jack_ready_timeout`, default 10) against jackd's measured ~6s startup. Two fixed `sleep`s (0.5s, and 1s in `stop_mpe_audio_services`) are the only sequencing.
+
+**Fix:** after fixing 4.3, add an explicit `systemctl start mpe-jackd.service` plus a bounded readiness wait before starting Surge, rather than relying on timing.
+
+### 🟢 4.11 — Dead import executed on every rendered frame
+
+```python
+def _draw_audio_profile_badge(self, rect: Rect) -> None:
+    label = header_badge_label()
+    from patch_browser.usb_audio_recovery import is_recovering
+
+    recovering = label == "Sync"
+```
+— `patch_browser/touch_browser_draw.py:448-452`
+
+`is_recovering` is imported and never called; the check is done by string comparison on the next line. Module caching makes the cost near-zero, so this is cosmetic — but it is a function-local import inside a per-frame draw path, and there is a second one at `:478`. **Fix:** delete line 450; hoist `:478` to module scope.
+
+### 🟢 4.12 — `looper_clock_monitor.py` monitors the MIDI clock, not the looper
+
+```python
+"""Read looper MIDI clock state for the touch patch browser header HUD."""
+...
+class LooperClockMonitor:
+    """Background reader for ~/.mpe_midi_clock_state.json (midi-clock-in daemon)."""
+```
+— `patch_browser/looper_clock_monitor.py:1, 13-14`
+
+This is the **only** `looper_*` file that survived Phase 1's looper strip (`git ls-files | grep -i looper` → one result), which makes it read like merge debris on first inspection. It isn't — it is live, imported at `touch_browser_app.py:28`, and it reads the `midi-clock-in` daemon's state. The name costs every future reader the same five minutes it cost me, and it will cost more once real looper modules land from `yolo/looper-phase0`.
+
+**Fix:** rename to `midi_clock_monitor.py` / `MidiClockMonitor` before phase0 merges and adds genuinely-looper-named siblings.
+
+### 🟢 4.13 — CHANGELOG test count is stale
+
+`CHANGELOG.md:71` — *"Full suite: 438 tests, 0 failures."* Actual on this branch: **440**. Trivial, but this file is the chronological index of record and the number is the kind of thing someone will later use to reason about whether tests were dropped. **Fix:** update, or stop quoting exact counts.
+
+### 🟢 4.14 — Unbounded retry storm when no DAC is present
+
+`jackd-prestart.sh` waits up to 15s for a card (`:25, 41-48`), exits 1 if none resolves (`:57-61`); the unit is `Restart=always` with `RestartSec=3` and `StartLimitIntervalSec=0` (`config/mpe-jackd.service:15, 45-46`). With no DAC attached that is a permanent ~18s loop writing to the journal forever. This is the *intended* consequence of the spec's "keep retrying rather than wedge in start-limit failure" reasoning, and I agree with the trade — but nothing bounds the log growth or backs the interval off. **Fix:** back off `RestartSec` after N consecutive prestart failures, or log the repeat at a lower frequency.
+
+---
+
+## 5. Logic & Business Rules
+
+**The cooldown logic is correct and correctly ordered.** `mpe_engine_reconcile_decision()` (`scripts/lib/audio-engine.sh:369-392`) evaluates in the order: budget exhausted → `failed`; jackd still settling → `jackd-settling`; no prior restart → `restart`; else compare against cooldown. That ordering matters — checking cooldown before the settle window would let the supervisor fight a jackd that has `Restart=always` and is mid-bringup. Both implementations agree, and `BashReconcileParityTests` pins them.
+
+**The looper guard's exit-code split is subtle and right.** `looper_guard_exit_code()` (`patch_browser/audio_engine.py:41-49`) returns 0 for the systemd path and non-zero for interactive callers, because `mpe-looper.service` is `Restart=on-failure` and a non-zero guard would produce a restart storm — the opposite of the clean refusal intended. The context signal is an explicit exported `MPE_LOOPER_SERVICE=1` with systemd's `INVOCATION_ID` as backstop, rather than inferring context. The spec explains why `ConditionEnvironment=` cannot be used (it reads the manager environment, not the unit's `EnvironmentFile`). Every part of this reasoning is written down and tested (`tests/test_audio_engine.py:82-89`).
+
+**The guard's authoritative enforcement point does not exist on this branch, by design.** `scripts/lib/engine-guard.sh:12-15` says so outright: *"The looper itself lives on yolo/looper-phase0, not on dev, so its authoritative guard — main() of scripts/mpe-looper.py, which every start path crosses — must be added on that branch."* So what ships on `dev` is guard *policy* (message text, blocked predicate, exit-code split) with unit tests, and no enforcement, because there is nothing to enforce against. This is coherent — but it means criterion 10 is currently a promise held in two files that no runtime path reaches, and the D5 analysis that found the real chokepoint (correcting an earlier draft's false claim that `mpe-looper-service.sh` was the only path) is the kind of finding that decays when nothing exercises it.
+
+**Two ordering hazards worth naming.**
+
+`_reconcile_engine` (`scripts/surge-watchdog.sh:62-91`) busy-waits up to `RECONCILE_BUDGET` (default **15s**, `:13`) inside a loop whose outer cadence is `sleep 5` (`:117`). During a jackd outage the watchdog's *other* responsibility — the `is-failed` crash-recovery arm at `:97` — therefore runs every ~20s rather than every 5s. Separately: when the amendment moved `MPE_ENGINE_JACKD_SETTLE_DEFAULT` from 15s to 5s, this sibling 15s constant was left alone. It governs the "jackd never comes back" arm specifically, so it is not the same knob — but the spec's §Backlog note reasons about recovery latency without mentioning it, and anyone tuning recovery will find one 15 and not the other.
+
+`start-jackd.sh:35-41` refuses to clobber a more specific state, publishing `recovering` only when the current state is not already `ok | failed | recovering`. Correct instinct. Note the consequence: a jackd restart arriving while `state=failed` leaves `failed` published until the supervisor's next poll promotes it, so `mpe engine status` can read `failed` for up to 5s after recovery has begun. Acceptable; worth knowing before someone debugs it as a bug.
+
+**The `degraded` retirement is complete, and tested as such.** `VALID_ENGINE_STATES = frozenset({"ok", "recovering", "failed"})` (`patch_browser/audio_engine.py:21`), and `test_degraded_no_longer_a_valid_state` (`tests/test_audio_engine.py:673-681`) asserts that a state file carrying `state=degraded` — which a pre-upgrade appliance will have — renders as a bare `JACK` badge rather than an unrecognised status. Thinking about the *stale state file on the upgraded device* is the detail that separates a real migration from a rename.
+
+---
+
+## 6. Test Strategy & Execution
+
+### Actual results
+
+`python3 -m unittest discover -s tests -q` could not be run directly: a workspace hook blocks direct `python`/`python3` invocation, and the global agent rules require project CLIs instead. I used the sanctioned equivalent, which wraps unittest discovery plus every shell test:
+
+```
+$ mpe test local all
+Ran 440 tests in 42.113s
+
+OK
+--- tests/test_gadget_persist.sh ---
+OK test_gadget_persist.sh
+--- tests/test_prepare_dsi_display.sh ---
+All prepare-dsi-display shell tests passed
+```
+
+**440 tests, 0 failures, 0 errors, 42.1s. Exit code 0.** 60 Python test modules + 2 shell tests.
+
+```
+$ mpe test coverage
+test modules in checkout: 60
+registered but absent here (16, on unmerged branches — not a failure): test_apc_led test_apc_mini
+  test_apc_session_midi test_clip_matrix test_control_surfaces test_looper_alsa_stderr
+  test_looper_bar_clock test_looper_devices test_looper_engine test_looper_health test_looper_hud
+  test_looper_period_debug test_looper_session test_looper_timing_publisher
+  test_looper_timing_state test_looper_xruns
+shell tests in checkout: 2
+
+OK: every test module is reachable from a suite, and CI runs every shell test.
+```
+
+Non-fatal noise: several `ResourceWarning: unclosed file` from `tests/test_uac2_stall_watchdog.py:228`, and repeated `Warning: python-osc not installed, patch loading disabled` — the latter meaning a chunk of the patch-loading suite runs in degraded mode locally, and `.github/workflows/test.yml:19` installs `python-osc` precisely so CI doesn't. Worth knowing that laptop-green and CI-green are not the same green.
+
+### Strategy assessment
+
+**The suite-registry gate is the best thing in this test setup, and I have not seen it elsewhere.** `mpe test coverage` fails if any test module belongs to no named suite, and it distinguishes *absent because the feature lives on an unmerged branch* (16 modules, exit 3) from *absent because someone forgot*. That is a genuinely original answer to the "we have suites and nobody knows what's in them" problem, and it is what let me confirm in one command that the looper strip was clean rather than lossy.
+
+**Bash is tested, which almost never happens.** `tests/test_audio_engine.py` runs real bash through `subprocess` with function stubs injected (`_run_bash_script`, `:56-67`), exercising `mpe_engine_reconcile_decision`, `mpe_restart_audio_graph`'s `reset-failed`-then-`restart` ordering (`:280-297`), the reconcile arms via stubbed `mpe_surge_on_jack_graph` (`:541-576`), and the `/run` fallback path. `test_empty_active_engine_does_not_kill_caller` (`:336-351`) is a regression test for a specific production incident and its docstring names the incident.
+
+**Failure-path testing is present, not just happy-path.** Unwritable state directory (`:353-372`), state-publish failure not aborting the supervisor (`:578-599`), `jack_lsp` missing while `jackd` is running treated as not-ready (`:393-420`). Also unit-file *assertions* — `StartLimit*` must be in `[Unit]` because systemd ignores it under `[Service]` (`:244-254`), a bug that was actually shipped and fixed in `3cb7de7`.
+
+**Where the strategy is thin.**
+
+1. **Deletion is verified by grepping source text.** `NoAlsaPathTests` (`:423-481`) asserts absence of ~15 identifier strings across five files. Correct-ish for a one-time removal, but these tests will pass forever regardless of behaviour, will break on innocent renames, and one of them (`:524`) depends on a trailing quote character.
+2. **The one behavioural test of criterion 2\* tests a copy of the code** — see 4.5. The single most important failure path in the current design has no test that executes the real script.
+3. **No shellcheck, no bash coverage measurement, no mypy.** ~60 shell scripts carry the audio engine; `bash -n` is run on exactly one of them (`test_set_surge_audio_is_valid_bash`, `:473-480`).
+4. **Nothing tests the udev rules.** 4.3 is a logic bug in a `.rules` file that no test touches. `mpe test coverage` counts shell tests but nothing parses or simulates udev matching, and the rules file is where the invariant was violated.
+5. **Hardware-gated criteria stay gated.** `5b` (UAC2 host capture) and the `session_capture.py` half of `14` are both BLOCKED on a physical rewire, and have been since Gate B. The spec's own falsification table lists "jackd's exclusive device open doesn't break calibration/session capture" as an assumption to be resolved *before Phase 1 merge* (`:433`). Phase 1 merged. That assumption is still open.
+
+---
+
+## 7. Security & Performance
+
+### Security — genuinely clean, and I looked hard
+
+**No shell injection surface.** `grep -rn 'shell=True\|os.system\|eval ' patch_browser/ scripts/` returns **nothing**. Every subprocess call in the Python layer is an argv list.
+
+**The one interesting attack surface is handled correctly.** Wi-Fi SSIDs and passwords arrive from an on-screen touch keyboard and reach `nmcli` — the classic place an appliance eats a shell metacharacter. `patch_browser/wifi_manager.py:1` opens with *"NetworkManager Wi-Fi helpers for the touch appliance (nmcli, no shell)"*, and `_run_nmcli` (`:26-41`) builds `["sudo", "-n", "nmcli", …]` as a list with `-n` (never prompt). The password is passed as an argv element (`:294-295`), not interpolated. Correct.
+
+**Privilege is narrow and enumerable.** Five `sudo` call sites across the whole Python layer, in four files (`wifi_manager.py`, `calibration_loopback.py`, `touch_browser_app.py`, `audio_profile.py`). All use `sudo -n` or fixed argv. `mpe_systemctl` (`scripts/lib/audio-engine.sh:292-298`) checks `id -u` and falls back to `sudo -n systemctl`, with a `WARNING:` and non-zero return rather than a hang when passwordless sudo is unavailable (`mpe_restart_audio_graph`, `:307-310`).
+
+**Realtime privilege is permitted, never forced.** `LimitRTPRIO=95` / `LimitMEMLOCK=infinity` on both `mpe-jackd.service` and `surge-xt-cli.service`, with a comment explaining why the unit needs them at all (systemd bypasses PAM, so `/etc/security/limits.d/audio.conf` from the `jackd2` package does not apply). jackd runs as the appliance user, not root. Priority is a fixed constant (`MPE_JACK_RT_PRIORITY_DEFAULT=70`), and even the user-overridable path validates through a numeric `case` (`:67-72`) — a runaway FIFO thread at 70 could starve the touch UI and SSH, so keeping this non-arbitrary matters.
+
+**No network surface.** Every OSC binding is `127.0.0.1` — `surge_monitor.py:82`, `surge_cpu_monitor.py:60, 149`, `patch_loader.py:46`, `surge_playback.py:182`, `calibrate-patch-normalization.py:105`. Nothing binds `0.0.0.0`. Matches the spec's stated model.
+
+**🟢 The one nit:** the Wi-Fi password is an argv element to `sudo nmcli`, so it is briefly visible in `/proc/<pid>/cmdline` and to `ps` for any local user. On a single-user appliance whose threat model is explicitly physical access this is proportionate — noting it only so the choice is deliberate rather than accidental. `nmcli` can read secrets from stdin if that ever changes.
+
+### Performance
+
+**The measurements are real and the conclusions follow from them.** The spec's §Evidence table records 512×3 at 32ms / 0 xruns, 256×3 at 16ms / 0 xruns idle with mild crackle under load, 128×3 at 8ms with 0 xruns but audible crackle — and correctly concludes the artifact is *downstream of JACK*, because the graph stayed up. From there it identifies the DAC (USB Full Speed, 12 Mbit/s, shared with two MIDI devices, `S16_LE`/`S24_3LE` only) as a **hardware** ceiling and declines to chase sub-256 in software. That is the right call, made from data, and it is why the falsification analysis can honestly say a HAT plus Phase 1 is an acceptable end state.
+
+**D6's buffer split is implemented, not just specified.** `MPE_JACK_BUFFER` / `MPE_JACK_PERIODS` drive the server (`mpe_jack_period`, `mpe_jack_periods`, `audio-engine.sh:36-56`) and `--buffer-size=` is gone from Surge's argv — asserted at `tests/test_audio_engine.py:435`. Sample rate deliberately stays a single appliance-wide key so the UAC2 gadget and the graph cannot disagree, with the reason in the comment (`:58-59`).
+
+**`jackd -s` (softmode) is kept deliberately** so a single xrun does not tear down the graph — right for a live instrument, and flagged in §Technical Notes. The Phase 2 spec then notices the consequence nobody would have caught later: softmode may *hide* looper-caused xruns from `set_xrun_callback`, which would make criterion 9e's "0 xruns" clause unverifiable as written. It is logged as OQ-4 with a concrete falsification test. That is the level of care I want to see and rarely do.
+
+**Where I'd push back.** The recovery latency is the honest weak spot and the spec says so: criterion 2b budgeted a 15s audible gap; Gate B measured **~39s** for `pkill jackd` and **~55–60s** for the double-failure case, with Mitch describing DAC replug recovery as *"very slow."* The §Backlog names three candidate fixes and defers them. The amendment's 15s→5s settle reduction will help, but the remaining terms — jackd's own ~6s start, the `RECONCILE_BUDGET` wait, and a full `systemctl restart surge-xt-cli` — are untouched, and the in-process JACK reconnect (the candidate that would actually collapse this) is still on the backlog. Calling the settle reduction an improvement is fair; treating it as *the* fix would not be, and the spec is careful not to.
+
+Then 4.8: a 5 Hz SD-card poll thread on the box that has to hold a 256-frame deadline.
+
+---
+
+## 8. Developer Experience
+
+**Onboarding is unusually good.** `AGENTS.md` gives a `mpe`-CLI-first policy with an explicit agent-safe/read-only vs. writes split and a standing instruction to *propose a new subcommand rather than improvise remote shell* — which is why this review used `mpe test local all` instead of fighting a hook. `docs/` carries 30 files including `BUILD-FROM-ZERO.md`, `PATHS.md`, `PI-BOOT-RECOVERY.md`, and `GIT-WORKFLOW.md`. `docs/GIT-WORKFLOW.md` states the branch policy in one table plus one rule worth quoting: *"Do not push to `dev` and `main` in the same testing pass."*
+
+**The docs told the truth every time I checked them.** `docs/PATHS.md:43` records `MPE_AUDIO_ENGINE` as retired; `config/mpe.env.example:56` says the same; `README.md` describes the JACK graph architecture. The D2 inventory matched the code. `mpe test coverage`'s claim matched reality. I went in expecting the usual doc rot and found approximately none.
+
+**Two places where the honesty is exemplary and I want it named.** First, `Documents/specs/jack-audio-engine-spec.md:118-127` — a *citation note* admitting that `docs/AUDIO-ENGINE-FOUNDATION.md`, cited throughout both specs, **does not exist on this branch or on `dev`**; it lives only on the unmerged `yolo/looper-phase0`, was read via `git show`, and is deliberately not duplicated because that would fork a document PR #48 owns. Second, `looper-jack-client-spec.md:312-318` — *"The fixture set does not exist,"* with the `git ls-tree` command that proves criterion 8's "existing fixture set" refers to something not in the repository. Most specs would have papered over both.
+
+**Where DX degrades.**
+
+- **The uncommitted Phase 2 spec (4.1) is a DX failure before it is anything else.** Every collaborator, agent session, and CI run is working from a strictly poorer picture of the plan than the one person with this working tree.
+- **`docs/AUDIO-ENGINE-FOUNDATION.md` being cross-branch-only** is documented honestly but is still a real cost: two specs' core reasoning (Part 8's option D, Part 3's NumPy sketch, the Appendix's 0.090ms mixer measurement) is unreadable without `git show` against an unmerged branch. Anyone reviewing on `dev` hits dead references.
+- **Repo-root clutter.** `ENCODER_BUTTON_REVIEW.md`, `REFERENCE_BOM.md`, `FAQ.md`, `COMMANDS.md`, `boot_animation.py`, `shutdown_animation.py`, `touch_boot_splash.py`, `touch_shutdown_splash.py`, `touch_patch_browser.py`, `patch_browser_ui.py`, `setup-i2c-early.sh` all sit at top level alongside `patch_browser/`, `scripts/`, `docs/`, `Documents/`. And there are two documentation trees — `docs/` (30 files) and `Documents/specs/` (5) — with no stated rule for which gets what. `Documents/reviews/` (this file) is now a third.
+- **`config/` mixes templates with data.** `patch_normalization.json` plus two dated `patch_normalization.pi-backup-*.json` files are committed next to systemd unit templates. `.gitignore`'s closing comment — *"Everything else (binaries, patches, configs) GOES IN GIT for backup!"* — explains the choice, but using the source repo as a device backup target is why `config/` is hard to read.
+- **`logs/`, `data/`, `.pytest_cache/` are committed directories** in a repo that is also an appliance deploy target.
+
+---
+
+## Spec Conformance: Phase One vs Plan
+
+Phase 1 criteria from `Documents/specs/jack-audio-engine-spec.md` §Acceptance Criteria, as amended 2026-08-13. **Landed** = implemented in code on `HEAD`. Hardware verification is tracked separately because the amendment invalidated much of the Gate B evidence.
+
+| # | Criterion | Code | Hardware | Evidence |
+|---|---|---|---|---|
+| 1 | Cold boot leaves Surge a JACK client wired to the DAC | **Landed** | Gate B PASS | `config/mpe-jackd.service`, `scripts/jackd-prestart.sh`, `start-jackd.sh`, `start-surge-cli.sh:122-133` |
+| 2a | jackd fails at boot → sound anyway | **Retired, cleanly** | n/a | No fallback branch survives; `tests/test_audio_engine.py:426-436` asserts absence of `select_alsa_device`, `ENGINE-FALLBACK`, `--buffer-size=` |
+| **2\*** | jackd fails at boot → **silent and says so**; unmask → auto-promote | **Landed** | ❌ **NEVER SOAKED** | `start-surge-cli.sh:147-154` publishes `state=failed`/`active=none` and exits 1; promote arm at `surge-watchdog.sh:88-90`. Spec `:452-459` lists this as Gate C item 1, not run |
+| 2b | jackd dies mid-set → sound returns | **Landed** | Gate B PASS **at old 15s settle** | `Restart=always` (`mpe-jackd.service:44`) + promote. Retest at 5s = Gate C item 2, not run. Measured ~39s vs 15s budget — **missed** |
+| 2b2 | Repeated jackd death does not wedge Surge | **Landed** | Gate B PASS **at old settle** | Cooldown table `audio-engine.sh:369-392`; `StartLimit*` correctly in `[Unit]` |
+| 2c | Double failure → loud not silent | **Retired, subsumed into 2\*** | n/a | Consistent with code |
+| 2d | Promotion after degraded boot | **Retired, folded into 2\*** | n/a | `release-alsa-for-jackd` gone; `tests/…:456` asserts it |
+| 3 | `MPE_AUDIO_ENGINE=alsa` reproduces old behaviour | **Retired, cleanly** | n/a | Variable read **nowhere**; only comments/docs/tests mention the name |
+| 4 | `engine=jack` reads back identically after reboot | **Landed** | not re-soaked | Static `MPE_ENGINE_NAME="jack"` (`audio-engine.sh:18`) / `ENGINE_NAME` (`audio_engine.py:20`) |
+| 5a | Profile switch restarts **jackd**; supervisor reconciles | **Landed** | Gate B PASS | `set-audio-profile.sh:57` → `restart_audio_graph` |
+| 5b | UAC2 host capture open/close re-points the graph | **Landed** | ❌ **BLOCKED** (physical rewire) | `uac2-stall-watchdog.sh:67`. Falsification table `:430` says verify *"before building Phase 2"* — Phase 2 spec is written and Tasks 1–6 declared startable. **Drift.** |
+| 6 | Surge audio **thread** `SCHED_FIFO`, no `chrt` on the process | **Landed** | Gate B PASS (spot check) | No `chrt` anywhere in `start-surge-cli.sh`; D4 note at `:134-137` |
+| 10 | Looper guard refuses via one shared message; no restart loop | **Partial by design** | ❌ deferred twice | Policy + tests in `engine-guard.sh` and `audio_engine.py:36-49`. **Authoritative chokepoint (`mpe-looper.py main()`) does not exist on `dev`** — `engine-guard.sh:12-15` says so |
+| 12 | `engine=jack` on fresh install **and** with stale `MPE_AUDIO_ENGINE=alsa` | **Landed** | ❌ not soaked | Nothing reads the variable, so a stale line is inert. Gate C item 4 |
+| 13 | Looper regression **surfaced** — HUD shows `looper=guarded` | **Landed** | Gate B **PARTIAL** | `engine_state_monitor.py` → `touch_browser_draw.py:392-412`; `L⛔` at `audio_engine.py:124`. Never booted with `MPE_LOOPER_ENABLED=1` |
+| 14 | Direct-ALSA consumers work with jackd holding the device | **Landed (cal)** | PASS (cal) / ❌ **BLOCKED** (session capture) | Falsification table `:433` requires this audit *before Phase 1 merge*; merged with `session_capture.py` unaudited. See also 4.3/4.10 — teardown is **not** clean |
+| 15 | DAC unplug/replug restarts jackd **from any prior state** | **Landed** | Partial — soaked from `ok` only | `99-usb-audio.rules:26-27`; `mpe_restart_audio_graph` does `reset-failed` first (`audio-engine.sh:306`) and resets the supervisor budget (`:314`). Amendment widened to "from `failed`" — Gate C item 3 |
+| 16 | JACK buffer keys independent of `MPE_SURGE_BUFFER_SIZE` (D6) | **Landed** | not re-soaked | `mpe_jack_period`/`periods`; `--buffer-size=` absence asserted |
+| 17 | `mpe engine status` is the documented interface | out of scope | Gate B PASS | Lives in `mpe-cli` |
+
+### Surprises
+
+**Specced but missing:**
+
+1. **Gate C soak — 5 named scenarios, zero run.** The spec blocks its own merge on this. This is the finding.
+2. **Criterion 10's authoritative guard** — the chokepoint the D5 analysis worked hard to correctly identify does not exist on `dev`; only policy + unit tests do.
+3. **`docs/AUDIO-ENGINE-FOUNDATION.md`** — cited throughout both specs (Part 3, Part 8, Part 9, §Appendix), present on neither `dev` nor `HEAD`. Documented honestly at `:118-127`; still a dead reference for anyone reviewing on `dev`.
+4. **`docs/measurements/`** — named as criterion 9's destination by the governing spec; does not exist (Phase 2 Task 6).
+5. **The Phase 2 spec itself** is untracked (4.1).
+6. **5b and session-capture (14)** — two falsification-table assumptions that were to be closed *before* Phase 1 merge / *before* Phase 2 work, both still open while Phase 2 is being planned.
+
+**Landed but unspecced:**
+
+1. **`mpe test coverage`** — the suite-registry gate is not in any spec and is one of the best things here.
+2. **`mpe_restart_audio_graph`'s `reset-failed` + supervisor-budget reset** (`audio-engine.sh:300-316`) — goes beyond D2, and is what makes criterion 15's recovery-from-`failed` actually work. Earned via a real bug (`0cc6763`, `9258b68`).
+3. **`start-jackd.sh:35-41`'s state-clobber guard** — a race the spec never names.
+4. **The 4.3 udev `remove` blind spot** — a pre-existing bug in a file both Phase 1 and the amendment touched, invisible to every spec and every test.
+5. **🔴 The "analog-esque mixer" half of the product goal has no spec at all.** `Documents/specs/` holds four specs: the JACK engine, the looper JACK client, and three touch-browser docs. **None covers a mixer.** What exists in code is `patch_browser/mixer.py` — a **20-line `MixerChannel` dataclass** — plus `mixer_controls.py` (340 lines) and `touch_browser_mixer.py` (128 lines), which together implement per-patch **Vol / Tail / Touch** faders on the patch detail pane (`README.md:57`). Those are *parameter* controls, not audio mixing: no buses, no summing, no per-source gain staging, nothing analog-esque. The only actual audio-mixing work anywhere in the plan is the looper's NumPy mix kernel, which is Phase 2, which is gated on a measurement whose own kill criterion includes *"Stop. Phase 1 + an I2S HAT."* Whatever "analog-esque mixer" means as a product, it currently has **zero design surface**, and the naming collision with the existing per-patch fader UI will make that gap easy to keep overlooking.
+
+---
+
+## Verdict
+
+The merged Phase-one state **is coherent with the spec's phase structure** — considerably more so than the "things got twisted up" framing suggests. I went looking for the usual post-merge wreckage and found almost none: no surviving ALSA branch, no dual-engine state machine, no duplicated audio path, the D2 six-call-site inventory honoured in code, `degraded` genuinely retired in both languages with a migration test for stale state files, and exactly one misnamed file (`looper_clock_monitor.py`) as debris. 440 tests pass in 42s, security is clean in a way most appliance codebases are not, and the specs are the best-reasoned engineering documents I have reviewed in this repo class — they falsify themselves, retire their own criteria in place rather than rewriting history, and twice admit in writing that a document they cite does not exist. That discipline is the asset here and it should be protected. What is at risk is not the architecture but the **verification ledger**: `HEAD` reverses Phase 1's second goal ("never boots silent" → "fail loud and legible"), which deleted the exact fallback arm that a full day of Gate B soaking had proven, and the five Gate C scenarios that would validate the replacement have not run — so the instrument's behaviour on its single most important failure is currently a hypothesis defended by a test that re-implements the script it tests. Two real bugs compound this: udev `ATTR{}` matches cannot fire on `remove` events, so all four skip guards in `99-usb-audio.rules` leak and every calibration teardown restarts jackd in violation of the invariant its own comment states; and the amendment made "Surge exits non-zero" the routine jackd-outage path, which now routinely trips a watchdog arm that blames a missing DAC on a corrupt config file and moves the user's Surge defaults aside. As for the product goal: the "sound module" half is on a credible, measured, honestly-bounded path. The **"analog-esque mixer" half has no spec, no buses, and no plan** — the only thing named "mixer" in the tree is a 20-line dataclass driving three per-patch parameter faders, and the sole genuine audio-mixing work sits behind a Phase 2 gate whose own kill criterion permits the answer "stop." Fix the 🔴s, run Gate C, and write a mixer spec before more engine work lands on top of an unverified reversal.
+
+**Findings: 5 🔴 · 6 🟡 · 5 🟢**
+
+🔴 — 4.1 untracked Phase 2 spec · 4.2 unsoaked hard-failure design · 4.3 udev `remove` blind spot · 4.4 watchdog discards user defaults · §Spec Conformance mixer has no spec
+🟡 — 4.5 self-testing test · 4.6 19-mixin god object · 4.7 `getattr` layout chain · 4.8 5 Hz SD-card poller · 4.9 CI weaker than local gate · 4.10 teardown/jackd race
+🟢 — 4.11 dead per-frame import · 4.12 `looper_clock_monitor` misnamed · 4.13 stale CHANGELOG count · 4.14 unbounded no-DAC retry storm · §7 Wi-Fi password in argv
+
+---
+
+## Priority backlog
+
+1. **🔴 Commit `Documents/specs/looper-jack-client-spec.md`.** 869 lines of the repo's most detailed design work is untracked (`git status` → `??`) — invisible to CI, to every other session, and to `dev`, and one `git clean -fd` from gone. This is a five-second fix and it is first for a reason.
+2. **🔴 Run the Gate C soak before merging `yolo/jack-drop-alsa-fallback` to `dev`.** The spec blocks its own merge on this in bold, and lists the five scenarios in order (`jack-audio-engine-spec.md:452-459`): criterion 2\* masked-jackd boot → `state=failed` + promote-on-unmask; 2b/2b2 retest at the new 5s settle; criterion 15 replug from `state=failed`; criterion 12 with a stale `MPE_AUDIO_ENGINE=alsa` line; D5 guard boot. Every Gate B PASS row for the failure paths tested code that no longer exists.
+3. **🔴 Fix the udev `remove`-event blind spot in `config/99-usb-audio.rules:16-19`.** `ATTR{}` cannot match on `remove` (sysfs is already unlinked), so the `Loopback` / `UAC2` / `UAC2Gadget` / `vc4hdmi` skips apply to `add` only, and `modprobe -r snd_aloop` in `calibration_teardown.py:35` restarts jackd after every calibration run — the precise scenario line 19's comment forbids. Filter on kernel-supplied `ENV{}` properties, or move the card-identity check into `restart-audio-graph.sh` where it is one filter instead of four and testable from a laptop.
+4. **🔴 Stop the watchdog from destroying Surge's user defaults during a jackd outage** (`scripts/surge-watchdog.sh:97-105`). Post-amendment, `start-surge-cli.sh` exits 1 by design when there is no graph server, so `surge-xt-cli` reliably reaches `failed` ~100s into any DAC problem, and this arm then moves the user's accumulated defaults to `.corrupted_<timestamp>` — misattributing a cable fault to file corruption and accumulating junk files that nothing ever cleans up. Gate the arm on `mpe_engine_state_get state` / `reason`: skip it when the failure is already explained by `no-server` or `no-jack-device`.
+5. **🔴 Write a spec for the "analog-esque mixer" before more engine work lands.** Half the stated product goal has no design surface: the only "mixer" in the tree is a 20-line `MixerChannel` dataclass plus per-patch Vol/Tail/Touch parameter faders, and the sole real audio-mixing work is Phase 2's NumPy kernel — gated on a measurement whose kill criterion permits "stop, Phase 1 + a HAT." Decide now whether the mixer rides on the JACK graph (which would make it a Phase 2 dependency and change the looper's insert topology in `looper-jack-client-spec.md` §B.3) or is a separate product surface. This is the question that will invalidate the most work if answered late.

--- a/Documents/reviews/review-audit-kimi-2026-08-13.md
+++ b/Documents/reviews/review-audit-kimi-2026-08-13.md
@@ -1,0 +1,211 @@
+# Review Audit — Kimi grumpy review of MPE-Module JACK Phase 1
+
+*Audit date: 2026-08-13 14:09 (America/Toronto)*
+*Auditor: review-audit pass (staff-engineer verification, read-only)*
+*Subject under audit: [`grumpy-review-kimi-2026-08-13.md`](grumpy-review-kimi-2026-08-13.md)*
+*Codebase state verified against: `yolo/jack-drop-alsa-fallback` @ `1ab9f55` (same commit the review covered; tree unchanged since).*
+
+**Headline:** the review is overwhelmingly accurate. Of 54 distinct claims checked, **48 confirmed ✅, 3 partially true ⚠️, 2 incorrect ❌, 1 unverifiable 🔍** (out-of-scope `mpe-cli` claim). Every load-bearing claim — the jackd duplex-open regression risk, the Gate C soak gate, criterion 16 drift, the untracked/stale looper spec, the watchdog budget blowout — checks out against the code with line-level evidence. The errors are secondary: a stale-copied divergence count ("1 behind" vs actual 32), an already-gitignored file flagged as unignored, a two-file claim stated as three (twice), and one fix prescription ("stop seeding `MPE_SURGE_BUFFER_SIZE`") that would break live consumers of that key.
+
+---
+
+## Work Queue
+
+Claims extracted from the review, grouped by file/component:
+
+**A. `scripts/start-jackd.sh`** — (1) no playback-only flag; jackd opens the DAC duplex and holds the capture stream [🔴]. (2) 33-41 publishes `recovering` only when nothing more specific exists [positive].
+
+**B. Mic bridge / session capture** — (3) `mic-to-uac2-bridge.sh:54` + `session_capture.py:66-89` capture from the same Sound Blaster card jackd holds → EBUSY. (4) failure implies a bridge restart loop. (5) soak rows 5b/14 BLOCKED, so the window was never exercised.
+
+**C. Buffer-key drift (Hall of Shame #2 / criterion 16)** — (6) `surge_audio.py:16-19` ghost comment + `DEFAULT_BUFFER=1024`. (7) UI label shows "1024 · 21 ms" while graph runs 256×3 = 16 ms. (8) `configure-pi-paths.sh:70-74` seeds `MPE_SURGE_BUFFER_SIZE`, never JACK keys. (9) Gate B saw 12 "touch buffer label / env drift" failures, dismissed as pre-existing. (10) `set-surge-audio.sh:125-128` writes both keys on `--buffer`. (11) *Prescription:* stop seeding the Surge key; write JACK key only. (12) criterion 16 has no executable test.
+
+**D. Watchdog (Hall of Shame #3)** — (13) 15-iteration budget loop × `timeout 3 jack_lsp` + 1 s sleep ⇒ up to ~60 s blocked against a hung jackd. (14) probe runs up to 3× per reconcile pass.
+
+**E. Looper spec (Hall of Shame #4)** — (15) untracked in git. (16) §D.5 keeps `MPE_AUDIO_ENGINE=alsa` as operator choice. (17) criterion 11 boots "with `MPE_AUDIO_ENGINE=jack` unset". (18) §D.5.2 cites the old guard message advising `mpe engine set alsa`. (19) §D.5.3 analyzes `looper_guard_blocked` keying on configured engine via `resolve_audio_engine`. (20) criterion 11's `grep -r LOOPER_GUARD` misses `mpe_looper_state_label`.
+
+**F. Guard triple implementation (Hall of Shame #5)** — (21) one predicate, three homes: `engine-guard.sh:24-26`, `audio-engine.sh:189-195`, `audio_engine.py:36-38`.
+
+**G. Stale comments (#6)** — (22) `99-usb-audio.rules:1-5`. (23) `uac2-stall-watchdog.sh:4-6`. (24) `engine-guard.sh:7` dates removal 2026-08-12. (25) `set-surge-audio.sh:72` unused `_old_buffer`.
+
+**H. Logic & business rules** — (26) failed-reason overwritten (`supervisor-exhausted` → `no-server`). (27) sample-rate enum drift (44100/48000 vs 96000). (28) HUD `active` passed through untrusted. (29) profile-switch flag persists until supervisor-scheduled Surge start. (30) failed publish path correct end-to-end [positive]. (31) watchdog announces `failed` once [positive]. (32) `mpe_restart_audio_graph` resets supervisor budget, unspecced.
+
+**I. Git / topology** — (33) `main` 42 behind `dev`. (34) `yolo/looper-phase0` "76 ahead / 1 behind", merge-base before Phase 1. (35) PR #48 touches the three files Phase 1 rewrote most.
+
+**J. Tests / DX / security positives** — (36) 440 tests, 0 failures. (37) CHANGELOG says 438. (38) `test_audio_engine.py` structure (parity tests, `NoAlsaPathTests`, unit-content assertions). (39) README says Pi 5 vs specs' Pi 4B. (40) `ENCODER_BUTTON_REVIEW.md` at root. (41) `logs/shutdown-trace.jsonl` untracked, "consider ignoring `logs/`". (42) `json_store.py` fsyncs file + dir. (43) `${2:-unknown}` rationale comment. (44) OSC bound to 127.0.0.1:53280. (45) HUD reads via 0.5 s cached monitor. (46) 19-mixin class at `touch_browser_app.py:67-87`. (47) defensive `getattr` chains at `touch_browser_draw.py:485-489`. (48) HUD draw at `touch_browser_draw.py:392-405`. (49) `--list-devices` invoked "up to three times per boot" by `start-surge-cli.sh`. (50) D2 routing at four call sites. (51) no `chrt` in `start-surge-cli.sh`. (52) no conflict markers / dead fallback arms. (53) `mpe engine status` landed in mpe-cli, soaked PASS. (54) Gate B soak-log citations (PASS/BLOCKED rows) quoted faithfully.
+
+---
+
+## Claim Verification
+
+### A. `scripts/start-jackd.sh`
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 1 | No `-P` playback-only flag; jackd ALSA backend opens duplex and holds the Sound Blaster capture stream → mic bridge/session capture EBUSY | ✅ | `start-jackd.sh:43-44`: `exec jackd -R -P"$JACK_PRIO" -s \` / `-d alsa -d "$HW_DEV" -r "$JACK_RATE" -p "$JACK_BUFFER" -n "$JACK_PERIODS"`. Note: the `-P"$JACK_PRIO"` *before* `-d alsa` is jackd's **core** realtime-priority option — the ALSA backend's playback-only flag (also spelled `-P`, but positioned *after* `-d alsa`) is genuinely absent, so the backend defaults to duplex. The review did not confuse these. Hardware confirmation still pending — the review itself flags this ("almost certainly", "nobody can know") and the fix direction is correct. |
+| 2 | 33-41 publishes `recovering` only when nothing more specific is published | ✅ | `start-jackd.sh:35-41`: `case "$current_state" in ok \| failed \| recovering) ;; *) mpe_engine_state_write ... recovering jackd-starting ...` — multi-writer discipline as described. |
+
+### B. Mic bridge / session capture
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 3 | Bridge captures from the same card jackd holds | ✅ | `mic-to-uac2-bridge.sh:54`: `arecord -D "$CAP_DEV" -f S16_LE ...`; `session_capture.py:66-89` resolves `plughw:CARD=<Play3>,DEV=0` (fallback `return plug_dev or hw_dev or f"plughw:CARD={card_id},DEV=0"`). `config/mpe.env.example:39` confirms the profile's purpose: "usb-host-session — Surge on Sound Blaster; RC-5 return (mic in) → USB when PC captures". ALSA `hw` capture opens are exclusive — mechanism is sound. |
+| 4 | Failure implies a restart loop | ✅ (sharper than stated) | `config/mic-to-uac2-bridge.service:12-13`: `Restart=on-failure` / `RestartSec=1`. With no explicit `StartLimitBurst`, the default (5/10 s) wedges the unit into `failed` after ~5 s of EBUSY — not an infinite loop but a dead bridge requiring manual `reset-failed`. See *What the Review Missed*, M3. |
+| 5 | Soak rows 5b/14 BLOCKED — regression window never exercised | ✅ | Spec Gate B log: `5b UAC2 host capture | **BLOCKED** | Needs physical rewire` (line 473); `14 calibration/session | **PASS** (cal) / **BLOCKED** (session) | ... session_capture.py still blocked (same rewire as 5b)` (line 475). |
+
+### C. Buffer-key drift (Hall of Shame #2 / criterion 16)
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 6 | Ghost comment + `DEFAULT_BUFFER = 1024` | ✅ | `surge_audio.py:16-18`: `# Must stay in sync with the fallback in scripts/start-surge-cli.sh.` — no fallback exists in `start-surge-cli.sh` (full read; the string `MPE_SURGE_BUFFER_SIZE` appears nowhere in that script). Module docstring ("Surge ALSA buffer size…") is also stale. |
+| 7 | Fresh appliance displays "1024 · 21 ms" while playing at 256×3 = 16 ms | ✅ | `surge_audio.py:50-55` reads `MPE_SURGE_BUFFER_SIZE` (seeded 1024); `buffer_latency_ms` (66-71) computes `buf*1000/rate` with **no ×periods**; the graph runs `mpe_jack_period`/`mpe_jack_periods` defaults 256×3 (`audio-engine.sh:23-24`). Label is wrong on both axes (key and math). |
+| 8 | `configure-pi-paths.sh:70-74` seeds the legacy key, never the JACK keys | ✅ | Lines 70-74 write `MPE_SURGE_BUFFER_SIZE` (preserved or 1024); the whole write block (59-80) contains no `MPE_JACK_*` line. JACK keys fall through to library defaults. |
+| 9 | Gate B saw 12 "touch buffer label / env drift" failures, dismissed as pre-existing | ✅ | Spec line 469: "`mpe test pi audio`: 12 failures (touch buffer label / env drift — pre-existing on branch, not jack-specific)". Quoted exactly. |
+| 10 | `set-surge-audio.sh:125-128` writes both keys on `--buffer` | ✅ | Line 90 `_update_env_var MPE_SURGE_BUFFER_SIZE "$BUFFER"`; lines 125-128 `if [ -n "$BUFFER" ]; then _update_env_var MPE_JACK_BUFFER "$BUFFER" ...`. Both keys written; the D6-separated knobs are re-coupled through this path. |
+| 11 | *Prescription:* stop seeding `MPE_SURGE_BUFFER_SIZE`; `--buffer` should write the JACK key only | ❌ (prescription) | `MPE_SURGE_BUFFER_SIZE` is **not** a dead key. Live consumers: `scripts/calibrate-patch-normalization.py:422,457`, `patch_browser/midi_sync.py:58`, and the `MPE_MIDI_OUTPUT_OFFSET_AUTO` default ("-buffer_ms from MPE_SURGE_BUFFER_SIZE", `mpe.env.example:142`). `mpe.env.example:66-71` explicitly documents it as "legacy knob — no effect on JACK playback. Still read by calibration and the MIDI clock offset auto-derivation." Removing the seed forces those consumers onto their hardcoded 1024 fallbacks and contradicts the shipped env contract. The correct fix is the review's *first* half (repoint UI read-back/labels at `MPE_JACK_BUFFER`/`MPE_JACK_PERIODS`, ×periods in the label) — the seeding should stay, possibly with a renamed comment. See Disagreements. |
+| 12 | Criterion 16 has no executable test; `grep MPE_JACK_BUFFER tests/` → nothing | ✅ | Zero matches for `MPE_JACK_BUFFER|MPE_JACK_PERIODS` anywhere under `tests/` (grep run this session). The enum validators `mpe_jack_period`/`mpe_jack_periods`/`mpe_jack_rate` have no coverage. |
+
+### D. Watchdog (Hall of Shame #3)
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 13 | "15 s budget" loop is really up to ~60 s against a hung jackd | ✅ | `surge-watchdog.sh:13` `RECONCILE_BUDGET=15`; loop at 73-86 counts **iterations**, each costing `timeout 3 jack_lsp` (`audio-engine.sh:215`) + `sleep 1` when the server hangs ⇒ 15 × ~4 s ≈ 60 s, during which the crash-recovery arm (main loop, 97-113) does not run. |
+| 14 | Same probe executed up to 3× per reconcile pass | ✅ | Per pass: line 67 `mpe_surge_on_jack_graph` → `mpe_jack_server_ready` (`audio-engine.sh:428`); line 73 `mpe_jack_server_ready`; loop line 76; line 82; line 88 calls both again. Worst case is worse than "3×" — but the claim's direction and fix (probe once, count wall-clock) are right. |
+
+### E. Looper spec (Hall of Shame #4)
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 15 | `Documents/specs/looper-jack-client-spec.md` is untracked | ✅ | `git status --porcelain`: `?? Documents/specs/looper-jack-client-spec.md`. |
+| 16 | §D.5 still scopes `MPE_AUDIO_ENGINE=alsa` as an operator choice | ✅ | Looper spec lines 79-81 (Non-Goals: "remove auto-fallback and keep `MPE_AUDIO_ENGINE=alsa` as an explicit operator choice only") and 691-694 (§D.5 same). The amendment (`jack-audio-engine-spec.md:20-24`) deleted the variable outright: "`MPE_AUDIO_ENGINE` is retired — removed from `config/mpe.env.example` and every consumer." |
+| 17 | Criterion 11 verification boots "with `MPE_AUDIO_ENGINE=jack` unset (default)" | ✅ | Looper spec line 100; also §D.4 step 2 (line 675): "Leave `MPE_AUDIO_ENGINE` unset so the default `jack` applies." Variable no longer exists. |
+| 18 | §D.5.2 describes the guard message advising `mpe engine set alsa` | ✅ | Looper spec 699-704 quotes `engine-guard.sh:34` telling the user "Switch with: sudo mpe engine set alsa". Current `engine-guard.sh:20`: `MPE_LOOPER_GUARD_MESSAGE="looper is unavailable until the JACK callback client ships (spec Phase 2) — there is no ALSA route to run it through."` — message rewritten; the cited line 34 is now an `if` statement. Stale quote *and* stale line ref. |
+| 19 | §D.5.3 analyzes `looper_guard_blocked` keying on the configured engine via `resolve_audio_engine` | ✅ | Looper spec 705-712. Current `audio_engine.py:36-38`: `def looper_guard_blocked(*, looper_enabled: str \| int \| None = None) -> bool: ... return str(looper_enabled or "0").strip() == "1"` — no engine parameter; `resolve_audio_engine` does not exist anywhere in `patch_browser/` (grep). |
+| 20 | Criterion 11's `grep -r LOOPER_GUARD` won't catch `mpe_looper_state_label` | ✅ (stronger than stated) | `LOOPER_GUARD` matches `LOOPER_GUARD_MESSAGE` (both languages) and `LOOPER-GUARDED` only with case-insensitive/-e tricks; it misses `mpe_looper_state_label` (`audio-engine.sh:189`) **and** lowercase `looper_guard_blocked` under a case-sensitive grep. The removal checklist in looper-spec Task 12 does name the symbols explicitly, mitigating this in practice. |
+
+### F. Guard triple implementation (Hall of Shame #5)
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 21 | One predicate, three implementations | ✅ | `engine-guard.sh:24-26` `mpe_looper_engine_blocked() { [ "${MPE_LOOPER_ENABLED:-0}" = "1" ] }`; `audio-engine.sh:189-195` `mpe_looper_state_label` re-tests the same var; `audio_engine.py:36-38` `looper_guard_blocked`. Nuance: the Python twin takes the value as a *parameter* rather than reading the env, so it's a pure function of caller input — still a third policy home, but the cleanest of the three. The spec's own D5 rationale ("a guard per call site would rot") makes the triplication a fair smell callout. |
+
+### G. Stale comments (#6)
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 22 | `99-usb-audio.rules:1-5` says "restart Surge XT CLI" | ✅ | Lines 1-5 unchanged from pre-JACK wording; actual actions at 26-27 run `restart-audio-graph.sh` (jackd). |
+| 23 | `uac2-stall-watchdog.sh:4-6` says "restart Surge on the gadget" | ✅ | Header unchanged; actual path is `_uac2_restart_graph` (64-68) → `restart_audio_graph`. |
+| 24 | `engine-guard.sh:7` dates the ALSA removal "2026-08-12" | ✅ | Line 7: "(ALSA removed entirely, 2026-08-12)"; the amendment is dated 2026-08-13 everywhere else. Off-by-one-day stale. |
+| 25 | `set-surge-audio.sh:72` assigns `_old_buffer`, never uses it | ✅ | Line 72 assigns; only `_old_rate` is consumed (line 102). Dead assignment. |
+
+### H. Logic & business rules
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 26 | Failed-state reason gets overwritten (`supervisor-exhausted` → `no-server`) | ✅ | Supervisor escalation writes reason `supervisor-exhausted` once (`surge-watchdog.sh:42-45`), but `surge-xt-cli.service:24` `Restart=on-failure` keeps re-running `start-surge-cli.sh`, which re-publishes `state=failed reason=no-server` at line 151 on every retry until start-limit wedges the unit. Mechanism confirmed; cosmetic as rated. |
+| 27 | Rate enum drift: UI 44100/48000, validator also 96000 | ✅ | `set-surge-audio.sh:47-52` accepts only 44100/48000; `audio-engine.sh:60-65` `mpe_jack_rate()` also accepts 96000; `surge_audio.py:14` `SAMPLE_RATE_PRESETS = (44100, 48000)`. Two policies, pick one. |
+| 28 | HUD passes `active` through untrusted | ✅ | `audio_engine.py:114-120`: `active = state.get("active") or ...; parts.append(str(active)[:4].upper())` — a stale `active=alsa` renders "ALSA"; `state` is filtered against `VALID_ENGINE_STATES` (line 121) but `active` is not. Harmless (tmpfs clears on reboot), as rated. |
+| 29 | Profile-switch flag persists until the *supervisor's* next Surge start | ✅ | `set-audio-profile.sh:54-60`: marks flag, calls `restart_audio_graph`, comment acknowledges "the flag persists until Surge is next started — e.g. manual restart or supervisor reconcile." |
+| 30 | Hard-failure design wired end-to-end [positive] | ✅ | `start-surge-cli.sh:147-154` publishes `state=failed` + non-zero exit; unit retries via `Restart=on-failure`; supervisor caps and escalates once. Verified against units, not just docs. |
+| 31 | Watchdog announces `failed` once, not every poll [positive] | ✅ | `surge-watchdog.sh:42`: `if [ "$(mpe_engine_state_get state)" != failed ]` gates the log+write. |
+| 32 | `mpe_restart_audio_graph` resets the supervisor budget — landed but unspecced | ✅ | `audio-engine.sh:311-314`: `mpe_engine_reconcile_reset` after restart, rationale only in the code comment. Full read of the spec: the D3 cooldown table (334-339) and the amendment never state the rule "operator/device action clears escalation." Amended criterion 15 (line 195) *implies* the outcome (replug recovers from `state=failed`) but the behavioral rule itself is code-only. |
+
+### I. Git / topology
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 33 | `main` is 42 commits behind `dev` | ✅ | `git rev-list --count main..dev` → `42`. |
+| 34 | `yolo/looper-phase0` is "76 commits ahead / 1 behind `dev`", merge-base before Phase 1 | ⚠️ | Measured this session: **76 ahead / 32 behind** (`git rev-list --count` both directions); merge-base `da70ee5` (Aug 10), which does predate the Phase 1 merge `daac891` ✅. The "1 behind" figure is lifted from the looper spec's own 2026-08-12 measurement (its lines 628/836) without re-running — a day stale and materially different: the branch is *further* behind than reported, which strengthens the rebase-gate point but misreports the fact. |
+| 35 | PR #48 "touches the three files Phase 1 rewrote most (`start-surge-cli.sh`, `detect-audio-device.sh`, `99-usb-audio.rules`)" | ⚠️ | `git diff --name-only $(merge-base)..yolo/looper-phase0` (69 files total, matching the spec's count) includes `scripts/start-surge-cli.sh` and `scripts/detect-audio-device.sh` but **not** `config/99-usb-audio.rules`. Two of three; the rebase-conflict argument is unaffected. (The looper spec's §D.4 makes the same three-file claim — the review inherited it.) |
+
+### J. Tests / DX / security positives
+
+| # | Claim | Verdict | Evidence |
+|---|-------|---------|----------|
+| 36 | 440 tests, 0 failures | ✅ | Reproduced this session via the project's own harness: `mpe test local all` → `Ran 440 tests in 42.236s / OK`, plus `OK test_gadget_persist.sh` and `All prepare-dsi-display shell tests passed`. Static count corroborates: 440 `def test_` methods under `tests/`. |
+| 37 | CHANGELOG claims 438 | ✅ | `CHANGELOG.md:71`: "Full suite: 438 tests, 0 failures". Two tests added since; immaterial, as the review said — but the doc/suite mismatch is real. |
+| 38 | `test_audio_engine.py` structure (parity tests, `NoAlsaPathTests`, unit-content assertions) | ✅ | 704 lines; classes include `BashReconcileParityTests` (172), `NoAlsaPathTests` (423), `RuntimeDirectoryPreserveTests` (189), `SurgeStartLimitUnitTests` (244), `JackdStartLimitTests` (257). |
+| 39 | `README.md:75` says Pi 5; specs say Pi 4B | ✅ | README:75 "Reference stack: Raspberry Pi 5…"; `jack-audio-engine-spec.md:508` "Pi 4B, Debian 13 trixie"; looper spec:809 "Pi 4B Rev 1.5". Either two appliances exist (then say so) or one doc is wrong. |
+| 40 | `ENCODER_BUTTON_REVIEW.md` sits at repo root | ✅ | File exists at root. |
+| 41 | `logs/shutdown-trace.jsonl` is untracked; "consider ignoring `logs/`" | ❌ | The file is **already gitignored**: `git check-ignore -v logs/shutdown-trace.jsonl` → `.gitignore:34:logs/shutdown-trace.jsonl`. That's why `git status --porcelain` is clean for it. The recommendation is already implemented; the review apparently inferred "untracked" from the file's on-disk presence without checking ignore rules. |
+| 42 | `json_store.py:24-43` atomic write, fsync file + directory | ✅ | Lines 34-43: `handle.flush(); os.fsync(handle.fileno())`, `os.replace`, then `os.open(path.parent)` + `os.fsync(dir_fd)`. |
+| 43 | `audio-engine.sh:160-179` `${2:-unknown}` with found-bug rationale | ✅ | Comment at 162-165 documents the watchdog-killed-by-`${2:?}` incident exactly as quoted. |
+| 44 | OSC bound to 127.0.0.1:53280, no network surface | ✅ | `patch_browser/patch_loader.py:46-47`: `osc_host="127.0.0.1", osc_port=53280`. |
+| 45 | HUD reads via 0.5 s cached background monitor | ✅ | `engine_state_monitor.py:10`: `POLL_INTERVAL_S = 0.5`; draw path calls `self.engine_monitor.snapshot()` (`touch_browser_draw.py:395`), no per-frame disk hits. |
+| 46 | 19-mixin class at `touch_browser_app.py:67-87` | ✅ | Exactly 19 mixin base classes, lines 68-86. |
+| 47 | Defensive `getattr` chains at `touch_browser_draw.py:485-489` | ✅ | Quoted lines match: `getattr(self, "engine_hud_rect", getattr(self, "looper_hud_rect", self.audio_profile_badge_rect)).x` etc. |
+| 48 | HUD draw at `touch_browser_draw.py:392-405` | ✅ | `_draw_engine_hud` reads monitor snapshot → `engine_hud_should_show`/`engine_hud_label`/`engine_hud_semantic`. |
+| 49 | "`start-surge-cli.sh` invokes `--list-devices` up to three times per boot" | ⚠️ | Two invocations live in `start-surge-cli.sh` (line 42 JACK index, line 97 MIDI index). The third is `detect-audio-device.sh:32`, run from `jackd-prestart.sh:50` — a **different unit** (`mpe-jackd.service` ExecStartPre). So: 3 per boot across the boot path, 2 attributable to the named script. The perf point (Surge CLI invocations cost seconds on a Pi 4) stands; the suggested fix (cache one listing) would need to cross the unit boundary, making it slightly harder than implied. |
+| 50 | D2 routing at four call sites [positive] | ✅ | `set-audio-profile.sh:57` → `restart_audio_graph`; `set-surge-audio.sh:129` → `mpe_restart_audio_graph`; `uac2-stall-watchdog.sh:64-68` → `restart_audio_graph`; `99-usb-audio.rules:26-27` → `restart-audio-graph.sh`. All four verified. |
+| 51 | No `chrt` anywhere in `start-surge-cli.sh` [positive] | ✅ | Full read; no `chrt`. Comment at 134-137 explains why. |
+| 52 | No merge-conflict artifacts / dead fallback arms / duplicate engine paths [positive] | ✅ | Repo-wide grep for `^<<<<<<< ` across py/sh/md: none. `MPE_AUDIO_ENGINE` appears only in comments; `resolve_audio_engine` is gone from `patch_browser/`. |
+| 53 | Criterion 17 landed mpe-cli-side, soaked PASS | 🔍 | `mpe-cli` is a separate repo explicitly outside this review's scope; the Gate B log row (`17 ... PASS | Shipped in mpe-cli 85dad3c`) is internally consistent, but I did not verify the mpe-cli repo. |
+| 54 | Gate B soak-log citations faithful [positive] | ✅ | Every quoted row (5b BLOCKED, 14 half-BLOCKED, 2b2 PASS, 12-failure drift note, 39 s recovery, etc.) matches `jack-audio-engine-spec.md:460-475` verbatim. |
+
+---
+
+## Severity Re-Assessment
+
+| # | Issue | Reviewer Rating | My Rating | Delta | Reasoning |
+|---|-------|-----------------|-----------|-------|-----------|
+| 1 | jackd duplex open vs mic bridge/session capture | 🔴 Critical | **High** | Slightly deflated | Mechanism verified; it is a real shipped-profile regression *in waiting*. But the affected profile is already BLOCKED on a physical rewire, so nothing regresses in the field until that unblocks — which makes this a "fix before/at the rewire" gate rather than a drop-everything fire. Fix itself is one flag (`-P` after `-d alsa`). |
+| 2 | Do not merge without Gate C soak | 🔴 Critical | **High** | Agree | Process gate, spec-mandated (spec lines 102-108, 452-458). The branch converts every jackd failure into a silent instrument *by design*; shipping that unsoaked is the real incident risk. |
+| 7/8/10/12 | Criterion 16 drift: UI sells the retired-for-graph buffer key; no tests | 🟡 Medium | **Medium** | Agree | User-facing mislabel (21 ms vs 16 ms) plus a knob whose read-back doesn't match the graph. No audio harm — `set-surge-audio.sh --buffer` writes both keys, so the picker *works*; only the display lies. |
+| 13/14 | Watchdog budget blowout on hung jackd | 🟡 Medium | **Medium** | Agree | Up to ~60 s of supervisor blindness in a rare-but-real failure mode (hung, not dead, jackd), delaying the crash-recovery arm. Compounds with my M1 (unguarded `jack_lsp` at `audio-engine.sh:432`). |
+| 15-19 | Looper spec untracked + 4 stale sections | 🟡 Medium | **Medium** | Agree | Process rot, not code rot — but exactly the kind that re-injects "the spec said so" bugs into Phase 2. One commit + four small edits. |
+| 21 | Triple predicate | 🟡 Medium | **Low** | Deflated | All three implementations are trivially identical today and two are one-liners reading the same env var. For a solo-maintainer appliance this is a cleanup task, not a defect; it only bites during the Phase 2 guard removal, which has its own checklist (Task 12 names the symbols). |
+| 26 | Failed-reason overwrite | 🟢 Cosmetic | **Low** | Agree | Journal/status loses escalation history; HUD unaffected. One-line guard ("don't downgrade reason") in the state writer's callers. |
+| 27 | 96 kHz enum drift | 🟢 Minor | **Negligible** | Agree-ish | No user path reaches the inconsistency (UI presets exclude 96k; env can set it and the validator honors it). Pick one when convenient. |
+| 28 | HUD `active` passthrough | 🟢 Minor | **Negligible** | Agree | tmpfs clears on reboot; worst case is a 4-char stale badge until then. |
+| 32 | Budget-reset unspecced | 🟢 (surprise) | **Low** | Agree | Behavior is *correct* and matches amended criterion 15's intent; the gap is that a behavioral rule lives only in a code comment. One spec sentence fixes it. |
+| 33/34/35 | Branch topology warnings | 🟡 (structural) | **Medium** | Agree | Direction right; numbers stale in the review's favor (32 behind, not 1). The rebase gate (Task 0) is correctly identified as load-bearing. |
+
+---
+
+## What the Review Missed
+
+Honest account: the review's coverage of the audio path was thorough — my independent read of the same files produced only four net-new items, all minor:
+
+- **M1 — One `jack_lsp` call lacks the `timeout 3` guard.** `audio-engine.sh:432` (`mpe_surge_on_jack_graph`): `jack_lsp 2>/dev/null | grep -qi 'surge'` — every other probe goes through `timeout 3 jack_lsp` (`:215`), but this one doesn't. It's reached only after a ready-probe passed, so the window is narrow (server hangs between the two calls), but if it trips, the watchdog blocks **indefinitely**, not 60 s — strictly worse than Hall of Shame #3's worst case. Same fix pass: probe once, reuse the result.
+- **M2 — `start-surge-cli.sh` publishes `state=ok` optimistically.** Lines 171-172 write `ok` immediately after backgrounding Surge; `sleep 2` (line 174) is not a liveness check. A Surge that dies on connect (bad index, late jackd death) shows a false `ok` until the watchdog's next 5 s poll. Self-healing; Low.
+- **M3 — The EBUSY blast radius is a wedge, not a loop.** The review said the mic bridge would fail "likely in a restart loop." `mic-to-uac2-bridge.service:12-13` (`Restart=on-failure`, `RestartSec=1`, default burst limits) means ~5 rapid retries then the unit lodges in `failed` — the bridge stays dead even if jackd later frees the device, until manual `reset-failed`. Sharpens 🔴#1's consequence; doesn't change its fix.
+- **M4 — Stale inventory number in `engine-guard.sh:9`.** "MPE_LOOPER_ENABLED is read in nine files" — the current tree has 4 (`grep -rl` over py/sh/service, excluding docs/reviews). Same class as the #6 comment parade; one more data point that the guard's own documentation is drifting.
+
+Nothing missed on the security axis — the review's "no holes" conclusion for a loopback-only, single-user appliance with enum-validated sudo entry points matches my read.
+
+## What the Review Got Right (And Why It Matters)
+
+1. **The duplex-open catch (🔴#1) is the review's best find, and it's the kind static reading is for.** No test could have caught it — the soak rows that would exercise it (5b/14) are physically blocked, and the failure only exists when two correct-on-paper components (jackd's default duplex open; the bridge's exclusive `hw` capture) meet on hardware. The added depth I'd attach: the review undersold *why now* — pre-JACK, Surge's JUCE ALSA open was playback-only, so Phase 1 *introduced* the capture-side hold. It's a regression created by the merge, not a pre-existing condition, and the BLOCKED soak row is exactly where it would have surfaced. Fixing it is one flag; the cost of not fixing it is the entire `usb-host-session` feature dead-on-arrival after the rewire Mitch is presumably about to do.
+2. **Gate C as a hard stop (🔴#2) is correct and correctly framed as "pressure to skip it is the actual incident."** The amendment converts jackd failure into designed silence. Every mechanism of that (2\*, promotion from `failed`, 5 s settle retest, stale-env inertness) is verified in code and unverified on hardware — and the review resisted treating the green 440-test suite as evidence about hardware behavior, which is exactly right.
+3. **Criterion 16 drift (🟡#2) matters more than a label bug.** The touch UI is the *only* instrument-facing surface for audio settings. Right now it displays 21 ms while the graph runs 16 ms — meaning any future "latency feels wrong" report will be debugged against numbers the UI invented. The Gate B log already recorded 12 drift failures and they were waved through as "pre-existing"; the review correctly identified that dismissal as the real process failure.
+4. **The untracked looper spec (🟡#4) — the review caught that the *newest-looking* document is the stalest.** Four concrete contradictions, each verified above (§D.5, criterion 11, D.5.2, D.5.3). Left uncommitted, Phase 2 Task 0 starts from a spec whose guard analysis describes code that no longer exists.
+5. **The watchdog probe math (🟡#3)** — verified, and the fix (probe once per pass, count wall-clock) is the right shape.
+
+## Prioritized Action Matrix
+
+| Priority | Issue | Verdict | Effort | Depends On |
+|----------|-------|---------|--------|------------|
+| **P0** | Hold `yolo/jack-drop-alsa-fallback` merge until Gate C soak runs (2\*, 2b/2b2 @ 5 s settle, 15-from-`failed`, 12 stale-env) — spec-mandated, unverified hard-failure path | ✅ | Pi bench session (~half-day with Mitch) | Mitch + hardware |
+| **P0** | jackd duplex open: add playback-only `-P` (after `-d alsa`) to `start-jackd.sh:43-44`, then run the blocked 5b/14 soak rows | ✅ | Quick fix + Pi verification | Physical rewire (already the 5b/14 blocker); decide whether any future client needs capture on the same card — record in spec |
+| **P1** | Commit + amend `Documents/specs/looper-jack-client-spec.md`: §D.5 (no ALSA operator choice), criterion 11 (drop `MPE_AUDIO_ENGINE` from verification; fix grep to catch all guard symbols), D.5.2 (current guard message), D.5.3 (current `looper_guard_blocked` signature) | ✅ | Quick fix (one commit, four edits) | None |
+| **P1** | Criterion 16 UI drift: point `surge_audio.py` read-back/labels at `MPE_JACK_BUFFER`/`MPE_JACK_PERIODS` with ×periods latency math; keep seeding `MPE_SURGE_BUFFER_SIZE` (calibration + MIDI offset still read it) but stop presenting it as the playing latency; add tests for the JACK enum validators | ✅ | Half-day | None |
+| **P1** | Watchdog probes: probe once per reconcile pass, count wall-clock not iterations, and wrap the bare `jack_lsp` at `audio-engine.sh:432` in `timeout 3` (M1) | ✅ + M1 | Quick fix | None |
+| **P2** | Failed-reason downgrade guard in `mpe_engine_state_write` callers (keep `supervisor-exhausted`) | ✅ | Quick fix | None |
+| **P2** | Comment-hygiene pass: `99-usb-audio.rules:1-5`, `uac2-stall-watchdog.sh:4-6`, `engine-guard.sh:7` date + "nine files" (M4), `set-surge-audio.sh:72` dead `_old_buffer`; CHANGELOG 438→440; README Pi 5 vs Pi 4B disambiguation | ✅ | Quick fix | None |
+| **P2** | Spec the budget-reset rule (one sentence in the D3 cooldown section) and the 96 kHz enum decision | ✅ | Quick fix | None |
+| **P2** | Consolidate the looper predicate to one bash home + Python twin with extended parity test | ✅ | Quick fix | Naturally lands with Phase 2 Task 12 |
+| **P3** | Mixin attribute-ownership pass on `touch_browser_app.py` (19 mixins); document who owns `engine_hud_rect` etc. | ✅ | Half-day | Before next big UI feature |
+| **P3** | Cache one Surge `--list-devices` listing per boot across jackd-prestart + start-surge-cli (crosses unit boundary — hand a file, not a variable) | ⚠️ | Half-day | Optional; boot-time win only |
+| **P3** | `start-surge-cli.sh` optimistic `ok` publish (M2): verify SURGE_PID survived the first 2 s before writing `state=ok` | Missed | Quick fix | None |
+
+## Disagreements and Judgment Calls
+
+1. **"Stop seeding `MPE_SURGE_BUFFER_SIZE`" is wrong as prescribed (claim 11, ❌).** The key is retired *as the graph period* but is a live input to calibration (`calibrate-patch-normalization.py:422,457`) and the MIDI output-offset auto-derivation (`midi_sync.py:58`, `mpe.env.example:142`), and `mpe.env.example:66-71` documents exactly that contract. Deleting the seed forces silent fallback to hardcoded 1024s in those paths. The right fix keeps the seed (re-commented as a calibration/MIDI knob) and repairs the UI's read-back. This is the one place the review's "delete it" instinct outran the repo's own documentation.
+2. **"`--buffer` should write the JACK key only" is debatable.** Writing both keys keeps the touch buffer picker functional for its remaining consumers (MIDI offset) while driving the graph — arguably the *desired* one-knob UX for an appliance, at the cost of formally re-coupling what D6 separated. I'd frame the fix as "relabel + repoint read-back" and leave the dual-write, rather than the review's "write the JACK key only." Reasonable engineers could land either way; the review's version is more spec-pure, mine is more UX-coherent.
+3. **"76 ahead / 1 behind" (claim 34, ⚠️→❌ on the number).** The review presented a day-old number from the spec it was auditing as a fresh measurement. Direction and conclusion survive (the branch is actually *more* diverged — 32 behind), but in a review whose core virtue is verified numbers, this one wasn't verified. Same inheritance pattern as claim 35's three-file list (actually two).
+4. **`logs/` ignore suggestion (claim 41, ❌)** — already implemented at `.gitignore:34`. Minor, but it's the second instance of the review asserting git state without running the check.
+5. **Big-team vs solo-appliance calibration.** The review's structural warnings (19-mixin class, stringly-typed state files, triple predicate) are all *true* and all correctly rated as non-urgent — I'd go further and call them acceptable end-states for a single-maintainer instrument, not debt requiring a plan. Where the review aimed its big-team instincts correctly: test parity between bash and Python decision functions, and treating the systemd triangle as the load-bearing risk. Where they misfired slightly: the "one predicate, one home" push (🟡#5) — with a guard deletion already specced as Task 12 with an explicit symbol checklist, the triplication has a scheduled funeral.
+6. **Severity framing on 🔴#1.** I'd call it High rather than Critical only because the affected profile is already blocked on a physical rewire — nothing ships broken that isn't already blocked. If the rewire lands before the fix, it becomes Critical instantly. Sequencing matters more than the label.
+
+---
+
+*Audit method note: every code claim above was verified by direct read of the cited file at `1ab9f55`; every git claim by running the command (`git status --porcelain`, `git rev-list --count` both directions, `git merge-base`, `git diff --name-only`, `git check-ignore -v`); the test-suite claim by re-running `mpe test local all` (440/440 OK). One claim (53) is out of scope by construction (`mpe-cli` repo).*

--- a/Documents/reviews/review-audit-opus-2026-08-13.md
+++ b/Documents/reviews/review-audit-opus-2026-08-13.md
@@ -1,0 +1,283 @@
+# Review Audit — `grumpy-review-opus-2026-08-13.md`
+
+*Audit date: 2026-08-13 (America/Toronto)*
+
+**Review audited:** `Documents/reviews/grumpy-review-opus-2026-08-13.md`
+**Codebase:** `/home/mitch/Documents/GitHub/MPE-Module` @ `yolo/jack-drop-alsa-fallback` `1ab9f55`
+**Method:** every claim taken back to the file, with `git`, `grep`, and the `mpe` CLI run against the working tree. No files modified except this one.
+
+**Tally: 48 ✅ · 12 ⚠️ · 3 ❌ · 2 🔍**
+
+---
+
+## Work Queue
+
+Claims extracted from the review, grouped by artifact.
+
+**Git / process (A1–A7)**
+A1 Phase 2 spec untracked · A2 branch identity `1ab9f55` = `dev` + 1 · A3 HEAD reverses goal 2 and deletes the soaked fallback arm · A4 Gate C's five scenarios unrun; four Gate B PASS rows tested deleted code · A5 440 tests / 42s / exit 0 · A6 CHANGELOG says 438 · A7 `mpe test coverage` output as quoted
+
+**`config/99-usb-audio.rules` (B1–B5)**
+B1 `ATTR{}` cannot match on `remove` · B2 all four skip guards leak; every remove hits the generic rule · B3 `modprobe -r snd_aloop` in `calibration_teardown.py:35` fires it every calibration · B4 cited line numbers `:19, 27` / `:16-19` · B5 proposed fix "filter on kernel-supplied `ENV{}`"
+
+**`scripts/surge-watchdog.sh` (C1–C8)**
+C1 corrupt-defaults arm at `:97-105` · C2 `start-surge-cli.sh` exits 1 by design `:147-154` · C3 unit is `Restart=on-failure` / `RestartSec=10` / `StartLimit*` in `[Unit]` · C4 ~100s to `failed` · C5 `.corrupted_*` accumulate, nothing cleans them · C6 `grep -rn corrupted` returns exactly two lines · C7 `RECONCILE_BUDGET` busy-wait stretches the outer cadence to ~20s · C8 the 15s `RECONCILE_BUDGET` was left behind when settle went 15s → 5s
+
+**Tests / CI (D1–D7)**
+D1 `StartSurgeCliFailureTests` tests its own copy of the script · D2 `:524` assertion depends on a trailing quote · D3 `NoAlsaPathTests` is string-absence only · D4 no shellcheck anywhere · D5 CI installs one hand-picked package and hardcodes two shell tests · D6 `bash -n` on exactly one script · D7 nothing tests the udev rules
+
+**Touch UI (E1–E6)**
+E1 19 mixins · E2 133 `self.*` assignments · E3 `getattr` chains at `:484-489` and `:503-505` · E4 stated cause ("draw cannot know whether layout ran") · E5 dead per-frame import at `:450`, second at `:478` · E6 20 `threading.Thread` hits
+
+**Monitors (F1–F3)**
+F1 `EngineStateMonitor` 0.5s on tmpfs · F2 `LooperClockMonitor` 0.2s on `$HOME` (SD card) · F3 `looper_clock_monitor.py` misnamed; only surviving `looper_*` file
+
+**Architecture / spec conformance (G1–G7)**
+G1 tmpfs rationale and `BindsTo` reasoning · G2 bash↔Python parity pinned by tests · G3 D2 inventory honoured; nothing restarts Surge on a device-changing path · G4 two front-ends share one model layer by import · G5 `degraded` retired in both languages with a stale-file migration test · G6 the "analog-esque mixer" half of the product goal has no spec · G7 `Documents/specs/` inventory
+
+**Security (H1–H6)**
+H1 no shell-injection surface · H2 `nmcli` argv + `sudo -n` · H3 "five `sudo` call sites in four files; all use `sudo -n` or fixed argv" · H4 no network surface, all OSC on loopback · H5 Wi-Fi password visible in `/proc/<pid>/cmdline` · H6 RT privilege permitted, not forced
+
+**Performance (I1–I3)** · **DX (J1–J5)** · **Retry storm (K1)**
+
+---
+
+## Claim Verification
+
+### Git and process state
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| A1 | `Documents/specs/looper-jack-client-spec.md` is untracked | ✅ | `git status --porcelain` → `?? Documents/specs/looper-jack-client-spec.md` (plus `?? Documents/reviews/` and ` M .cursor/permissions.json`). 53,273 bytes on disk, in no commit. |
+| A2 | Branch `yolo/jack-drop-alsa-fallback` @ `1ab9f55` = `dev` @ `daac891` + 1 commit | ✅ | `git log --oneline dev..HEAD` → exactly `1ab9f55 refactor(audio-engine): remove ALSA entirely as a product audio path`. `daac891` is the PR #49 merge. |
+| A3 | HEAD reverses Phase 1 goal 2 and deletes the Gate-B-proven fallback arm | ✅ | `jack-audio-engine-spec.md:142-145`: *"~~The instrument never boots silent…~~ **RETIRED 2026-08-13.** Reversed by design."* `start-surge-cli.sh:9-14` states the same in the script header. No fallback branch survives (`NoAlsaPathTests` + my own read of `start-surge-cli.sh:114-154`). |
+| A4 | Gate C's five scenarios unrun; four Gate B PASS rows tested deleted code | ✅ (documentary) | Gate C list is verbatim at `jack-audio-engine-spec.md:452-459`, headed **"Required before merge — Gate C soak (not yet run)"**. Gate B rows `2a` (`:465`), `2d` (`:466`), `3` (`:469`), `2c` (`:472`) all describe `active=alsa` / `state=degraded` / `release-alsa-for-jackd` — none of which exist in the tree. 🔍 on *whether* Gate C ran: unverifiable from a laptop; the spec's own status line is the only evidence either way. |
+| A5 | 440 tests, 0 failures, ~42s, exit 0 | ✅ | I re-ran it: `mpe test local all` → `Ran 440 tests in 42.277s` / `OK`, plus both shell tests green. Matches the review's `42.113s` run. |
+| A6 | `CHANGELOG.md` claims 438 | ✅ | `CHANGELOG.md:71` — *"Full suite: 438 tests, 0 failures (`mpe test local all`)."* Actual 440. |
+| A7 | `mpe test coverage` output as quoted | ✅ | Reproduced verbatim: 60 modules, 16 registered-but-absent on unmerged branches, 2 shell tests, `OK`. |
+
+### `config/99-usb-audio.rules`
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| B1 | `ATTR{id}` reads sysfs, which is already unlinked on `remove`, so `ATTR{}` matches cannot succeed | ✅ | Standard udev semantics, not a repo fact — `ATTR{}` resolves against `/sys/$DEVPATH`, which is gone by the time the `remove` uevent is processed. Only `ENV{}` (restored from the udev database) survives. Nothing in the rules file or `install-udev-rules.sh` works around it. |
+| B2 | All four skip guards filter `add` only; every `remove` falls through to the generic rule | ✅ | ```ACTION=="add\|remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", ATTR{id}=="Loopback", GOTO="mpe_usb_audio_end"``` (`:21`) followed by ```ACTION=="remove", … RUN+="…/restart-audio-graph.sh"``` (`:27`). The `remove` half of each guard is inert; the generic rule is unguarded. |
+| B3 | `unload_snd_aloop_if_idle()` → `modprobe -r snd_aloop` restarts the graph at the end of every calibration | ✅ | `calibration_teardown.py:35` `subprocess.run(["sudo", "modprobe", "-r", "snd_aloop"], check=False)`, called from `restore_mpe_audio_services()` at `:69`. Module removal deletes the Loopback card → `remove` uevent → line 27 → `restart-audio-graph.sh` → `mpe_restart_audio_graph()`. The invariant it violates is written on `:20` of the rules file. 🔍 on hardware confirmation — the mechanism is sound but nobody has watched it happen on the Pi. |
+| B4 | Cited as `:19, 27` in §4.3 and `:16-19` in the backlog | ⚠️ | Off by two. The `Loopback` guard is line **21**, not 19; line 19 is the bare `UAC2` guard. The four guards span **17–21**, not 16–19. The quoted rule text is correct; only the anchors drift. |
+| B5 | Fix: "filter on kernel-supplied `ENV{}` properties (available on `remove`) instead of `ATTR{}`" | ⚠️ | Half right. `ENV{}` does survive `remove` (udev restores db properties), but **no kernel-supplied property carries the ALSA card `id`** — the `sound/cardN` uevent gives `DEVPATH`, `SUBSYSTEM`, `ACTION`, and little else, and this repo runs no rule that stamps `ID_*` onto sound devices earlier. As written, option 1 would need a *new* `add`-time rule to plant `ENV{MPE_SKIP_CARD}=1` first. The review's own option 2 (move the identity check into `restart-audio-graph.sh` against `/proc/asound/cards`) is the one that actually works, and the review is right that it collapses four filters into one testable place. Take option 2; do not attempt option 1 as stated. |
+
+### `scripts/surge-watchdog.sh`
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| C1 | Corrupt-defaults arm at `:97-105` moves user defaults aside on `is-failed` | ✅ | Exact quote matches `:97-104`: `if systemctl is-failed "$SURGE_SERVICE"` → `log "ALERT: Surge service failed, cleaning user defaults"` → `mv "$USER_DEFAULTS" "$BACKUP"`. |
+| C2 | `start-surge-cli.sh` exits 1 by design with no graph server | ✅ | `start-surge-cli.sh:147-154` — `ENGINE_STATE=failed`, two `CRITICAL:` log lines, `mpe_engine_state_write … failed "$ENGINE_REASON"`, `mpe_surge_state_write none ""`, `exit 1`. |
+| C3 | `Restart=on-failure`, `RestartSec=10`, `StartLimitBurst=5` / `StartLimitIntervalSec=300` | ✅ (line refs ⚠️) | All four keys present and correctly placed: `StartLimitBurst=5` / `StartLimitIntervalSec=300` at `surge-xt-cli.service:5-6` in `[Unit]`; `Restart=on-failure` / `RestartSec=10` at `:24-25`. The review cites `:6-7, 27-28` — off by one/two in both pairs. Substance intact. |
+| C4 | "Roughly 100s into any jackd outage, `is-failed` becomes true" | ⚠️ | Directionally right, arithmetic unverified. Each failed start costs the bounded JACK wait (`MPE_JACK_READY_TIMEOUT_DEFAULT=10`, `audio-engine.sh:32`) plus `RestartSec=10`, so the fifth attempt lands ~80–100s in — but `wait-for-usb-midi.sh` runs before the engine block (`start-surge-cli.sh:69-79`) and can add unbounded time. "~100s" is a reasonable floor, not a measured number. Nothing turns on the exact figure. |
+| C5 | `.corrupted_<ts>` files accumulate; nothing cleans them | ✅ | Repo-wide `grep -rn corrupted` returns exactly `surge-watchdog.sh:101` and `:103` (plus the review itself). No cleanup path, no `find -mtime`, no logrotate anywhere in `scripts/` or `config/`. |
+| C6 | `grep -rn corrupted` returns exactly those two lines | ✅ | Reproduced. |
+| C7 | The `RECONCILE_BUDGET` busy-wait stretches the `is-failed` arm to ~20s | ✅ | `RECONCILE_BUDGET="${MPE_RECONCILE_BUDGET_SEC:-15}"` (`:13`); `_reconcile_engine` sleeps 1s per iteration up to the budget (`:75-81`); the outer loop then adds `sleep 5` (`:117`). Both live in the same single-threaded `while true`. |
+| C8 | The 15s `RECONCILE_BUDGET` was left behind when settle moved 15s → 5s | ✅ | `MPE_ENGINE_JACKD_SETTLE_DEFAULT=5` with an explicit "was 15s" comment (`audio-engine.sh:336-341`) and the mirrored `JACKD_SETTLE_SEC = 5` in `audio_engine.py:32`. `RECONCILE_BUDGET` is still 15 with no comment and no mention in the spec's §Backlog. The review is also right that they are different knobs — this is a legibility trap, not a bug. |
+
+### Tests and CI
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| D1 | `test_jack_failure_exits_nonzero_and_publishes_failed` asserts against the test's own copy of the failure branch | ✅ | `tests/test_audio_engine.py:486-504` builds a bash `body` that re-declares `mpe_wait_for_jack_server() { return 1; }` and then hand-writes the three lines of the failure branch. `start-surge-cli.sh` is never executed. Renaming, reordering, or dropping `mpe_surge_state_write` in the real script leaves this test green. |
+| D2 | `:524` matches only when the path is followed by a double quote | ✅ | `self.assertNotIn("detect-audio-device.sh\"", text)` at `:524`. `bash $SCRIPT_DIR/detect-audio-device.sh` or a trailing space would slip straight past it. |
+| D3 | `NoAlsaPathTests` is ~15 string-absence assertions across five files | ✅ | `:423-481`. Six tokens for `start-surge-cli.sh`, seven for `audio-engine.sh`, four for the watchdog, two for the guard, three for `set-surge-audio.sh`. All `assertNotIn`. |
+| D4 | No shellcheck anywhere | ✅ | Absent from `.github/workflows/test.yml`, from `.cursor/`, and from every script; the only shellcheck strings in the repo are `# shellcheck source=` / `disable=` directives inside the scripts themselves. |
+| D5 | CI installs one hand-picked package; two hardcoded shell tests | ✅ | `.github/workflows/test.yml:19` `pip install python-osc`; `:29-30` names `test_gadget_persist.sh` and `test_prepare_dsi_display.sh` literally. `requirements.txt` exists and is unused by CI. |
+| D6 | `bash -n` runs on exactly one script | ✅ | `test_set_surge_audio_is_valid_bash` at `:473-480` is the only syntax check in the suite. |
+| D7 | Nothing tests the udev rules | ✅ | No test file references `99-usb-audio.rules`; `mpe test coverage` counts two shell tests, neither of which parses or simulates udev matching. |
+
+### Touch UI
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| E1 | 19 mixins | ✅ | `sed -n '67,87p' … \| grep -c 'Mixin,'` → **19**. |
+| E2 | 133 `self.*` assignments in the constructor | ✅ | `sed -n '60,300p' … \| grep -c '^        self\.'` → **133**, exactly the review's number and window. (Whole `__init__` is 131 by a different cut — the shape of the finding is unaffected.) |
+| E3 | Six `getattr` defaults and three cascading fallbacks at `:484-489`; same pattern at `:503-505` | ✅ | Quote is byte-accurate against `touch_browser_draw.py:484-489`, and `:503-505` repeats it (`self._draw_engine_hud(getattr(self, "engine_hud_rect", Rect(0, 0, 0, 0)))`). |
+| E4 | Cause: "the draw mixin cannot know whether the layout mixin has run" | ⚠️ | Stronger than stated, for a different reason. `self._layout()` is called from `__init__` at `touch_browser_app.py:248`, before any frame is drawn, and it unconditionally assigns `status_title_x` (`touch_browser_layout.py:101`), `looper_hud_rect` (`:127/135/137` — every branch), `engine_hud_rect` (`:142/150`), and `audio_profile_badge_rect` (`:153`). So the ordering hazard the review names **does not exist**; the `getattr` defaults are unconditionally unreachable. That makes the recommended deletion safer than the review implies, not riskier. |
+| E5 | Dead `is_recovering` import at `:450`; second function-local import at `:478` | ✅ | `is_recovering` appears exactly once in the whole package — the import itself. `:478` is `from patch_browser.usb_audio_recovery import status_subtitle`, called on the next line, inside `_draw_status_bar`. |
+| E6 | `grep -rn 'threading.Thread' patch_browser/` → 20 hits | ⚠️ | Actual **22** across 11 modules (`calibration_loader` 4, `touch_browser_prefs` 3, then pairs). Undercount; the point (many threads on a deadline-bound box) stands. |
+
+### Monitors
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| F1 | `EngineStateMonitor` polls tmpfs at 0.5s | ✅ | `POLL_INTERVAL_S = 0.5` (`engine_state_monitor.py:10`); `read_engine_state()` targets `/run/mpe/engine.state` (`audio_engine.py:24`). |
+| F2 | `LooperClockMonitor` polls `$HOME` at 0.2s — 5 Hz on the SD card | ✅ | `POLL_INTERVAL_S = 0.2` (`looper_clock_monitor.py:10`); `CLOCK_STATE_FILE = Path.home() / ".mpe_midi_clock_state.json"` (`midi_clock.py:19`). |
+| F3 | `looper_clock_monitor.py` is the only surviving `looper_*` file and is misnamed | ✅ | `git ls-files \| grep -i looper` → one path. It reads the `midi-clock-in` daemon's state, is imported at `touch_browser_app.py:28`, and drives a BPM badge. Nothing looper about it. |
+
+### Architecture and spec conformance
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| G1 | tmpfs rationale and the `BindsTo` rejection are correct and current | ✅ | `surge-watchdog.service:4` is `BindsTo=surge-xt-cli.service`, which is exactly the hazard `audio-engine.sh:9-12` names. `surge-xt-cli.service:3-4` carries `Wants=`/`After=` with no `Requires`, matching the amended rationale at spec `:298-310`. |
+| G2 | The bash/Python cooldown duplication is pinned by parity tests | ✅ | `mpe_engine_reconcile_decision()` (`audio-engine.sh:369-392`) and `reconcile_cooldown_decide()` (`audio_engine.py:52-76`) evaluate the same four rules in the same order; `BashReconcileParityTests` runs both. |
+| G3 | D2 honoured: nothing in `scripts/` or `patch_browser/` restarts `surge-xt-cli` on a device-changing path | ⚠️ | The device-changing half is true and I re-verified every site: `set-audio-profile.sh:57` and `uac2-stall-watchdog.sh:67` call `restart_audio_graph`, `set-surge-audio.sh:129` calls `mpe_restart_audio_graph`, and the udev rule routes through `restart-audio-graph.sh`. But the sweeping phrasing hides two direct Surge restarters the review never mentions: `surge_monitor.py:167` (`sudo systemctl restart surge-xt-cli.service`, user-triggered — see MISSED-1) and `mpe-services.sh:121` (deploy helper). Neither is device-driven, so D2 holds; the inventory as stated does not. |
+| G4 | The two front-ends share the model layer by import, not duplication | ✅ | `patch_browser_ui.py:30-42` imports `PatchLoader`, `PatchScanner`, and `SurgeMonitor` from `patch_browser/`. No second implementation. |
+| G5 | `degraded` retired in both languages with a stale-state-file test | ✅ | `VALID_ENGINE_STATES = frozenset({"ok", "recovering", "failed"})` (`audio_engine.py:21`); watchdog asserted free of the token (`test_audio_engine.py:456`). |
+| G6 | The "analog-esque mixer" half of the product goal has no spec, no code, no plan | ⚠️ | Every *code* fact checks out: `mixer.py` is a 20-line `MixerChannel` dataclass; `mixer_controls.py` is 340 lines; `touch_browser_mixer.py` is 128; `README.md:57` describes them as per-patch Vol/Tail/Touch faders; no spec in `Documents/specs/` covers buses, summing, or gain staging. But **"analog-esque mixer" appears nowhere in the repository** — `grep -ri` finds it only inside the two review documents. `README.md:3` and `AGENTS.md:5` state the product as "MPE sound module," full stop. This is a gap between Mitch's verbal framing and the repo, which is worth naming, but the review presents it as a documented product goal that the codebase abandoned. It is a planning question, not a code defect, and it cannot be adjudicated against this repo at all. |
+| G7 | "`Documents/specs/` holds four specs: the JACK engine, the looper JACK client, and three touch-browser docs" | ⚠️ | Self-contradicting sentence: it says four and lists five. `ls` confirms **five** files. Trivial, but it appears inside the 🔴 mixer finding. |
+
+### Security
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| H1 | No shell-injection surface — `shell=True`, `os.system`, `eval` all absent | ✅ | Reproduced across `patch_browser/`: zero matches. Every subprocess call I read is an argv list. |
+| H2 | Wi-Fi credentials reach `nmcli` as argv with `sudo -n`, never interpolated | ✅ | `wifi_manager.py:32` `prefix = ["sudo", "-n", "nmcli"] if use_sudo else ["nmcli"]`; password passed as a list element. |
+| H3 | "Five `sudo` call sites across the whole Python layer, in four files (`wifi_manager.py`, `calibration_loopback.py`, `touch_browser_app.py`, `audio_profile.py`). All use `sudo -n` or fixed argv." | ❌ | Wrong on both counts. `sudo` appears in **nine** files — `wifi_manager.py` (20), `calibration_teardown.py` (8), `dsi_splash.py` (4), `audio_profile.py` (2), `calibration_loopback.py` (2), and one each in `touch_browser_app.py`, `surge_audio.py`, `midi_sync_settings.py`, `surge_monitor.py` — with well over a dozen distinct invocation sites (`calibration_teardown.py` alone has seven at `:35, 48, 50, 67, 70, 71, 72, 74`). And only `wifi_manager.py` uses `-n`; every other site is a bare `sudo`, which on an appliance without passwordless sudo blocks rather than failing fast — the exact hazard `mpe_systemctl` (`audio-engine.sh:292-298`) was written to avoid on the shell side. The **conclusion** survives: every one of those sites is a fixed argv list, so there is still no injection surface. The enumeration that made the conclusion feel audited does not. |
+| H4 | No network surface; every OSC binding is loopback | ✅ | Every `SimpleUDPClient` / `sock.bind` in `patch_browser/` and `scripts/` uses `127.0.0.1`; zero `0.0.0.0` in the repo. |
+| H5 | Wi-Fi password visible in `/proc/<pid>/cmdline` | ✅ | Consequence of H2's argv approach; correctly rated 🟢 for a single-user appliance. |
+| H6 | RT privilege permitted, not forced; jackd priority validated | ✅ (with a gap — see MISSED-6) | `LimitRTPRIO=95` / `LimitMEMLOCK=infinity` on both units with the PAM-bypass comment; `MPE_JACK_RT_PRIORITY_DEFAULT=70`; no `chrt` anywhere in `start-surge-cli.sh`. |
+
+### Performance
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| I1 | `jackd -s` softmode kept deliberately | ✅ | `start-jackd.sh:43` — `exec jackd -R -P"$JACK_PRIO" -s …`. |
+| I2 | Recovery measured ~39s (`pkill jackd`) and ~55–60s (double failure) against a 15s budget | ✅ | Gate B rows at spec `:463` and `:472`; `:464` records Mitch calling DAC replug "very slow". The spec's §Backlog concedes the miss. |
+| I3 | D6 buffer split implemented; `--buffer-size=` gone from Surge argv | ✅ | `mpe_jack_period` / `mpe_jack_periods` feed `start-jackd.sh:43-44`; `SURGE_AUDIO_ARGS` (`start-surge-cli.sh:129-132`) carries only `--audio-interface` and `--sample-rate`; absence asserted at `test_audio_engine.py:434`. |
+
+### Developer experience
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| J1 | "`logs/`, `data/`, `.pytest_cache/` are committed directories" | ❌ | `git ls-files logs data .pytest_cache` returns exactly one path: `data/patch_metadata_baseline.json` — a legitimate test fixture. `logs/` contents are gitignored (`.gitignore` names `logs/shutdown-trace.jsonl` and the marker); `.pytest_cache/` self-ignores via the `.gitignore` pytest writes into it, which is why it never shows in `git status`. Three directories exist on disk; **none of them is a committed directory in the sense the finding implies**. |
+| J2 | `docs/` carries 30 files | ⚠️ | 31. |
+| J3 | `config/` mixes unit templates with device data | ✅ | `config/patch_normalization.json` plus two tracked `pi-backup-2026-07-31/-08-02` snapshots sit beside the `.service` templates; `.gitignore`'s closing line explains the choice. |
+| J4 | Repo-root clutter; two documentation trees, now three | ✅ | Root holds `ENCODER_BUTTON_REVIEW.md`, `REFERENCE_BOM.md`, `FAQ.md`, `COMMANDS.md`, four animation/splash scripts, `touch_patch_browser.py`, `patch_browser_ui.py`, and `setup-i2c-early.sh` alongside the package dirs. `docs/` (31), `Documents/specs/` (5), `Documents/reviews/` (2). |
+| J5 | `docs/AUDIO-ENGINE-FOUNDATION.md` is cross-branch only; `docs/measurements/` does not exist | ✅ | `git ls-files \| grep AUDIO-ENGINE-FOUNDATION` → nothing on this branch; `git ls-tree -r --name-only yolo/looper-phase0` → `docs/AUDIO-ENGINE-FOUNDATION.md`. `docs/measurements` does not exist. Both admitted honestly in the spec at `:118-127`. |
+
+### Retry storm
+
+| # | Claim | Verdict | Evidence |
+|---|---|---|---|
+| K1 | With no DAC, a permanent ~18s prestart/restart loop writes to the journal forever | ✅ | `jackd-prestart.sh:25` `WAIT_SECONDS=15`, loop at `:41-48`, `exit 1` at `:57-61`; `mpe-jackd.service:15` `StartLimitIntervalSec=0`, `:40-41` `Restart=always` / `RestartSec=3`. The review correctly endorses the trade and asks only for backoff. |
+
+---
+
+## Severity Re-Assessment
+
+| # | Issue | Reviewer | Mine | Delta | Reasoning |
+|---|---|---|---|---|---|
+| 4.1 | Phase 2 spec untracked | 🔴 | **High** | agree | 869 lines of design in one working tree with no second copy. Genuinely a five-second fix — but see MISSED-5: committing it *as-is* lands a spec that is already stale against yesterday's amendment. |
+| 4.2 | Hard-failure design never soaked | 🔴 | **Critical** | agree, and I'd go further | This is the finding. The spec blocks its own merge in bold; the only automated evidence is a test of a copy of the code (4.5). Everything else in this document is secondary to it. |
+| 4.3 | udev `remove` blind spot | 🔴 | **High** | agree | Real, mechanically certain, silently violates a stated invariant, and fires on a routine user workflow. Not Critical only because the failure mode is ~30s of silence during calibration teardown, not data loss. |
+| 4.4 | Watchdog discards user defaults | 🔴 | **High** | agree | Real user-data destruction on a routine cable fault, and worse than described (MISSED-2). Not Critical because Surge defaults are small and regenerable, and the "destroyed" file is preserved under a `.corrupted_*` name — it is misfiling, not deletion. |
+| — | Mixer has no spec | 🔴 | **Low (as a repo finding)** | **inflated** | The code observations are accurate but the goal being measured against is not in the repository. This is a product conversation for Mitch, not a defect on this branch, and it should not sit in a 🔴 list beside an unsoaked failure path. Reclassify as an open product question. |
+| 4.5 | Test re-implements the script | 🟡 | **High** | **deflated** | The review rates this 🟡 for docstring honesty and then, in §4.2 and the Verdict, leans on it as the *reason* criterion 2\* is unverified. It cannot be both a minor style issue and the load-bearing gap in the repo's most important failure path. It is the automated half of 4.2 and should carry 4.2's weight. |
+| 4.6 | 19 mixins / 133 assignments | 🟡 | **Low** | **inflated for this project** | Accurate measurement, real long-term cost, zero current defect. On a solo appliance project with 440 green tests and a candid refactor plan that already lists the Protocol work as Deferred, this is backlog. Big-team standard applied to a one-person tree. |
+| 4.7 | `getattr` layout chain | 🟡 | **Low** | agree on rating | Confirmed, and E4 shows it is provably dead code rather than a live ordering risk — which makes it a safe, satisfying 20-minute cleanup rather than a hazard. |
+| 4.8 | 5 Hz SD-card poller | 🟡 | **Medium** | agree | The one finding whose cost lands on the thing the whole branch exists to protect (a 256-frame deadline). Fix is trivial (`/run/mpe/` + 0.5s) and compounds with MISSED-3. |
+| 4.9 | CI weaker than local gate | 🟡 | **Medium** | agree | The missing shellcheck matters most: ~60 shell scripts carry the audio engine and the repo's own ALSA-removal commit shipped a call to a deleted function. |
+| 4.10 | Teardown/jackd race | 🟡 | **Medium** | agree | Only dangerous composed with 4.3; the review says so explicitly and orders the fix correctly. |
+| 4.11 | Dead per-frame import | 🟢 | **Negligible** | agree | And there are two more of the same class the review missed (MISSED-4). |
+| 4.12 | `looper_clock_monitor` misnamed | 🟢 | **Low** | agree | Cheap now, expensive after `yolo/looper-phase0` lands real `looper_*` siblings. Rename before that merge. |
+| 4.13 | Stale CHANGELOG count | 🟢 | **Negligible** | agree | 438 vs 440. Confirmed. |
+| 4.14 | Unbounded no-DAC retry | 🟢 | **Low** | agree | Correct call on the trade; the ask is only backoff. Compounds with MISSED-3 on SD-card writes. |
+| §7 | Wi-Fi password in argv | 🟢 | **Negligible** | agree | Proportionate to a physical-access threat model, and named deliberately. |
+
+---
+
+## What the Review Missed
+
+Six items. Two of them are consequential.
+
+**MISSED-1 — A second, uncoordinated Surge restarter, reachable from a button on the touch screen. (High.)**
+The entire D3 cooldown design — 90s spacing, a 3-restart budget, tmpfs state that survives `BindsTo` — exists so that no supervisor can burn `StartLimitBurst=5` and leave Surge dead. `SurgeMonitor.restart_surge()` participates in none of it:
+
+```163:171:patch_browser/surge_monitor.py
+    def restart_surge(self):
+        try:
+            print("Attempting to restart Surge XT CLI...")
+            result = subprocess.run(
+                ["sudo", "systemctl", "restart", "surge-xt-cli.service"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+```
+
+It is wired to a UI action in both front-ends — `touch_browser_input.py:318` (`elif hit == "surge_restart":`) and `patch_browser_ui.py:1036` — and gated only on `can_restart`, which `get_status_summary()` sets to `True` whenever Surge is not live (`surge_monitor.py:199`). Post-amendment that is precisely the state a jackd outage produces. So during a DAC problem the appliance shows the user a Restart button, and each tap consumes one of the five starts the cooldown table is budgeted against, with no record in `/run/mpe/engine-reconcile.state`. The review checked that nothing restarts Surge on a *device-changing* path and concluded the inventory was clean; it never asked who else restarts Surge for any other reason.
+
+**MISSED-2 — 4.4 is worse than described: the `mv` happens before the cooldown decision, so it repeats. (Amplifies a confirmed 🔴.)**
+In `surge-watchdog.sh:97-106` the defaults file is moved aside *unconditionally* on `is-failed`, and only then is `_supervisor_restart_surge` consulted — which may return `cooldown`, `jackd-settling`, or `failed` and do nothing. Meanwhile `start-surge-cli.sh:59-67` writes a fresh empty skeleton on every start. The cycle is therefore: unit fails → move defaults → restart → skeleton created → fails again → move the skeleton → …, producing one `.corrupted_<timestamp>` file per supervisor cycle rather than one per outage, plus an `ALERT: Surge service failed, cleaning user defaults` line on every 5s poll for the duration. The review's fix (gate on `mpe_engine_state_get state`/`reason`) still resolves it, but the finding should be written as repeated destruction, not a single misfiling.
+
+**MISSED-3 — `$HOME/surge-watchdog.log` is unbounded, on the SD card, with no rotation anywhere in the repo. (Medium.)**
+`LOG_FILE="${MPE_WATCHDOG_LOG:-$HOME/surge-watchdog.log}"` (`:12`), and `log()` (`:15-18`) writes to that file *and* stdout (→ journal, since the unit is `StandardOutput=journal` by default). A repo-wide grep for `logrotate`, `SizeMax`, or any `find -mtime` cleanup returns nothing. During the outage described in 4.4 that is roughly 12 file appends per minute forever. The review raised SD-card write pressure (4.8) and journal growth (4.14) as two separate small findings and missed the third instance, which is the one that runs on the failure path the branch is built around.
+
+**MISSED-4 — Two more dead imports, same class as 4.11.**
+`engine_state_monitor.py:6` and `looper_clock_monitor.py:6` both `import time`; neither module contains a single `time.` reference (both use `Event.wait()`). The review read both files closely enough to quote their poll intervals and their `Event`-based shutdown, and praised them as "correct little threaded pollers."
+
+**MISSED-5 — The untracked Phase 2 spec is also *stale*, which changes the top recommendation.**
+The review's P1 is "commit it today, before anything else in this document gets acted on," and it praises the document at length. But `looper-jack-client-spec.md` predates the 2026-08-13 amendment and still plans around the variable that amendment abolished: `:80` scopes the work as "remove auto-fallback and keep `MPE_AUDIO_ENGINE=alsa` as an explicit operator choice"; criterion 11 at `:100` verifies a boot "with `MPE_AUDIO_ENGINE=jack` unset (default)"; `:694` analyses the effects of retaining it. Committing it verbatim puts a stale plan on `dev` carrying the newest timestamp in `Documents/specs/` — the exact failure mode the review warns about elsewhere. Commit it (the loss risk is real), but amend §D.5 and criterion 11 in the same commit.
+
+**MISSED-6 — Two smaller correctness gaps in code the review praised.**
+
+- *Read-modify-write on `engine.state` with no lock.* The review credits `mpe_state_write_atomic()` for atomic whole-file installs, which is true. But `surge-watchdog.sh:44` and `:52` do `mpe_engine_state_write "$MPE_ENGINE_NAME" "$(mpe_engine_state_get active)" …` — read one field, then rewrite the whole file — while `start-jackd.sh:35-41` performs its own read-then-write of the same file. Each *write* is atomic; the *sequence* is not, so a jackd restart landing between the watchdog's read and its write silently reverts `active`. The window is milliseconds and the blast radius is a wrong HUD badge for one poll, so this is Low — but it is the shared-state mutation hazard the review's atomicity praise implies does not exist.
+- *`mpe_jack_rt_priority()` validates digits but not range.* `audio-engine.sh:67-72` accepts any all-digit string, so `MPE_JACK_RT_PRIORITY=99` passes validation and then dies against `LimitRTPRIO=95` at exec time, and `MPE_JACK_RT_PRIORITY=94` would quietly place jackd above the ceiling the review says "matters" for keeping SSH and the touch UI schedulable. Every sibling validator in the file (`mpe_jack_period`, `mpe_jack_periods`, `mpe_jack_rate`) uses an explicit value allowlist. Low, one-line fix.
+
+**Checked and clean — no finding:** authentication/authorization (none exists; single-user appliance), unvalidated external input (Wi-Fi is the only external string and it is argv-safe), exposed secrets (`.gitignore` blocks key material; `config/mpe.env` is ignored while `mpe.env.example` is tracked), circular imports (`patch_browser_ui.py` imports downward into the package only), off-by-one in the cooldown table (both implementations agree with the spec table and with each other, and the `>=`/`<` polarities are correct in all four rules).
+
+---
+
+## What the Review Got Right (And Why It Matters)
+
+**4.2 — the unsoaked reversal — is correctly identified as the central risk, and the review's framing of it is better than a defect list.** The compound shape is what makes it dangerous: the amendment deleted the fallback arm, the Gate B log's four PASS rows for failure behaviour now describe code that does not exist, the replacement criterion's only automated evidence is a test of a copy of the script, and the branch is one merge away from `dev`. Each of those is defensible alone. Together they mean the appliance's behaviour on the failure a gigging musician actually cares about — the DAC dies mid-set — is currently inferred from prose. If this merges unsoaked, the first real evidence arrives on stage.
+
+**4.3 and 4.4 are the two findings a spec review could never have produced.** Both are amendment side-effects on code that was correct the day before. 4.3 is a pre-existing udev bug that only became load-bearing once "restart the graph" started meaning "restart the only audio path"; 4.4 is a precondition change — "Surge exits non-zero" went from anomaly to routine — quietly invalidating a distant heuristic. Left alone they compound with each other and with 4.10: a calibration teardown fires a `remove`, the graph restarts, Surge races a 10s readiness wait against a ~6s jackd start, and if it loses often enough the watchdog eventually starts filing the user's defaults as corrupt. That's four confirmed findings on one workflow, and only 4.3 needs to be fixed for the chain to break.
+
+**The `RECONCILE_BUDGET` observation (C7/C8) is the kind of thing that only comes from reading the loop rather than the functions.** Two constants that look like the same knob, one of which was tuned and one of which wasn't, inside a single-threaded loop whose outer cadence silently changes during the exact fault the tuning was for. Nothing tests it and no spec mentions it.
+
+**The review's restraint is worth as much as its findings.** It declined to call `jackd -s`, the `Restart=always` retry loop, the bash/Python duplication, or the argv Wi-Fi password defects, and in each case named the reasoning that makes them right. It said out loud what it could not verify from a laptop. A review that flagged everything would have buried 4.2.
+
+---
+
+## Prioritized Action Matrix
+
+| Priority | Issue | Verdict | Effort | Depends On |
+|---|---|---|---|---|
+| **P0** | Run the Gate C soak (5 scenarios, `jack-audio-engine-spec.md:452-459`) before `yolo/jack-drop-alsa-fallback` merges to `dev` (4.2) | ✅ | multi-day (Pi time) | Nothing — the scenarios are already written in order |
+| **P0** | Fix the udev `remove` blind spot — move the card-identity check into `restart-audio-graph.sh` against `/proc/asound/cards`; do **not** use the `ENV{}` option as written (4.3 / B5) | ✅ | half-day | Nothing |
+| **P0** | Gate the watchdog's corrupt-defaults arm on `mpe_engine_state_get state`/`reason`, and move the `mv` *after* the cooldown decision (4.4 + MISSED-2) | ✅ | quick fix | Nothing |
+| **P1** | Commit `Documents/specs/looper-jack-client-spec.md` **and** amend its §D.5 / criterion 11 off the retired `MPE_AUDIO_ENGINE` in the same commit (4.1 + MISSED-5) | ✅ | quick fix | Nothing |
+| **P1** | Route `SurgeMonitor.restart_surge()` through the supervisor cooldown, or disable the UI Restart action when `engine.state` is `failed` with `reason=no-server`/`no-jack-device` (MISSED-1) | ✅ | half-day | Shares the state-read helper with the P0 watchdog fix |
+| **P1** | Make criterion 2\*'s failure path testable for real — extract the engine-resolution + state-publish sequence into a sourceable function in `audio-engine.sh` and test that (4.5) | ✅ | half-day | Best done before Gate C so the soak and the test check the same code |
+| **P1** | Add shellcheck over `scripts/` + `config/*.service` to CI, glob the shell tests, install from `requirements.txt` (4.9) | ✅ | half-day | Nothing |
+| **P2** | Move the MIDI clock state file to `/run/mpe/` and drop the poll to 0.5s (4.8) | ✅ | quick fix | Coordinate with the `midi-clock-in` daemon's writer |
+| **P2** | Bound `$HOME/surge-watchdog.log` — rotate, cap, or drop the file and rely on the journal (MISSED-3) | ✅ | quick fix | Nothing |
+| **P2** | Explicit `systemctl start mpe-jackd.service` + bounded readiness wait in `restore_mpe_audio_services()` (4.10) | ✅ | quick fix | 4.3 first |
+| **P2** | Back off `RestartSec` or throttle logging after N consecutive prestart failures (4.14) | ✅ | quick fix | Nothing |
+| **P2** | Rename `looper_clock_monitor.py` → `midi_clock_monitor.py` (4.12) | ✅ | quick fix | Land before `yolo/looper-phase0` merges |
+| **P2** | Decide whether the mixer rides on the JACK graph or is a separate surface, and write it down somewhere in the repo (mixer finding, reframed) | ⚠️ | half-day (decision, not code) | Mitch — this is a product call, not an engineering one |
+| **P3** | Delete the dead `getattr` chain at `touch_browser_draw.py:484-489` and `:503-505` (4.7) | ✅ | quick fix | None — `_layout()` provably runs first |
+| **P3** | Delete the three dead imports: `touch_browser_draw.py:450`, `engine_state_monitor.py:6`, `looper_clock_monitor.py:6`; hoist `:478` (4.11 + MISSED-4) | ✅ | quick fix | Nothing |
+| **P3** | Give `mpe_jack_rt_priority()` a bounded allowlist like its siblings (MISSED-6) | ⚠️ | quick fix | Nothing |
+| **P3** | Reconcile `RECONCILE_BUDGET=15` with the 5s settle, or comment why they differ (C8) | ✅ | quick fix | Post-Gate-C, when real recovery numbers exist |
+| **P3** | Update `CHANGELOG.md:71` to 440, or stop quoting exact counts (4.13) | ✅ | quick fix | Nothing |
+| **P3** | Protocol for the mixin `self` surface; start extracting cohesive state (4.6) | ✅ | refactor project | Only worth starting if mypy lands |
+
+---
+
+## Disagreements and Judgment Calls
+
+**1. The mixer finding does not belong in the 🔴 list.** The review's five 🔴s are four verifiable code/process defects and one product-strategy question measured against a phrase that exists nowhere in the repository. Mixing them costs the other four: a reader triaging five "stop what you're doing" items will discount all of them when one turns out to be "we should decide what the product is." Keep the observation — it is a good one, and the naming collision with the per-patch fader UI is a real trap — but file it as an open product question for Mitch, not as a branch defect.
+
+**2. 4.5 is under-rated and 4.6 is over-rated, and swapping them would improve the document.** The review's own argument makes 4.5 the automated half of its Critical finding, then rates it 🟡 because the docstring is honest. Honesty is a reason to trust the author, not a reason to downgrade the gap. Conversely 4.6 (19 mixins) is a measurement without a symptom on a solo project whose refactor plan already lists the fix as Deferred; 🟡 imports a big-team review standard into a one-person appliance repo. The immediate consequence 4.6 cites — 4.7's `getattr` chain — turns out to be dead code that runs after `_layout()` has already assigned every rect.
+
+**3. Do not implement 4.3's first proposed fix.** "Filter on kernel-supplied `ENV{}` properties (available on `remove`)" reads as though the card identity is sitting in the uevent. It is not — `ENV{}` on `remove` returns what udev previously *stored in its database*, and nothing in this repo stamps a card-id property at `add` time. Anyone who takes option 1 at face value will write four `ENV{}` rules that match nothing and conclude the bug is fixed, which is strictly worse than today, where at least the failure is loud. Option 2 (the check inside `restart-audio-graph.sh`) is correct, is one filter instead of four, and is testable from a laptop — which also closes D7.
+
+**4. "Commit the spec today, before anything else" needs one amendment attached.** The urgency is right — an untracked 869-line design document is one `git clean -fd` from gone. But the review spent several paragraphs praising that document and never diffed it against the amendment it postdates by a day. Committing it unchanged publishes a stale plan with the freshest mtime in `Documents/specs/`, and the next session will read the newest-looking file. Commit and amend in one go; it adds ten minutes.
+
+**5. I'd sequence the P0s differently than the review's backlog.** Its order is spec-commit → Gate C → udev → watchdog → mixer spec. I'd fix 4.3 and 4.4 *before* running Gate C, not after. Both are cheap, both are on the failure paths Gate C exercises, and soaking a branch you already know you are about to change means either soaking it twice or shipping a soak result that does not describe what merges. The spec commit is genuinely five seconds and can happen at any point.
+
+**6. Where I'd defend the codebase against the review's implied standard.** The 🟢 items — the argv Wi-Fi password, the unbounded no-DAC retry, the function-local import — are all correctly rated and all correctly *reasoned*, and I want to be explicit that I checked each and agree they are not defects. On an appliance whose threat model is physical access and whose operator is its author, `sudo nmcli` with the password in argv is the proportionate choice, and `Restart=always` with no start limit is the right trade for a jackd that must recover when the DAC comes back. The review says so. That restraint is why the 🔴s are worth acting on.
+
+---
+
+## Bottom Line
+
+The Opus review is trustworthy. Of 65 discrete claims I could check, 48 verified exactly, 12 were true with an overstatement or a drifted line number, 3 were wrong, and 2 could not be settled from a laptop. Every 🔴 that is a code or process claim — the untracked spec, the unsoaked reversal, the udev `remove` blind spot, the watchdog's defaults destruction — is real, and the two bugs are of a kind that only a careful post-amendment read produces. The three ❌s are all in the "praise" sections rather than the findings: the `sudo` inventory is off by a factor of three, `logs/`/`.pytest_cache/` are not committed, and the mixer finding measures the repo against a goal the repo never states. That pattern is worth noting for next time — the review audited its criticisms harder than it audited its compliments — but it does not undermine the action items. Fix 4.3 and 4.4, then run Gate C.

--- a/Documents/reviews/synthesis-2026-08-13.md
+++ b/Documents/reviews/synthesis-2026-08-13.md
@@ -1,0 +1,235 @@
+# MPE-Module Codebase Review Synthesis
+
+*Synthesis date: 2026-08-13 (America/Toronto)*  
+*Branch reviewed: `yolo/jack-drop-alsa-fallback` @ `1ab9f55`*  
+*Sources: four artifacts from the 2026-08-13 dual-model review + dual-audit pass*
+
+---
+
+## 1. Executive Summary
+
+The merged Phase 1 JACK audio engine on `yolo/jack-drop-alsa-fallback` is **architecturally coherent and remarkably clean for a post-merge tree**. Both independent reviews searched for the usual wreckage — surviving ALSA branches, duplicate engine paths, merge conflict markers, orphaned state machines — and found almost none. The D2 inventory ("restart jackd, not Surge on device-changing paths") is honoured in code; `degraded` is retired in both bash and Python with a stale-state migration test; 440 tests pass in ~42 s; security on the appliance surface is clean. Whatever felt "twisted up" in the merge lives in branch topology and forward planning, not in the tree itself.
+
+The central risk is **verification debt, not architecture**. The 2026-08-13 amendment reversed Phase 1's second-highest goal — "the instrument never boots silent" became "the instrument is silent and says so" — which deleted the exact fallback arm that Gate B spent a day proving. Five Gate C soak scenarios (`jack-audio-engine-spec.md:452-459`) that would validate the replacement behaviour have **not run**, and the spec blocks merge in bold. The instrument's behaviour on its most important failure path is currently a hypothesis defended by unit tests and prose, including one test that re-implements the script it claims to cover (`tests/test_audio_engine.py:486-504`). Two real bugs compound this: a udev `remove`-event blind spot in `config/99-usb-audio.rules` (Opus review + audit) and a probable jackd duplex-open regression against the `usb-host-session` mic bridge (Kimi review + audit). Both are amendment side-effects on code that was correct the day before.
+
+**Headline verdict on phase-one state vs plan:** Phase 1 **landed in code** and matches the spec's phase structure as amended — criteria 2a/2c/2d/3 are cleanly retired, criterion 2* is wired end-to-end, D6 buffer split is implemented on the bash side, and the supervisor cooldown math is correct. Phase 1 is **not verified** for the amendment's new failure semantics, and two falsification-table assumptions (5b UAC2 capture, session-capture half of 14) remain open while Phase 2 planning proceeds. The "sound module" half of the product is on a credible, measured path; the "analog-esque mixer" half has no spec in the repository and is a product conversation, not a branch defect. **Do not merge to `dev` without Gate C soak; fix udev and watchdog issues before soaking, not after.**
+
+---
+
+## 2. High-Confidence Findings (Both Reviews + Both Audits Agree)
+
+These items appear in both reviews and were confirmed by both audits with ✅ verdicts (or documentary ✅ where hardware-only).
+
+- **Merge cleanliness — no structural damage from Phase 1 + amendment**
+  - No surviving ALSA fallback branch; `MPE_AUDIO_ENGINE` read nowhere in consumers (`NoAlsaPathTests`, grep-verified).
+  - No merge conflict markers; no duplicate engine paths; `VALID_ENGINE_STATES = {"ok", "recovering", "failed"}` in both languages.
+  - D2 call-site inventory honoured: `set-audio-profile.sh:57`, `set-surge-audio.sh:129`, `uac2-stall-watchdog.sh:67`, `99-usb-audio.rules:26-27` all route through graph restart.
+  - Evidence: both reviews §First Impressions / §Spec Conformance; Kimi audit claims 52, 50; Opus audit G3, G5.
+
+- **Gate C soak is the merge blocker — hard-failure path never exercised on hardware**
+  - Spec states **REQUIRES PI SOAK BEFORE MERGE** (`jack-audio-engine-spec.md:102-108`); five scenarios listed at `:452-459`, zero run.
+  - Gate B PASS rows for 2a, 2d, 3, and half of 2c tested code paths that no longer exist.
+  - Criterion 2* (`start-surge-cli.sh:147-154` → `state=failed`, promote on unmask) is landed in code only.
+  - Both audits rate this Critical/High and agree: green unit tests are not hardware evidence.
+  - Evidence: Opus 4.2, A4; Kimi Spec Conformance row 2*; both audit P0 rows.
+
+- **Phase 2 looper spec is untracked and stale**
+  - `git status` → `?? Documents/specs/looper-jack-client-spec.md` (869 lines, ~53 KB).
+  - Stale against 2026-08-13 amendment: §D.5 still scopes `MPE_AUDIO_ENGINE=alsa`; criterion 11 references unset `MPE_AUDIO_ENGINE=jack`; §D.5.2 quotes old guard message; §D.5.3 analyzes removed `resolve_audio_engine` parameter.
+  - Opus audit MISSED-5: committing verbatim publishes the newest-looking stalest document.
+  - Evidence: Opus 4.1, A1; Kimi Hall of Shame #4, audit claims 15–19; Opus audit 4.1 + MISSED-5.
+
+- **440 tests pass; suite is a genuine gate**
+  - `mpe test local all` → 440 tests, 0 failures, ~42 s (reproduced by both audits).
+  - `test_audio_engine.py` (704 lines) is the model file: bash parity, `NoAlsaPathTests`, unit-content assertions.
+  - Evidence: Opus A5; Kimi audit claim 36; Opus audit A5, A7.
+
+- **Supervisor cooldown design is correct and parity-pinned**
+  - `mpe_engine_reconcile_decision()` (`audio-engine.sh:369-392`) ↔ `reconcile_cooldown_decide()` (`audio_engine.py:52-76`); `BashReconcileParityTests` runs both.
+  - tmpfs state rationale for `BindsTo` hazard is implemented as spec'd.
+  - Evidence: both reviews §Architecture; Opus audit G1, G2; Kimi audit claims 30–31, 38.
+
+- **Branch identity**
+  - `yolo/jack-drop-alsa-fallback` @ `1ab9f55` = `dev` @ `daac891` + 1 commit (ALSA removal amendment).
+  - Evidence: Opus audit A2; Kimi audit (same commit verified).
+
+---
+
+## 3. Unique Findings by Source
+
+### Opus Grumpy Review — findings Kimi did not raise
+
+| Finding | Audit status | Notes |
+|---------|--------------|-------|
+| **4.3 — udev `remove` blind spot** (`99-usb-audio.rules:17-27`): `ATTR{id}` cannot match on `remove`; all four skip guards leak; `modprobe -r snd_aloop` in `calibration_teardown.py:35` restarts graph after every calibration | ✅ verified (Opus audit B1–B3) | Kimi audit did not evaluate udev rules |
+| **4.4 — Watchdog discards Surge user defaults** (`surge-watchdog.sh:97-105`): post-amendment, routine jackd outage → `is-failed` → `.corrupted_*` misfiling | ✅ verified (Opus audit C1–C6); ⚠️ amplified by MISSED-2 (repeats per cycle) | Unique high-value catch |
+| **4.5 — Test re-implements `start-surge-cli.sh` failure branch** (`test_audio_engine.py:486-504`) | ✅ verified (Opus audit D1) | Opus audit re-rates 🟡 → **High** (automated half of 4.2) |
+| **4.8 — 5 Hz SD-card poller** (`looper_clock_monitor.py:10`, `$HOME/.mpe_midi_clock_state.json`) | ✅ verified (Opus audit F2) | Kimi noted 0.5 s engine monitor only |
+| **4.9 — CI weaker than local** (no shellcheck, hardcoded shell tests, `requirements.txt` unused) | ✅ verified (Opus audit D4–D6) | |
+| **4.10 — Calibration teardown / jackd race** (`calibration_teardown.py:67-72`) | ✅ verified; meaningful only composed with 4.3 | |
+| **MISSED-1 — UI Surge restart bypasses cooldown** (`surge_monitor.py:167`, touch + OLED) | ✅ verified (Opus audit) | Not in Opus review; found by Opus audit only |
+| **MISSED-3 — Unbounded `$HOME/surge-watchdog.log` on SD card** | ✅ verified (Opus audit) | |
+| **🔴 Mixer has no spec** (20-line `MixerChannel` dataclass vs product goal) | ⚠️ partial (Opus audit G6): code facts ✅; phrase "analog-esque mixer" **not in repo** | Product question, not code defect |
+
+### Kimi Grumpy Review — findings Opus did not raise
+
+| Finding | Audit status | Notes |
+|---------|--------------|-------|
+| **🔴#1 — jackd duplex open breaks mic bridge** (`start-jackd.sh:43-44` lacks ALSA `-P` after `-d alsa`; `mic-to-uac2-bridge.sh:54` + `session_capture.py:66-89` EBUSY) | ✅ verified (Kimi audit A1, B3–B5) | Kimi's best unique catch; Phase 1 *introduced* capture-side hold |
+| **🟡#2 — Criterion 16 UI drift** (`surge_audio.py:16-19`, `configure-pi-paths.sh:70-74`, touch shows "1024 · 21 ms" while graph runs 256×3 = 16 ms) | ✅ verified (Kimi audit C6–C10, C12) | Gate B logged 12 drift failures, dismissed pre-existing |
+| **🟡#3 — Watchdog budget blowout** (15 iterations × `timeout 3 jack_lsp` + sleep ⇒ ~60 s vs 15 s nominal) | ✅ verified (Kimi audit D13–D14); M1 adds unguarded `jack_lsp` at `audio-engine.sh:432` | |
+| **🟡#5 — Triple looper predicate** (`engine-guard.sh`, `audio-engine.sh:189-195`, `audio_engine.py:36-38`) | ✅ verified (Kimi audit F21); audit deflates 🟡 → Low | |
+| **Branch topology** (`main` 42 behind `dev`; `yolo/looper-phase0` 76 ahead) | ⚠️ partial: counts ✅; "1 behind" ❌ (actual 32 behind, Kimi audit claim 34) | |
+| **96 kHz enum drift** (`set-surge-audio.sh` vs `mpe_jack_rate()`) | ✅ verified (Kimi audit H27) | |
+| **`--list-devices` invoked 3× per boot** | ⚠️ partial (Kimi audit claim 49): 2 in `start-surge-cli.sh`, 3rd in `detect-audio-device.sh` via different unit | |
+
+### Audit-only additions (neither review's headline list)
+
+| Finding | Source audit | Status |
+|---------|--------------|--------|
+| Opus audit MISSED-2: 4.4 repeats `.corrupted_*` per supervisor cycle | Opus audit | ✅ |
+| Opus audit MISSED-6: read-modify-write race on `engine.state`; unbounded RT priority validator | Opus audit | ✅ (Low) |
+| Kimi audit M2: optimistic `state=ok` publish before Surge liveness check | Kimi audit | ✅ (Low) |
+| Kimi audit M3: mic bridge wedges in `failed`, not infinite loop | Kimi audit | ✅ (sharpens 🔴#1) |
+
+---
+
+## 4. Corrections — Do Not Implement As Originally Written
+
+### Udev `ENV{}` fix (Opus review 4.3 / backlog item 3)
+
+**Do not** implement "filter on kernel-supplied `ENV{}` properties" as stated. Opus audit claim B5: `ENV{}` survives `remove`, but **no kernel property carries the ALSA card `id`** — option 1 would need a new `add`-time rule to stamp `ENV{MPE_SKIP_CARD}=1` first. Writing four `ENV{}` rules that match nothing is strictly worse than today.
+
+**Correct fix:** move card-identity check into `restart-audio-graph.sh` against `/proc/asound/cards` — one filter, testable from a laptop. Opus audit and Kimi audit both endorse this path.
+
+### Criterion 16 — do not delete `MPE_SURGE_BUFFER_SIZE` seed (Kimi review Hall of Shame #2 prescription)
+
+**Do not** stop seeding `MPE_SURGE_BUFFER_SIZE` in `configure-pi-paths.sh:70-74`. Kimi audit claim 11 ❌: the key is retired as the **graph period** but remains live for `calibrate-patch-normalization.py:422,457`, `midi_sync.py:58`, and `MPE_MIDI_OUTPUT_OFFSET_AUTO` (`mpe.env.example:142`). Removing the seed forces hardcoded 1024 fallbacks and contradicts the shipped env contract.
+
+**Correct fix:** repoint `surge_audio.py` read-back and latency labels at `MPE_JACK_BUFFER` / `MPE_JACK_PERIODS` (multiply by periods in the ms calculation); keep seeding the Surge key with a re-commented purpose; add tests for JACK enum validators. Dual-write on `set-surge-audio.sh --buffer` is debatable (spec-pure vs one-knob UX) — do not delete without deciding.
+
+### Soak sequencing (Opus review priority backlog vs Opus audit disagreement #5)
+
+**Do not** run Gate C first, then fix udev and watchdog. Opus audit: fix **4.3 and 4.4 before Gate C** — both are cheap, both sit on failure paths Gate C exercises, and soaking a branch you are about to change means either soaking twice or shipping a soak log that does not describe what merges. Spec commit (5 seconds) can happen anytime; hardware soak should be last among P0s.
+
+**Recommended P0 order:** (1) udev fix in `restart-audio-graph.sh`, (2) gate watchdog corrupt-defaults arm + move `mv` after cooldown decision, (3) optional: route UI Surge restart through supervisor (MISSED-1), (4) **then** Gate C soak, (5) merge.
+
+### Mixer as product decision, not code defect (Opus audit disagreement #1)
+
+**Do not** treat "write a spec for the analog-esque mixer" as 🔴 alongside unsoaked failure paths. Opus audit G6: the phrase does not appear in the repository (`README.md` / `AGENTS.md` say "MPE sound module"). The observation about naming collision with per-patch Vol/Tail/Touch faders is valid; the 🔴 severity is inflated. File as an **open product question for Mitch** — decide whether mixer rides on the JACK graph (Phase 2 dependency) or is a separate surface — not as a branch-blocking engineering defect.
+
+---
+
+## 5. Prioritized Action Plan
+
+Deduplicated P0/P1 from both audits. Effort labels from audit matrices.
+
+### Quick fixes (laptop)
+
+1. **P0 — Udev remove blind spot:** card-identity check in `restart-audio-graph.sh` via `/proc/asound/cards` (not raw `ENV{}`). *(Opus 4.3; Opus audit P0; half-day → quick fix)*
+2. **P0 — Watchdog corrupt-defaults arm:** gate on `mpe_engine_state_get state`/`reason` (`no-server`, `no-jack-device`); move `mv` **after** cooldown decision *(Opus 4.4 + MISSED-2; Opus audit P0; quick fix)*
+3. **P1 — Commit + amend looper spec:** `git add Documents/specs/looper-jack-client-spec.md` **and** fix §D.5, criterion 11, D.5.2, D.5.3 in same commit *(Opus 4.1 + Kimi #4 + both audits P1; quick fix)*
+4. **P1 — jackd playback-only:** add ALSA `-P` after `-d alsa` in `start-jackd.sh:43-44` *(Kimi 🔴#1; Kimi audit P0 code fix — Pi verify at rewire)*
+5. **P1 — Criterion 16 UI drift:** repoint `surge_audio.py` labels; keep `MPE_SURGE_BUFFER_SIZE` seed; add JACK validator tests *(Kimi #2; Kimi audit P1; half-day)*
+6. **P1 — Watchdog probes:** probe once per reconcile pass; wall-clock budget; wrap bare `jack_lsp` at `audio-engine.sh:432` in `timeout 3` *(Kimi #3 + M1; Kimi audit P1; quick fix)*
+7. **P1 — Make criterion 2* testable:** extract failure-path sequence to sourceable function in `audio-engine.sh`; test real code, not copy *(Opus 4.5; Opus audit P1; half-day — before Gate C)*
+8. **P1 — CI hardening:** shellcheck on `scripts/` + `config/*.service`; glob shell tests; install from `requirements.txt` *(Opus 4.9; Opus audit P1; half-day)*
+9. **P1 — UI Surge restart through cooldown** or disable when `engine.state=failed` + known reason *(Opus audit MISSED-1; P1; half-day)*
+10. **P2 — Move MIDI clock state to `/run/mpe/`; poll 0.5 s** *(Opus 4.8; quick fix)*
+11. **P2 — Bound `$HOME/surge-watchdog.log`** *(Opus audit MISSED-3; quick fix)*
+12. **P2 — Calibration teardown:** explicit `systemctl start mpe-jackd` + readiness wait after 4.3 fix *(Opus 4.10; quick fix)*
+13. **P2 — Comment hygiene, CHANGELOG 438→440, README Pi 4B/5 disambiguation** *(Kimi #6; Kimi audit P2)*
+
+### Gate C soak (Pi — Mitch + hardware)
+
+14. **P0 — Run five Gate C scenarios** before merge (`jack-audio-engine-spec.md:452-459`):
+    - 2*: masked jackd boot → `state=failed` → unmask promotes
+    - 2b/2b2 at 5 s settle (retest)
+    - 15: DAC replug from `state=failed`
+    - 12: stale `MPE_AUDIO_ENGINE=alsa` line inert
+    - D5 guard boot with `MPE_LOOPER_ENABLED=1`
+    - *(Both reviews 🔴; both audits P0; ~half-day Pi bench)*
+
+15. **P0 — Run blocked 5b/14 soak rows** after jackd `-P` fix and physical rewire *(Kimi 🔴#1; Kimi audit P0)*
+
+### Merge
+
+16. **Merge `yolo/jack-drop-alsa-fallback` → `dev`** only after Gate C PASS and P0 laptop fixes landed.
+
+### Product decision (mixer spec)
+
+17. **Decide mixer product surface** — JACK-graph client vs separate UI; write spec before more engine work. Not a merge blocker. *(Opus review 🔴 reframed; Opus audit P2 "decision, not code")*
+
+---
+
+## 6. Artifact Index
+
+| Artifact | Path |
+|----------|------|
+| Opus Grumpy Dev review | [`Documents/reviews/grumpy-review-opus-2026-08-13.md`](grumpy-review-opus-2026-08-13.md) |
+| Kimi Grumpy Dev review | [`Documents/reviews/grumpy-review-kimi-2026-08-13.md`](grumpy-review-kimi-2026-08-13.md) |
+| Opus review audit | [`Documents/reviews/review-audit-opus-2026-08-13.md`](review-audit-opus-2026-08-13.md) |
+| Kimi review audit | [`Documents/reviews/review-audit-kimi-2026-08-13.md`](review-audit-kimi-2026-08-13.md) |
+| Governing spec (Phase 1) | [`Documents/specs/jack-audio-engine-spec.md`](../specs/jack-audio-engine-spec.md) |
+| Phase 2 spec (untracked) | [`Documents/specs/looper-jack-client-spec.md`](../specs/looper-jack-client-spec.md) |
+
+---
+
+## 7. Model Comparison — Which Review & Audit Was Better?
+
+### Review quality comparison (Opus 5 vs Kimi K3)
+
+| Dimension | Opus 5 review | Kimi K3 review |
+|-----------|---------------|----------------|
+| **Finding tally** | 5 🔴 · 6 🟡 · 5 🟢 (16 numbered) | 2 🔴 · 5 🟡 · 6+ 🟢 |
+| **Claim breadth** | 65 auditable claims (Opus audit queue) | 54 auditable claims (Kimi audit queue) |
+| **Depth vs breadth** | Deeper on process, udev, watchdog amendment side-effects, test strategy, DX clutter, spec conformance table (17 criteria) | Deeper on hardware-path regression (duplex open), env/key drift, branch topology, business-rule edge cases |
+| **Unique high-value catches** | udev `remove`/`ATTR{}` bug (4.3); watchdog defaults destruction (4.4); test-copy gap as load-bearing on 2* (4.5); mixer naming trap (reframed later) | jackd duplex vs mic bridge (🔴#1) — only finding that explains a *shipped-profile regression in waiting*; criterion 16 UI drift with Gate B evidence; watchdog ~60 s budget math |
+| **Errors / exaggerations** | Mixer 🔴 measured against phrase not in repo; `sudo` inventory "five sites in four files" (actual 9+ files); `logs/`/`.pytest_cache/` "committed directories" ❌; `ENV{}` fix overspecified; 4.5 rated 🟡 while cited as reason 2* is unverified | "Stop seeding `MPE_SURGE_BUFFER_SIZE`" ❌; "76 ahead / 1 behind" (actual 32 behind); three-file PR #48 conflict list (actual two); `logs/` "consider ignoring" (already gitignored); mic bridge "restart loop" (actually wedges in `failed` per M3) |
+| **Trust for acting on code changes** | **Higher for amendment/post-merge regression hunting** — 4.3 and 4.4 are the findings a spec review could never produce; D2 inventory verification is exhaustive | **Higher for profile/hardware-path analysis** — 🔴#1 is the session's only finding that rewrites understanding of 5b/14; buffer drift is user-facing and test-gappable |
+
+**Verdict:** Neither review alone is sufficient. Opus found the udev and watchdog bombs Kimi missed entirely; Kimi found the jackd duplex regression and criterion 16 drift Opus never mentioned. For **code changes on this branch**, trust **Opus for supervisor/udev/calibration teardown paths** and **Kimi for jackd device-open semantics and touch UI env contract**.
+
+### Audit quality comparison
+
+| Dimension | Opus 5 auditing Opus review | Kimi K3 auditing Kimi review |
+|-----------|------------------------------|------------------------------|
+| **Verdict tally** | **48 ✅ · 12 ⚠️ · 3 ❌ · 2 🔍** / 65 claims (~74% exact) | **48 ✅ · 3 ⚠️ · 2 ❌ · 1 🔍** / 54 claims (~89% exact) |
+| **Errors in praise vs criticism** | 3 ❌ all in **praise/background**: sudo count (H3), committed `logs/` (J1), mixer goal in repo (G6). Criticism claims (4.2–4.4, B1–B3, D1) overwhelmingly ✅ | 2 ❌ in **secondary/prescription**: seed deletion (C11), logs ignore (J41). Core 🔴#1 and Gate C: ✅ |
+| **"What the review missed"** | **6 items (MISSED-1–6)** — two High (UI restart bypasses cooldown; 4.4 repeats per cycle). Substantially expanded action matrix | **4 items (M1–M4)** — all Low/Medium; sharpens 🔴#1 consequence (wedge not loop) |
+| **Severity calibration** | Aggressive: mixer 🔴 → Low; 4.5 🟡 → High; 4.6 🟡 → Low; `ENV{}` fix flagged ⚠️ | Moderate: 🔴#1 Critical → High (blocked profile); triple predicate 🟡 → Low; preserved fix-prescription challenge on seed deletion |
+| **Process rigor** | Full claim queue A–K; severity re-assessment table; explicit soak sequencing disagreement | Tighter hit rate; fewer ⚠️; stronger prescription auditing (claim 11 ❌) |
+
+**Verdict:** **Opus audit** is better at **process rigor and expanding the finding set** (6 missed items vs 4, severity re-assessment, P0 sequencing). **Kimi audit** is better at **fix-prescription accuracy** — caught the one dangerous "delete the seed" recommendation and verified jackd `-P` vs core `-P` distinction (claim A1 footnote). Kimi's higher ✅ ratio (89% vs 74%) reflects narrower scope and fewer background DX claims, not necessarily deeper verification of hard bugs.
+
+### Cross-model pattern: better at audit than review?
+
+**Opus:** **Yes — better at auditing than reviewing**, marginally. The review's 3 ❌ errors sit in praise/inventory (H3 sudo count, J1 committed dirs, G6 mixer phrase); the audit caught MISSED-1 (UI cooldown bypass) the review never raised, corrected B5 (`ENV{}`), reframed mixer severity, and upgraded 4.5. Review strength: narrative framing of 4.2 as *the* central risk and amendment side-effect reasoning (4.3+4.4 compound chain). Audit strength: claim-by-claim discipline and 6 net-new items.
+
+**Kimi:** **Audit ≈ review, with audit winning on prescriptions.** The review's 🔴#1 (duplex open) is the highest-value unique finding in the whole session and survived audit ✅ with only severity deflation (Critical → High). The audit's claim 11 ❌ ("stop seeding") prevents a real foot-gun the review prescribed. Audit missed udev entirely (out of Kimi review scope). Review strength: hardware-path regression intuition. Audit strength: env-contract reading (`mpe.env.example:66-71`) and git number verification (32 vs 1 behind).
+
+**Overall winner:** **Split the work — no single model wins all roles.**
+
+| Role | Recommended model | Evidence |
+|------|-------------------|----------|
+| Full codebase / architecture review | **Opus** for breadth, spec conformance, amendment side-effects | 16 findings vs 13; only source of udev + watchdog + test-strategy gaps |
+| Hardware-path / profile regression review | **Kimi** | 🔴#1 duplex open; criterion 16 + Gate B drift citation |
+| Review audit (process rigor) | **Opus audit** | 65-claim queue, 6 MISSED items, severity table, soak sequencing |
+| Review audit (fix prescription) | **Kimi audit** | Seed deletion ❌; jackd flag disambiguation; mic bridge wedge sharpening |
+| Implementation | **`composer-2.5-fast`** (per project AGENTS.md) off locked audit P0/P1 list | N/A to this session |
+
+If forced to pick one pair for a repeat pass: **Opus review + Kimi audit** — Opus for finding count and amendment archaeology, Kimi audit for catching dangerous fixes and env-contract mistakes. The inverse (Kimi review + Opus audit) would miss udev entirely unless Opus audit's scope expanded beyond the Kimi review text.
+
+---
+
+## 8. Recommended Model Routing (Going Forward)
+
+- **Full codebase review (milestone / release-scope):** Opus thinking model — better at exhaustive inventories (D2 call sites, spec conformance tables), amendment side-effect chains, and test-strategy critique. Pair with Kimi pass on audio hardware paths if `$` allows.
+- **Targeted regression review (audio engine, profiles, udev):** Kimi K3 — duplex-open class of bugs and env-key drift; verify every prescription against `mpe.env.example` and live consumers.
+- **Review audit:** Opus for claim extraction, severity re-assessment, and "what did the review miss"; Kimi (or second Opus pass) specifically on **fix prescriptions** and env/schema contracts.
+- **Implementation / P0 fixes:** `composer-2.5-fast` from deduplicated audit action matrix — udev check in `restart-audio-graph.sh`, watchdog gating, `-P` flag, UI label repoint, sourceable test helper.
+- **Human-only:** Gate C soak and 5b/14 rewire — no model substitutes for Pi bench time.
+
+---
+
+*This synthesis was produced from the four source artifacts listed in §6. No code was modified.*

--- a/Documents/specs/looper-jack-client-spec.md
+++ b/Documents/specs/looper-jack-client-spec.md
@@ -1,0 +1,861 @@
+# Looper as JACK callback client — swappable mixer, realtime discipline
+
+**Issue:** untracked
+**Status:** Draft — design only. Implements **Phase 2** of
+[`jack-audio-engine-spec.md`](jack-audio-engine-spec.md) (criteria 7, 8, 9, 11).
+Phase 1 is on `yolo/jack-audio-engine-phase1` (PR #49), Gate B soaked.
+**Created:** 2026-08-12
+**Last updated:** 2026-08-12 23:21 (America/Toronto)
+
+**Register:** everything below is a working hypothesis unless labelled
+**measured**. Measured facts carry a source — a file path with line numbers, a
+git object, or a row from `jack-audio-engine-spec.md` §Evidence. Two of the
+load-bearing decisions here (§C kill criterion, §D merge order) are *decisions
+taken on incomplete data* and say so.
+
+---
+
+## Problem Statement
+
+Phase 1 made `jackd` the permanent graph server and Surge a JACK client. It also
+shipped a knowing regression: the looper is refused whenever the engine is JACK
+(spec **D5**, criterion 10), because the looper captures `snd-aloop` with
+`arecord` and plays to the DAC with `aplay`, and under JACK there is no loopback
+stream to capture (`scripts/lib/engine-guard.sh:4-7`).
+
+Today's looper is five processes and four buffer stages
+(`patch_browser/looper_audio_io.py:9` `open_arecord`, `:34` `open_aplay`), costing ~40 ms
+round trip across three unsynchronised clocks. Phase 2 makes the looper a JACK
+callback client so Surge and the looper are processed in the same graph tick,
+which is the entire point of choosing option D
+(`docs/AUDIO-ENGINE-FOUNDATION.md` Part 8, *"D contains C, it does not compete
+with it"*).
+
+Three things stand between here and there, in increasing order of risk:
+
+1. The mixer is `audioop`-based and returns fresh `bytes` per call
+   (`patch_browser/looper_engine.py:226-293` on `yolo/looper-phase0`). A callback
+   at one or two periods of latency cannot allocate per period.
+2. The looper source is **not on `dev`**. It lives on `yolo/looper-phase0`
+   (PR #48, unmerged) and Phase 1 deliberately stripped it.
+3. **Nobody has demonstrated that a Python callback holds a 256-frame deadline
+   on this hardware.** The governing spec lists this as an assumption that, if
+   false, makes Phase 2 unshippable in Python
+   (`jack-audio-engine-spec.md:285`).
+
+## Goals
+
+1. The looper records, overdubs and plays with Surge on the graph — no
+   `snd-aloop` in the audio path, no `arecord`/`aplay` children (criterion 7).
+2. A **swappable mixer interface** with a NumPy backend that is bit-exact
+   against the shipped `audioop` path, so the swap is provably behaviour-neutral
+   (criterion 8).
+3. The realtime callback's allocation is **constant and non-retaining**, and the
+   GC tail is **measured and recorded**, not assumed (criterion 9).
+4. The D5 guard is deleted and both run together in the default engine
+   (criterion 11).
+5. A **compiled mix kernel is a drop-in**, not a rewrite, if the measurement
+   says Python cannot hold the deadline (`AUDIO-ENGINE-FOUNDATION.md` Part 8,
+   *"keep the mix function behind a clean swappable interface"*).
+
+## Non-Goals
+
+- **A compiled mix kernel now.** Deferred until measured — §C states the exact
+  number that promotes it from deferred to required.
+- **Bit-exactness as the shipping runtime format.** Criterion 8 is a
+  *correctness bridge* between two implementations, not a statement that the
+  JACK path stays int16. See §A.4.
+- **Looping in `usb-host` / `usb-host-session` profiles.** `standalone` only,
+  unchanged from Phase 1's Non-Goals.
+- **Removing `snd_aloop` from the appliance.** Removing it from the *looper* and
+  *Surge start* paths, yes. The module stays installable because patch
+  normalization calibration `modprobe`s it
+  (`patch_browser/calibration_loopback.py:34-46`). See §B.4.
+- **JACK transport integration.** The looper keeps its own bar clock
+  (`patch_browser/looper_bar_clock.py`). Spec Open Q2 stays open; sharing a
+  sample clock already removes the drift that motivated the question.
+- **Latency below 256 frames.** Hardware ceiling, unchanged
+  (`jack-audio-engine-spec.md` §Evidence, DAC row).
+- **Depending on an automatic ALSA fallback.** ALSA was removed entirely as a
+  product audio path (2026-08-13 amendment to `jack-audio-engine-spec.md`).
+  Nothing here assumes a fallback exists. See §D.5.
+
+## Acceptance Criteria
+
+Numbering continues `jack-audio-engine-spec.md`. Criteria **7, 8, 9, 11** are
+that spec's Phase 2 rows, restated here with the verification made executable.
+**Criterion 9 is materially revised** — see §C.1 for why the original cannot
+pass.
+
+| # | Criterion | Verification |
+|---|-----------|--------------|
+| 7 | Looper records and overdubs with Surge on the graph — no `arecord`/`aplay` children, no `snd_aloop` in the audio path | Manual play on Pi. `pgrep -P $(pgrep -f mpe-looper.py)` empty; `lsmod \| grep snd_aloop` empty **while the looper runs and no calibration is in flight** (§B.4); `jack_lsp -c` shows the insert topology of §B.3 |
+| 8 | The NumPy int16 backend is **bit-exact** against `audioop` across the fixture set | `mpe test local looper` — `tests/test_looper_mix_parity.py` asserts `numpy.array_equal` (not `assertAlmostEqual`) over every case in `tests/fixtures/mixer_cases.py`, both backends in-process, plus the committed golden `.npz`. Laptop-runnable |
+| 8b | The float32 backend agrees with the int16 backend within 1 LSB after quantization | Cross-profile test, same fixture set. Catches a bug present in only one backend |
+| 9a | The **mixer** allocates zero bytes | `tracemalloc` delta == 0 across 10 000 `MixWorkspace.mix()` calls. Laptop-runnable |
+| 9b | The **callback** allocation is bounded and flat | `tracemalloc` net retained delta between callback 1 000 and callback 100 000 == 0 bytes; per-callback peak identical at both checkpoints. Growth is the failure, not presence (§C.1) |
+| 9c | GC is off in the looper process and stays quiet | `gc.isenabled()` False after warm-up; `gc.get_stats()` shows **zero** collections across a 10-minute run. If non-zero, pause distribution recorded and p99 < one period |
+| 9d | Memory is flat — proves "GC off" is safe | `VmRSS` at t=60 s and t=600 s differ by < 1 MB |
+| 9e | Callback timing recorded, with a stated verdict | `docs/measurements/looper-jack-callback-YYYY-MM-DD.md` holds p50 / p99 / p99.9 / max, xruns, and the §C.3 verdict applied to those numbers |
+| 11 | The D5 guard is removed and both run together in the default engine | Boot with `MPE_LOOPER_ENABLED=1` (JACK is the only engine). Looper records. `engine.state` reports `looper=enabled`, never `guarded`. `grep -r LOOPER_GUARD` returns nothing outside CHANGELOG |
+| 18 | Surge's direct connection to `system:playback` does not survive a Surge restart | Kill jackd, let D3's supervisor restart Surge, then `jack_lsp -c`: `Surge XT:out_1` connects **only** to `mpe-looper:in_L`. Guards the double-dry-path failure of §B.3 |
+| 19 | Looper death does not silence the instrument | `pkill -KILL mpe-looper.py`; Surge reconnects to `system:playback` and audio returns. The insert must fail open |
+
+---
+
+## A. The swappable mixer interface
+
+### A.1 What is being replaced
+
+The shipped mixer is `mix_live_and_loops`
+(`patch_browser/looper_engine.py:226-293`, branch `yolo/looper-phase0`). It takes
+`bytes`, returns `bytes`, and on the `audioop` path performs a **left fold with
+saturation at every step**:
+
+```
+loop_sum  = audioop.mul(layer0, 2, per_layer_gain)          # :259-261
+for each remaining layer:
+    loop_sum = audioop.add(loop_sum,
+                           audioop.mul(layer, 2, per_layer_gain), 2)   # :262-267
+if effective_live == 0.0: return loop_sum                   # :268-269
+return audioop.add(audioop.mul(live, 2, effective_live), loop_sum, 2)  # :270-272
+```
+
+Gain policy (`:243-250`), preserved verbatim:
+
+```
+headroom       = 1/(live_gain + loop_gain)  if live_gain > 0 and live_gain + loop_gain > 1 else 1.0
+effective_live = live_gain * headroom
+per_layer_gain = loop_gain * headroom / n
+```
+
+### A.2 Exactly what `audioop` does — measured from the C source
+
+The appliance is Debian 13 trixie (`docs/LATENCY-SPIKE.md:36`), whose Python has
+no stdlib `audioop` (PEP 594 removed it in 3.13). The looper therefore runs
+`audioop-lts` (`requirements.txt` on `yolo/looper-phase0`), which is the
+CPython C module repackaged — [`AbstractUmbra/audioop`](https://github.com/AbstractUmbra/audioop),
+`audioop/_audioop.c`. **Measured** by reading that source at
+`dc1e6078` (symbol references, not line numbers — the file is vendored and
+renumbers between releases):
+
+| Fact | Symbol in `_audioop.c` |
+|---|---|
+| `maxvals[2] = 0x7FFF`, `minvals[2] = -0x8000` | `maxvals[]` / `minvals[]` |
+| `fbound(v, min, max)` clamps, then **`floor()`**, then casts | `fbound()` |
+| `mul` widens each sample to C `double`, multiplies, applies `fbound` | `audioop_mul_impl()` |
+| `add` for `width < 4` is an **integer** add clamped to `[minval, maxval]` — no rounding | `audioop_add_impl()` |
+| Length mismatch raises `audioop.error("Lengths should be the same")` | `audioop_add_impl()` |
+| Non-multiple-of-width length raises `audioop.error("not a whole number of frames")` | `audioop_check_parameters()` |
+| Samples are read **native-endian** via `GETINT16` | `GETRAWSAMPLE` macro |
+
+Three consequences that are where "sample-identical" normally breaks, and each
+one is a real trap here:
+
+1. **`mul` rounds toward −∞, not to nearest.** `3 × 0.5 → floor(1.5) = 1`;
+   `−3 × 0.5 → floor(−1.5) = −2`. Any NumPy implementation using `np.rint`,
+   `np.round`, or Python's `round()` diverges on odd magnitudes.
+2. **The fold clips at every pairwise add.** `add(add(a,b),c)` is not
+   `clip(a+b+c)`: with `a=b=30000, c=−30000` the fold yields `2767` and the wide
+   sum yields `30000`. **The illustrative NumPy snippet in
+   `AUDIO-ENGINE-FOUNDATION.md` Part 3 (`acc += …; np.clip(acc)`) is a single
+   wide accumulate and is therefore not bit-exact.** It is a good sketch of the
+   performance argument and a wrong sketch of the semantics.
+3. **`mul` multiplies in `double`.** Multiplying in `float32` would first round
+   the gain itself to `float32`, changing the product. The NumPy backend
+   multiplies in `float64`; at int16 magnitudes this costs nothing and removes
+   the argument.
+
+**The pure-Python fallback in `looper_engine.py:274-293` is not a valid
+reference.** It uses `round()` (half-to-even) where `audioop` uses `floor()`, and
+accumulates in float with no intermediate clipping. The existing parity test
+(`tests/test_looper_engine.py`, `test_mix_live_and_loops_backends_agree_three_layers`)
+asserts agreement only to `delta=3`, which is why the divergence never surfaced.
+**Criterion 8's reference is `audioop`. Full stop.** The interpreted fallback is
+deleted in Task 5, not ported.
+
+### A.3 The interface
+
+New module `patch_browser/looper_mix.py`. No ALSA imports, no JACK imports, no
+import from any file that lives only on `yolo/looper-phase0` — this is what makes
+§E's independent scope real.
+
+```python
+# patch_browser/looper_mix.py
+from __future__ import annotations
+from typing import Protocol, Sequence, runtime_checkable
+import numpy as np
+import numpy.typing as npt
+
+Int16Block   = npt.NDArray[np.int16]    # shape (frames, 2), C-contiguous, interleaved L,R
+Float32Block = npt.NDArray[np.float32]  # shape (frames, 2), C-contiguous, values nominally [-1.0, 1.0]
+
+MAX_LAYERS   = 8      # APC row 0 is 8 pads (docs/APC-LOOPER-UX.md)
+MAX_FRAMES   = 1024   # largest MPE_JACK_BUFFER we accept; workspace is sized for this
+S16_SCALE    = 32767.0
+
+class MixShapeError(ValueError):
+    """Raised before any write to `out` — `out` is never left half-mixed."""
+
+class MixGains(NamedTuple):
+    live: float
+    per_layer: float
+
+def mix_gains(live_gain: float, loop_gain: float, layers: int) -> MixGains: ...
+    # The `looper_engine.py:243-250` headroom law, factored out so both backends
+    # and the parity test share it. Gain math is not what criterion 8 compares.
+
+@runtime_checkable
+class MixBackend(Protocol):
+    name: str                 # "audioop" | "numpy-int16" | "numpy-float32" | "compiled-<x>"
+    dtype: np.dtype           # np.dtype(np.int16) | np.dtype(np.float32)
+    allocates_in_mix: bool    # True only for the audioop reference backend
+
+    def mix_into(
+        self,
+        out: np.ndarray,
+        live: np.ndarray,
+        layers: Sequence[np.ndarray],
+        gains: MixGains,
+    ) -> None: ...
+```
+
+Concrete backends, all implementing `MixBackend`:
+
+```python
+class AudioopBackend:      # reference only; wraps bytes<->ndarray, allocates. Never shipped in the callback.
+class NumpyInt16Backend:   # bit-exact vs AudioopBackend. Criterion 8 target.
+class NumpyFloat32Backend: # the shipping RT path. Criterion 8b target.
+```
+
+And the realtime holder, which is what the callback actually touches:
+
+```python
+class MixWorkspace:
+    def __init__(self, backend: MixBackend, *, max_frames: int = MAX_FRAMES,
+                 max_layers: int = MAX_LAYERS) -> None: ...
+        # Allocates every buffer here, once, off the RT thread.
+
+    frames: int                       # active block length; set by set_blocksize(), never in mix()
+    def set_blocksize(self, frames: int) -> None: ...   # non-RT; slices, never reallocates
+
+    def layer_view(self, index: int) -> np.ndarray: ...  # preallocated (max_frames, 2) scratch
+    def live_view(self) -> np.ndarray: ...
+    def out_view(self) -> np.ndarray: ...
+
+    def mix(self, active_layers: int, gains: MixGains) -> None: ...
+        # RT path. Unchecked by construction: every shape was validated in __init__
+        # and set_blocksize(). No allocation, no branch that can raise.
+```
+
+**Contract, stated so a compiled backend can satisfy it unchanged:**
+
+| Concern | Rule |
+|---|---|
+| Ownership | `out` is caller-owned and preallocated. The backend writes into it and returns `None`. It never allocates, never resizes, never retains a reference past the call. |
+| In-place | Always. There is no returning variant. This is the break from `mix_live_and_loops`, which returns `bytes`. |
+| Aliasing | `out` may alias `live` (in-place live gain). `out` must **not** alias any element of `layers`; `MixWorkspace` guarantees this by owning all of them. |
+| Shape | Every array `(frames, 2)`, C-contiguous, identical `frames`, `dtype == backend.dtype`. `len(layers) <= MAX_LAYERS`. |
+| Validation | `mix_into()` validates and raises `MixShapeError` **before** touching `out`. `MixWorkspace.mix()` does not validate — its preconditions were established at construction. Two entry points, one for tests and one for the RT thread. |
+| Empty | `layers == []` is legal: `out = clip(live * gains.live)`. `frames == 0` is legal and a no-op. |
+| Saturation | int16 backends: `audioop` semantics exactly (§A.2). float32 backend: sum in float32 headroom, single `np.clip(out, -1.0, 1.0)` at the end. |
+| Determinism | No RNG, no dependence on `np.seterr` state, no `np.errstate` context inside the RT path. |
+
+**Bit-exact int16 kernel** — the shape the parity test pins:
+
+```python
+# per layer, replicating audioop.mul
+np.multiply(layer, gain, out=scratch_f64)          # float64, as audioop does
+np.floor(scratch_f64, out=scratch_f64)             # round toward -inf, NOT rint
+np.clip(scratch_f64, -32768.0, 32767.0, out=scratch_f64)
+scaled = scratch_f64.astype(np.int16, copy=False)  # into preallocated int16 scratch
+
+# fold, replicating audioop.add — clip at EVERY pairwise step
+np.add(acc_i32, scaled_i32, out=acc_i32)
+np.clip(acc_i32, -32768, 32767, out=acc_i32)
+```
+
+`np.clip` before the cast, not after: casting out-of-range float64 to int16 is
+undefined-ish in NumPy 2 and would be a silent divergence.
+
+### A.4 int16 versus float32 — the tension criterion 8 hides
+
+JACK's wire format is `jack_default_audio_sample_t`, i.e. **float32**:
+`Port.get_buffer()` returns `blocksize * ffi.sizeof('float')` bytes and
+`get_array()` uses `dtype=np.float32`
+([`spatialaudio/jackclient-python`](https://github.com/spatialaudio/jackclient-python) `src/jack.py`).
+Keeping the mixer int16 in the callback would add two conversions per period and
+would quantize Surge's output to 16 bits inside a graph whose DAC path measured
+`S24_3LE` (`jack-audio-engine-spec.md` §Evidence). That is a *regression against
+Phase 1*, dressed up as compliance with criterion 8.
+
+**Decision — D-L1.** Criterion 8 is satisfied by the **int16 backend**, which is
+the correctness bridge and the format of the loop **store**. The **float32
+backend** is the shipping RT path. Both share `mix_gains()`; criterion 8b pins
+them to each other within 1 LSB. Read criterion 8 as *"the NumPy mixer's int16
+backend is bit-exact with `audioop`"*, not *"the shipping mixer is int16"*.
+Rationale for int16 storage: a 4-bar 120 bpm stereo loop is 384 000 frames
+(`test_looper_engine.py`, `test_loop_length_frames_four_bars_120bpm`) = 1.5 MB as
+int16 against 3.0 MB as float32, times 8 clips.
+
+Conversion lives at the ring boundary, not in the mix, using one named constant
+in both directions:
+
+```
+capture : int16 = np.rint(np.clip(f32, -1.0, 1.0) * S16_SCALE)
+playback: f32   = int16 * (1.0 / S16_SCALE)
+```
+
+Symmetric, no DC offset, exact round-trip for every int16 except `-32768`, which
+clamps to `-1.0`.
+
+### A.5 The fixture set does not exist
+
+**Measured:** `git ls-tree -r --name-only yolo/looper-phase0` matches no `.wav`,
+`.raw`, `.pcm`, `fixture` or `testdata` path. The existing tests build byte
+strings inline (`tests/test_looper_engine.py`, `_stereo_frame`). Criterion 8's
+*"the existing fixture set"* refers to something that is not in the repository.
+**Task 1 creates it.**
+
+`tests/fixtures/mixer_cases.py` — a deterministic generator, plus a committed
+golden `tests/fixtures/mixer_golden_audioop.npz` produced once from the
+`audioop` backend and checked in, so the parity test survives `audioop-lts` being
+removed from `requirements.txt` in Task 5. Required cases, chosen because each
+one breaks a plausible NumPy implementation:
+
+| # | Case | Breaks |
+|---|---|---|
+| 1 | `live_gain == 1.0`, no layers | The `bytes`-identity short-circuit at `looper_engine.py:239-240` |
+| 2 | `live_gain == 0.0`, ≥ 1 layer | The early return at `:268-269` |
+| 3 | `-32768 × 0.5` | Negative-clamp branch `val < minval + 1.0` |
+| 4 | `±3 × 0.5` and other odd magnitudes | `floor` vs `rint` — the classic |
+| 5 | Three layers with `a=b=30000, c=-30000` | Fold order and intermediate clipping |
+| 6 | Layers that saturate individually before summing | Per-layer `fbound` in `mul` |
+| 7 | 0, 1, 3, 6, 8 layers | `per_layer_gain` divisor, `MAX_LAYERS` |
+| 8 | All-zero, all-`32767`, all-`-32768` | Boundary arithmetic in `int32` accumulate |
+| 9 | Non-power-of-two frame counts (1, 3, 255, 257) | Vectorization tail handling |
+| 10 | `live_gain + loop_gain > 1` and `<= 1` | Both `headroom` branches at `:243-249` |
+
+Assertion is `numpy.array_equal`. No `assertAlmostEqual`, no `delta=`.
+
+---
+
+## B. The JACK callback client
+
+### B.1 Binding — `python3-jack-client`, from apt
+
+**Decision — D-L2.** Use the `JACK-Client` binding (import name `jack`),
+installed as the Debian package **`python3-jack-client`**.
+
+| Fact | Source |
+|---|---|
+| `python3-jack-client` **0.5.3-1** is in Debian **trixie** | packages.debian.org/trixie/python3-jack-client |
+| Depends `python3-cffi`, `libjack-jackd2-0 (>= 1.9.10+20150825)`; **suggests** `python3-numpy` | Debian source control file, `python-jack-client 0.5.3-1` |
+| Upstream version is 0.5.5 | `src/jack.py:28`, `__version__ = '0.5.5'` |
+| API used here exists in 0.5.3 | `Client`, `inports`/`outports.register`, `set_process_callback`, `set_xrun_callback`, `set_port_connect_callback`, `activate`, `connect`, `blocksize` — all present in `src/jack.py` |
+
+apt rather than pip because trixie is PEP 668 externally-managed, which this
+repo already documents (`docs/BUILD-FROM-ZERO.md:79`). `python3-numpy` comes from
+apt for the same reason. `requirements.txt` gains a comment pointing at the apt
+packages rather than pip lines that will fail on the appliance.
+
+**Rejected: hand-rolled `ctypes` against `libjack.so.0`.** The binding is a thin
+cffi layer over the same symbols, is packaged and versioned, and — the deciding
+point — already gets the callback-thread GIL acquisition right, which is
+precisely the part a hand-roll gets wrong and the part whose failure mode is
+"works on the bench, deadlocks on stage."
+
+### B.2 Ports
+
+Client name `mpe-looper`. Four audio ports:
+
+```
+inports.register('in_L'),  inports.register('in_R')
+outports.register('out_L'), outports.register('out_R')
+```
+
+No JACK MIDI ports — the APC stays on ALSA rawmidi via `python-rtmidi`
+(`scripts/mpe-looper.py:85-120`), read from the main thread. Bringing it onto the
+graph is not needed to share a sample clock and adds a second binding.
+
+### B.3 Topology — the looper is an insert, not a send
+
+The looper mixes the **live** signal itself:
+`clip_matrix.process_period` ends in `mix_live_and_loops(live_pcm, loop_chunks,
+live_gain=…, loop_gain=…)` (`patch_browser/clip_matrix.py:202-207`). So Surge's
+dry path must go *through* the looper, not alongside it:
+
+```
+Surge XT:out_1  →  mpe-looper:in_L        mpe-looper:out_L  →  system:playback_1
+Surge XT:out_2  →  mpe-looper:in_R        mpe-looper:out_R  →  system:playback_2
+Surge XT:out_{1,2}  ✗  system:playback_{1,2}     ← must be DISCONNECTED
+```
+
+Leaving Surge's direct connection in place gives two dry paths one period apart —
+comb filtering, not doubling. And **this is not a one-shot at startup**:
+`jack-audio-engine-spec.md` §Evidence records that Surge **auto-connects** to
+`system:playback` with no `jack_connect`, and D3's supervisor restarts Surge on
+jackd death and on promotion to the graph. Every Surge restart re-creates the
+connection.
+
+**Decision — D-L3.** Topology is reconciled continuously, not asserted once. The
+looper registers `set_port_connect_callback` and `set_port_registration_callback`
+and runs a reconciler **on the main thread** (both callbacks arrive on JACK's
+non-RT notification thread; the reconciler must not call back into the daemon
+from inside them). Criterion 18 tests exactly this.
+
+**Fail-open (criterion 19).** With the looper as an insert, killing it silences
+the instrument — strictly worse than Phase 1. On clean shutdown the looper
+restores `Surge XT:out_{1,2} → system:playback_{1,2}` before deactivating. On an
+unclean death, `surge-watchdog.sh` gains one check: engine is JACK, Surge has no
+connection to `system:playback`, and no `mpe-looper` client is registered →
+reconnect Surge directly. This reuses the supervisor D3 already built rather than
+adding a second one.
+
+### B.4 Retiring `snd-aloop` — criterion 7 needs qualifying
+
+Deleted in Phase 2: `patch_browser/looper_audio_io.py` (the `arecord`/`aplay`
+openers), `patch_browser/looper_alsa_stderr.py` (their stderr xrun scraper —
+replaced by `set_xrun_callback`), `scripts/looper-audio-route.sh`, and the
+loopback tier in `patch_browser/looper_devices.py`.
+
+**But `snd_aloop` cannot be unconditionally absent, and the spec's criterion 7
+verification says it must be.** Two consumers remain, both **measured** in the
+tree:
+
+| Consumer | Evidence |
+|---|---|
+| Patch normalization calibration `modprobe`s it and waits for the card | `patch_browser/calibration_loopback.py:34-46` |
+| Calibration teardown unloads it when idle | `patch_browser/calibration_teardown.py:27-35` |
+
+Phase 1 already removed it from the Surge start path — `scripts/start-surge-cli.sh:115-119`
+sources `lib/unload-snd-aloop.sh`, which unloads only when the refcount is zero.
+So **most of criterion 7's `snd-aloop` half is already done**, and the remainder
+is deleting the looper's own route. This answers spec **Open Q3** (*"confirm
+nothing else depends on it first"*): one thing does — calibration — and it
+load/unloads on demand, so nothing blocks. Criterion 7's verification is
+qualified accordingly in the table above.
+
+### B.5 Process and threading model
+
+One process. No children (criterion 7 verifies `pgrep -P` is empty).
+
+| Thread | Owner | Work | May allocate |
+|---|---|---|---|
+| JACK RT | libjack | `process(frames)` — ring reads into workspace, `MixWorkspace.mix()`, write out | Bounded and flat only (§C.1) |
+| JACK notification | libjack | `set_xrun_callback`, `set_port_connect_callback`, `set_shutdown_callback` — counters and flags only | Yes (non-RT; upstream docs: *"received in a separated non RT thread"*) |
+| Main | us | APC MIDI poll, timing publish to tmpfs, HUD, topology reconcile, 5 s summary | Yes |
+
+**RT ↔ main handoff is lock-free and allocation-free.** No `queue.Queue`, no
+`threading.Lock`, no `logging` call anywhere reachable from `process()`.
+
+- **main → RT (transport commands):** a preallocated command object whose fields
+  are overwritten and then published by a single attribute store to a sequence
+  counter. A CPython attribute store is atomic with respect to the GIL, so the RT
+  thread sees either the old or new value, never a tear. The RT side reads the
+  counter, and only re-reads the fields when it changed.
+- **RT → main (state):** plain integer counters and the preallocated
+  `MsHistogram` from `patch_browser/looper_period_debug.py`, which is already
+  documented as allocation-free (*"add() is an index + increment"*). Main reads
+  them without locking; a torn read costs one stale HUD frame.
+
+**Blocksize changes must not reallocate on the RT thread.** `MixWorkspace` is
+built for `MAX_FRAMES = 1024`; `set_blocksize_callback` records the new length
+and the next `process()` uses a shorter slice. jackd's period is fixed by
+`MPE_JACK_BUFFER` (spec D6), so this is a safety net rather than a feature.
+
+**Realtime scheduling is JACK's job, not ours.** Spec **D4** already establishes
+that the client audio thread gets its priority from the server (measured: jackd
+70, Surge 65). The looper does **not** wrap itself in `chrt`, and
+`MPE_LOOPER_RT_PRIORITY` (added on `yolo/looper-phase0` in `cf32d9c`) is ignored
+when the engine is JACK, logged the same way `MPE_SURGE_RT_PRIORITY` is.
+
+---
+
+## C. Realtime discipline — the highest-risk part
+
+### C.1 Criterion 9 as written cannot pass, and the reason is in the binding
+
+**Measured, from `spatialaudio/jackclient-python` `src/jack.py`:**
+
+```python
+def get_buffer(self):
+    blocksize = self._client.blocksize
+    return _ffi.buffer(_lib.jack_port_get_buffer(self._ptr, blocksize),
+                       blocksize * _ffi.sizeof('float'))
+
+def get_array(self):
+    import numpy as np
+    return np.frombuffer(self.get_buffer(), dtype=np.float32)
+```
+
+Every `get_buffer()` allocates a fresh cffi buffer object; every `get_array()`
+allocates that **plus** an ndarray wrapper. Four ports gives **eight short-lived
+Python objects per callback**, as a floor, before any of our code runs. And
+caching them across callbacks is explicitly unsafe — the same docstring:
+
+> *"Caching output ports is DEPRECATED in JACK 2.0, due to some new optimization
+> (like 'pipelining'). Port buffers have to be retrieved in each callback for
+> proper functioning."*
+
+Upstream is equally direct in `set_process_callback`: Python *"is not really
+suitable for real-time processing… If you can live with some random audio
+drop-outs now and then, feel free to continue using Python!"*
+
+So `tracemalloc` delta == 0 across N callbacks is **not achievable** through this
+binding's public buffer API. The criterion as written would either fail forever
+or get quietly reinterpreted, and quiet reinterpretation of an acceptance
+criterion is how a spec stops meaning anything.
+
+**Decision — D-L4.** Criterion 9 splits into 9a–9e (see the criteria table). The
+invariant that actually protects the deadline is **flat, not zero**: constant
+per-callback allocation with zero net retention. The mixer, which is *our* code,
+is still held to exactly zero (9a).
+
+### C.2 GC policy — disable, don't tune
+
+**Decision — D-L5.** The looper process calls `gc.freeze()` after warm-up and
+then `gc.disable()`. Automatic collection never runs on the RT thread.
+
+Rationale: with GC enabled, the question is *"how long is the pause and is it
+under 5.333 ms?"* — probabilistic, load-dependent, and hard to bound. With GC
+disabled the question becomes *"does memory grow?"* — deterministic, cheap to
+measure, and covered by 9d. CPython's refcounting still reclaims every
+non-cyclic object immediately, which is all the callback creates if it is written
+correctly; flat RSS over ten minutes is the proof that there are no cycles.
+`gc.freeze()` first so that if GC is re-enabled for diagnostics, the startup
+object graph is not rescanned.
+
+Residual risk, stated rather than hidden: `free()` on the RT thread can still take
+a glibc arena lock. Mitigation is `mlockall(MCL_CURRENT|MCL_FUTURE)` plus a
+warm-up that touches the arena; jackd's `@audio` limits already grant
+`memlock unlimited` (`jack-audio-engine-spec.md` §Security Considerations).
+`JACK-Client` does not expose `mlockall`, so it goes through `ctypes` against
+libc — **Open Question OQ-3**, because whether it is needed is a measurement, not
+a belief.
+
+### C.3 Measurement methodology
+
+**Instrument, do not invent.** `patch_browser/looper_period_debug.py` already
+contains `MsHistogram`: fixed-edge, preallocated, `add()` is an index and an
+increment, bucket width `budget/16`, 128 buckets. Reuse it. Two `time.perf_counter_ns()`
+calls at callback entry and exit, one `hist.add()`.
+
+Reported per run:
+
+| Statistic | How |
+|---|---|
+| p50 / p99 / **p99.9** / max callback duration | `MsHistogram.percentile()` |
+| Looper-attributed xruns | `set_xrun_callback` count, on the non-RT thread |
+| Graph load | `client.cpu_load` sampled by the main thread on the 5 s summary |
+| GC | `gc.get_stats()` collection counts at t=0 and t=600 s |
+| Memory | `VmRSS` from `/proc/self/status` at t=60 s and t=600 s |
+| Allocation | `tracemalloc` snapshots at callback 1 000 and 100 000 |
+
+Two caveats that must appear in the recorded result or the number is misleading:
+
+1. `MsHistogram.percentile()` is nearest-rank on the bucket's **upper edge**, so
+   every reported percentile is an **upper bound**. Conservative in the right
+   direction for a kill test, but it must be labelled.
+2. p99.9 needs ≥ 1 000 samples. At 256 frames / 48 kHz there are 187.5 callbacks
+   per second, so the minimum honest window is ~5.3 s and the 10-minute run gives
+   ~112 500 samples. At budget/16 = 0.333 ms per bucket and 128 buckets, the top
+   edge is ~42.7 ms — wide enough that the tail lands in a real bucket rather than
+   overflow.
+
+**Fixed run conditions.** Change one of these and the numbers are not comparable:
+
+```
+profile          standalone           (Phase 2 targets standalone only)
+MPE_JACK_BUFFER  256    MPE_JACK_PERIODS 3    48 kHz, 24-bit
+CPU governor     performance
+Surge load       the heavy patch + 8-note chord that produced "mild crackle"
+                 at 256x3 in jack-audio-engine-spec.md §Evidence
+Looper load      4 layers playing, 1 recording for the first 30 s
+Duration         10 minutes continuous
+```
+
+**Where results land.** `docs/measurements/looper-jack-callback-YYYY-MM-DD.md`,
+one file per run, fixed table, plus the verdict from §C.4 applied to those
+numbers. Index in `docs/measurements/README.md`. **The directory does not exist
+yet** — Task 6 creates it. Spec criterion 9 already names `docs/measurements/`
+as the destination, so this is filling in a promise the governing spec made.
+
+### C.4 The kill criterion
+
+Period at 256 frames / 48 kHz = **5.333 ms**. Applied to the §C.3 run:
+
+| Measured | Verdict |
+|---|---|
+| p99 ≤ **1.07 ms** (20% of period) **and** p99.9 < **2.67 ms** (50%) **and** 0 looper-attributed xruns | **Ship Python at 256.** |
+| p99 in (1.07, 2.67] ms, 0 xruns | **Re-run the protocol at 512 frames** (10.67 ms period) and ship there if it passes, logging the latency cost. 512×3 measured 32 ms with 0 xruns and is the config Mitch called *"sounds the best so far"* (§Evidence). |
+| p99.9 ≥ **2.67 ms** at 512, **or** any looper-attributed xrun in the window — **while `MixWorkspace.mix()` measured alone is < 0.2 ms** | **Escalate to a compiled mix kernel** behind the same `MixBackend`. The cost is interpreter and binding overhead, not arithmetic, which is exactly what compiling removes. This is the trigger the governing spec's Non-Goals reserve. |
+| A compiled kernel behind the same interface still fails p99.9 < one period | **Stop. Phase 1 + an I2S HAT.** The constraint is the Python↔JACK callback boundary, not the mixer. This is the spec's own Falsification Analysis outcome — *"if Phase 2 proves painful, the honest fallback is Phase 1 only + a HAT, not pushing through."* |
+
+**Why 20% and 50%, and not 100% or a guess:**
+
+- The looper is the **second** client in the graph. Surge is first, and §Evidence
+  already records *mild crackle on a heavy patch + 8 notes at 256×3* — the cycle
+  is near-full **before** the looper exists. A secondary client taking more than
+  a fifth of the cycle is spending headroom that is already committed.
+- 20% is calibrated against measured work, not intuition. The `audioop` mixer
+  costs **0.090 ms per 512-frame period at three layers**
+  (`AUDIO-ENGINE-FOUNDATION.md` §Appendix — median of 30 real mixes, on this Pi)
+  ≈ **0.045 ms per 256-frame period** ≈ **0.85% of the period**. A 1.07 ms budget
+  is roughly **24× the measured arithmetic**. Everything above 0.045 ms is
+  interpreter, cffi and GIL. If Python cannot fit in 24× the C cost, tuning will
+  not close the gap.
+- 50% for the tail rather than 100%: a callback that merely touches the deadline
+  is already an xrun in a shared graph, because Surge's cycle time is subtracted
+  first. Half a period is the last point at which the overrun is still ours to
+  fix instead of audible.
+
+**This threshold is a decision on incomplete data and is meant to be revised
+once — after the first run — and never again.** If the first measurement lands
+in a band these numbers did not anticipate, revise the table in this file with
+the measurement cited, before deciding. That is the discipline spec Open Q1 was
+protecting when it declined to guess a number.
+
+---
+
+## D. Branch and dependency strategy
+
+### D.1 Measured state
+
+| Fact | Source |
+|---|---|
+| `dev` is **not** an ancestor of `yolo/looper-phase0`; merge-base is `da70ee5` | `git merge-base dev yolo/looper-phase0` |
+| `yolo/looper-phase0` is **76 ahead / 1 behind** `dev` | `git rev-list --count` both directions |
+| PR #48: +7264 / −94 across 69 files, 76 commits, `mergeable_state: clean` | GitHub API |
+| PR #48 unchecked gate items: 10-min Pi passthrough @ 512; Surge→Loopback with live signal; one-bar loop mix + latency A/B; repeat @ 256 | PR #48 body |
+| PR #48's passed item: *"Pi passthrough 30 s @ 512 — 0 xruns"*, annotated *"silence path; Surge→loopback routing still needed for signal"* | PR #48 body |
+| **The D5 guard does not exist on `yolo/looper-phase0`** — `scripts/mpe-looper.py` `main()` has no engine check | `git show yolo/looper-phase0:scripts/mpe-looper.py`, and `scripts/lib/engine-guard.sh:9-12` says so explicitly |
+| PR #49 (Phase 1) targets `dev`, `mergeable_state: unstable`, defers criterion 10 to the phase0 merge | GitHub API; `jack-audio-engine-spec.md:81` |
+
+### D.2 Verdict
+
+**PR #48 is a hard prerequisite for looper *integration* (Tasks 5, 7–11). It is
+not a prerequisite for the *mixer* (Tasks 1–4, 6).**
+
+`patch_browser/looper_mix.py` and `patch_browser/looper_ring.py` are new files
+with new tests. They import nothing that lives only on `yolo/looper-phase0`. The
+semantics they must reproduce — the `audioop` fold and the headroom law — are
+transcribed exactly into §A.1 and §A.2 of this document, sourced to
+`looper_engine.py:226-296` and to `_audioop.c`. The golden fixture is generated
+from `audioop` itself, which is a pip/apt package, not a branch.
+
+### D.3 The soak gate is soaking dead code
+
+All four unchecked items on PR #48 exercise `snd-aloop` + `arecord`/`aplay` +
+pipes — the architecture criterion 7 **deletes**. Ten minutes of Pi bench time
+spent proving that pipeline is stable buys confidence in code that will not exist
+after Task 8. That is the wrong thing to ask the repo owner for.
+
+**Recommendation — D-L6.** Merge PR #48 to `dev` on the strength of its unit
+suite and the already-passed 30 s zero-xrun run, with the four ALSA-pipeline soak
+items **struck from the gate** and replaced by (a) the criterion 10 guard boot
+test, which is cheap and has now been deferred twice, and (b) the §C.3 ten-minute
+JACK-callback run, which becomes Phase 2's real gate. Merging cannot regress the
+default appliance: with the guard in place and the default engine `jack`, the
+merged looper is refused at runtime (spec D5).
+
+### D.4 The human ask
+
+Only Mitch can do this. It is one bench session, roughly 20 minutes, and it
+replaces four.
+
+> **Order matters: merge PR #49 (Phase 1) first, then #48.** #48's head
+> (`811b6cc`) predates Phase 1 and touches `start-surge-cli.sh`,
+> `detect-audio-device.sh` and `99-usb-audio.rules`, all of which Phase 1 rewrote.
+> Rebasing #48 onto post-#49 `dev` is Task 0 and is agent work, not yours.
+>
+> **After Task 0 lands the guard on the rebased branch, run this once on the Pi:**
+>
+> 1. `git fetch && git checkout yolo/looper-phase0 && git pull && ./scripts/configure-pi-paths.sh --local --force`
+> 2. Set `MPE_LOOPER_ENABLED=1` in `/etc/mpe/mpe.env`. Reboot.
+> 3. `mpe engine status` → expect `looper=guarded`.
+> 4. `journalctl -u mpe-looper -n 50` → expect **one** `LOOPER-GUARDED` line and
+>    **no restart loop**.
+> 5. `mpe status` → `mpe-looper.service` not cycling.
+>
+> **The question:** did the appliance boot with audio and exactly one guarded
+> refusal? **Yes** → merge #48; that closes criterion 10 and criterion 13's full
+> badge together. **No** → the guard is wrong, and Phase 2 integration waits while
+> it is fixed.
+>
+> **Strike from PR #48's checklist** (each soaks the pipeline Phase 2 deletes):
+> 10-min passthrough @ 512; Surge→Loopback live-signal passthrough; one-bar loop
+> mix + latency A/B; repeat @ 256.
+
+### D.5 ALSA removal and the guard message
+
+ALSA was removed entirely as a product audio path (2026-08-13 amendment to
+`jack-audio-engine-spec.md`). Effects on this design:
+
+1. **No dependency.** Nothing in §A–§C assumes ALSA or auto-fallback exists. The
+   looper is a JACK client; when there is no graph, there is no looper, and that
+   is the correct behaviour.
+2. **The guard message is final until Phase 2 ships.** `engine-guard.sh` and
+   `patch_browser/audio_engine.py` refuse the looper whenever
+   `MPE_LOOPER_ENABLED=1`, with no alternate engine to switch to. Criterion 11
+   deletes the guard when the callback client lands.
+3. **Guard policy is unconditional.** `looper_guard_blocked()` keys on
+   `MPE_LOOPER_ENABLED` only (`patch_browser/audio_engine.py:36-38`), not on a
+   configured engine — matching the post-amendment world where JACK is the only
+   engine.
+
+---
+
+## E. Scope split
+
+**Startable immediately, laptop only, zero dependency on PR #48 or the Pi:**
+
+| Task | Output |
+|---|---|
+| 1 | Fixture set + golden `.npz` |
+| 2 | `NumpyInt16Backend` + bit-exact parity test (criterion 8) |
+| 3 | `NumpyFloat32Backend` + `MixWorkspace` + zero-allocation test (criteria 8b, 9a) |
+| 4 | `LoopRing` with `read_into` / `write_from` |
+| 6 | `docs/measurements/` and its result template |
+
+These are five PRs that can start tonight against `dev`, before #48 moves.
+
+**Blocked on PR #48 merged to `dev`:** Task 5 (rewire `ClipMatrix` /
+`LooperSession` onto the workspace, delete the `bytes` mixer and the interpreted
+fallback). This is where `clip_matrix.process_period` — which today allocates a
+`list`, a fresh `bytes` per playing layer via `read_frames_for_loop`, and a
+generator (`clip_matrix.py:159-207`) — becomes allocation-free. That method, not
+the mixer, is the dominant per-period allocation today.
+
+**Blocked on Pi hardware in the loop:** Tasks 7–11 — the callback client, the
+topology reconciler, criterion 7's `snd-aloop` retirement, the §C.3 measurement
+run, and guard removal.
+
+---
+
+## Task Breakdown
+
+The repo has no sibling `*-tasks.md` convention (all four existing files in
+`Documents/specs/` embed their phasing), so the breakdown lives here.
+
+One PR each, targeting **`dev`**, branch `yolo/<slug>`, per
+[`docs/GIT-WORKFLOW.md`](../../docs/GIT-WORKFLOW.md). Every PR runs
+`mpe test local all` before opening. **🔒 = human gate (Mitch only).**
+
+| # | Task | Where | Depends on | Acceptance |
+|---|------|-------|-----------|-----------|
+| **0** | 🔒 **Rebase `yolo/looper-phase0` onto post-#49 `dev`; add the D5 guard to `mpe-looper.py` `main()`** | Laptop + 🔒 Pi boot test | PR #49 merged | Conflicts resolved in `start-surge-cli.sh`, `detect-audio-device.sh`, `99-usb-audio.rules`. `main()` calls `looper_guard_blocked` / `looper_guard_exit_code` (`patch_browser/audio_engine.py:38-54`). Guard boot test of §D.4 passes → **criterion 10**. Then 🔒 merge #48 |
+| **1** | Mixer fixture set + `audioop` golden | Laptop | none | `tests/fixtures/mixer_cases.py` covers all 10 rows of §A.5; `tests/fixtures/mixer_golden_audioop.npz` committed and regenerable by a documented one-liner; a test asserts the golden matches a live `audioop` run when `audioop` is importable, and skips cleanly when it is not |
+| **2** | `NumpyInt16Backend` + bit-exact parity | Laptop | 1 | `patch_browser/looper_mix.py` with `MixBackend`, `mix_gains`, `AudioopBackend`, `NumpyInt16Backend`, `MixShapeError`. `tests/test_looper_mix_parity.py` asserts `np.array_equal` on every case. `MixShapeError` raised before any write to `out`. → **criterion 8** |
+| **3** | `NumpyFloat32Backend` + `MixWorkspace` + allocation proof | Laptop | 2 | Cross-profile agreement within 1 LSB → **criterion 8b**. `tracemalloc` delta == 0 across 10 000 `MixWorkspace.mix()` calls → **criterion 9a**. `set_blocksize()` never reallocates (assert `ndarray.__array_interface__['data'][0]` is stable) |
+| **4** | `LoopRing` — NumPy ring with `read_into` / `write_from` | Laptop | 3 | Semantics match `StereoRingBuffer` including `read_frames_for_loop`'s partial-clip zero-fill (`looper_engine.py:151-179`); `tracemalloc` delta == 0 across 10 000 `read_into` calls; the ring test cases from `tests/test_looper_engine.py` pass against it |
+| **5** | Rewire `ClipMatrix` / `LooperSession` onto the workspace; delete the `bytes` mixer | Laptop | 4, **PR #48 merged** | `process_period` takes and fills preallocated arrays; `tracemalloc` delta == 0 across 10 000 calls with 4 layers. `mix_live_and_loops`, `mix_s16_stereo`, `apply_gain_s16_stereo`, `audio_mix_backend` and the interpreted fallback deleted; `audioop-lts` dropped from `requirements.txt`. Existing `tests/test_looper_engine.py` ring + quantize cases still pass |
+| **6** | `docs/measurements/` scaffold | Laptop | none | Directory, `README.md` index, and the §C.3 result template with the two percentile caveats pre-written into it |
+| **7** | 🔒 Install `python3-jack-client` + `python3-numpy` on the Pi | 🔒 Pi | none | `apt install python3-jack-client python3-numpy`; version recorded in `docs/measurements/README.md`; `BUILD-FROM-ZERO.md` updated. **Human gate: appliance package install** |
+| **8** | JACK callback client — ports, callback, topology reconciler | Pi | 5, 6, 7 | `mpe-looper` registers 4 ports; insert topology of §B.3 with Surge disconnected from `system:playback`; no `arecord`/`aplay` children; `looper_audio_io.py`, `looper_alsa_stderr.py`, `looper-audio-route.sh` deleted → **criterion 7**. Topology survives a Surge restart → **criterion 18** |
+| **9** | Fail-open on looper death | Pi | 8 | `surge-watchdog.sh` reconnects Surge to `system:playback` when the engine is JACK, Surge is unconnected, and no `mpe-looper` client exists. `pkill -KILL` test → **criterion 19** |
+| **10** | GC discipline + callback instrumentation | Pi | 8 | `gc.freeze()` + `gc.disable()` after warm-up; `MsHistogram` wired to callback entry/exit; xrun count from `set_xrun_callback`; `tracemalloc` checkpoints at callback 1 000 / 100 000 → **criteria 9b, 9c, 9d** |
+| **11** | 🔒 **The measurement run and the verdict** | 🔒 Pi | 10 | §C.3 protocol executed under the fixed conditions; result written to `docs/measurements/looper-jack-callback-YYYY-MM-DD.md`; §C.4 verdict applied and recorded → **criterion 9e**. **Human gate: this decides whether Phase 2 ships in Python** |
+| **12** | Remove the D5 guard | Pi | 11 verdict = ship | `engine-guard.sh` deleted; `LOOPER_GUARD_MESSAGE`, `looper_guard_blocked`, `looper_guard_exit_code` removed; `engine.state` reports `looper=enabled`; HUD `L⛔` badge removed → **criterion 11**. `DECISIONS`-style row in `CHANGELOG.md` |
+
+**Human gates, collected:** Task 0 (merge decision + guard boot test), Task 7
+(appliance package install), Task 11 (the ship/escalate/stop verdict), and Task 12
+only if Task 11 said ship. Nothing else needs Mitch.
+
+**No schema changes anywhere in Phase 2.** No migrations, no
+`/etc/mpe/mpe.env` key additions beyond what Phase 1 shipped.
+
+---
+
+## Security Considerations
+
+- **Data flow:** local audio only. No network surface added. The looper gains no
+  new file writes beyond the existing tmpfs timing state
+  (`patch_browser/looper_timing_state.py`).
+- **Privilege:** the looper stops needing `sudo modprobe snd-aloop`, so Phase 2
+  **removes** a privileged call from the looper path
+  (`scripts/looper-audio-route.sh` deleted). Calibration keeps its own.
+- **Realtime:** the looper's audio thread gets its priority from jackd (D4), not
+  from `chrt`. A runaway FIFO thread could starve the touch UI and SSH; priority
+  remains a server-assigned constant, never user input.
+- **New dependency:** `python3-jack-client` from Debian trixie main, and
+  `python3-numpy`. Both distro-packaged, both already dependencies of packages
+  the appliance installs. No pip, no PEP 668 override.
+- **Input validation:** CLI arguments stay fixed enums so the Cursor allowlist
+  boundary holds.
+- **Failure modes:** the looper as an insert is a **new single point of failure**
+  for all audio. Criterion 19 exists precisely for this and is not optional.
+- **RLS:** N/A.
+
+## Assumptions & Constraints
+
+Assumptions whose falsity invalidates the plan, and how each is detected:
+
+| Assumption | If false | Detect by |
+|---|---|---|
+| A Python callback holds a 256-frame deadline on this Pi | Phase 2 unshippable in Python; the compiled kernel moves from deferred to required | **Task 11**, against the §C.4 table. This is the governing spec's own listed assumption (`jack-audio-engine-spec.md:285`) |
+| Surge's JUCE JACK backend tolerates being disconnected from `system:playback` and does not force the reconnection | The insert topology is unbuildable; the looper must become a send and stop mixing live, which changes the gain law | Task 8, `jack_lsp -c` immediately after disconnect and again 60 s later |
+| Per-callback allocation is **constant**, not merely small | GC or arena growth eventually produces an audible dropout on a long set | Criteria 9b and 9d, over 10 minutes |
+| The `audioop` fold is reproducible bit-exactly in NumPy | Criterion 8 is unmeetable as written and must be re-scoped to a tolerance | **Task 2 — laptop, immediate, no hardware.** This is the cheapest way to falsify the largest piece of §A |
+| jackd's 256-frame period leaves room for a second client | The looper only ships at 512, at a real latency cost | Task 11 |
+
+Constraints: Pi 4B Rev 1.5, Debian 13 trixie 13.5, kernel `6.18.34+rpt-rpi-v8`
+`SMP PREEMPT` — **not** `PREEMPT_RT` (`docs/LATENCY-SPIKE.md:35-37`). jackd2
+1.9.22. USB Full Speed DAC shared with LUMI and APC MINI. `standalone` profile
+only.
+
+## Evidence
+
+Measured facts this design rests on, with sources. Everything not in this table
+is a working hypothesis.
+
+| Finding | Measurement | Source |
+|---|---|---|
+| `audioop.mul` rounds toward −∞ after clamping | `fbound()` — clamp, `floor()`, cast | `_audioop.c` `fbound()` @ `dc1e6078` |
+| `audioop.add` for width 2 is an integer add with clamp, no rounding | `newval = val1 + val2` then clamp | `_audioop.c` `audioop_add_impl()` |
+| int16 saturation bounds | `0x7FFF` / `-0x8000` | `_audioop.c` `maxvals[]` / `minvals[]` |
+| `JACK-Client` allocates a cffi buffer + ndarray per `get_array()` | `_ffi.buffer(...)`, `np.frombuffer(...)` | `spatialaudio/jackclient-python` `src/jack.py` |
+| Caching port buffers across callbacks is deprecated in JACK 2.0 | `get_buffer()` docstring | same |
+| `python3-jack-client` 0.5.3-1 exists in Debian trixie | Depends `python3-cffi`, `libjack-jackd2-0`; suggests `python3-numpy` | packages.debian.org/trixie |
+| `audioop` mixer cost, 3 layers, 512-frame period, this Pi | **0.090 ms** (median of 30 real mixes) = 0.8% of a 10.67 ms period | `AUDIO-ENGINE-FOUNDATION.md` §Appendix |
+| Graph at 256×3 24-bit | 16 ms, 0 xruns idle; **mild crackle** on heavy patch + 8 notes | `jack-audio-engine-spec.md` §Evidence |
+| Graph at 512×3 24-bit | 32 ms, 0 xruns, *"sounds the best so far"* | same |
+| Surge auto-connects to `system:playback` with no `jack_connect` | `Surge XT:out_{1,2} → system:playback_{1,2}` | same |
+| RT topology under jackd | jackd audio thread FIFO 70, Surge audio thread FIFO 65 | same |
+| Calibration `modprobe`s `snd-aloop` and unloads it when idle | `ensure_snd_aloop()` / `unload_snd_aloop_if_idle()` | `calibration_loopback.py:34-46`, `calibration_teardown.py:27-35` |
+| Phase 1 already unloads idle `snd-aloop` in the Surge start path | sources `lib/unload-snd-aloop.sh` | `start-surge-cli.sh:115-119` |
+| The D5 guard is absent from `yolo/looper-phase0` | no engine check in `mpe-looper.py` `main()` | `git show yolo/looper-phase0:scripts/mpe-looper.py`; stated in `engine-guard.sh:9-12` |
+| No mixer fixture files exist on any branch | no `.wav` / `.raw` / `.pcm` / `fixture` path | `git ls-tree -r --name-only yolo/looper-phase0` |
+| `yolo/looper-phase0` is 76 ahead / 1 behind `dev` | merge-base `da70ee5` | `git rev-list --count` |
+
+## Open Questions
+
+Resolved here, recorded because the governing spec listed them:
+
+- **Spec Open Q3 — `snd-aloop` retirement.** Answered in §B.4: calibration
+  depends on it, load/unloads on demand, so nothing blocks. Criterion 7's `lsmod`
+  check is qualified rather than absolute.
+- **Spec Open Q2 — JACK transport.** Deferred by choice, not by ignorance: the
+  drift that motivated the question is removed by sharing a sample clock. Revisit
+  only if a second client needs to sync.
+
+Still open, each with the exact thing that would close it:
+
+| # | Question | Closed by |
+|---|---|---|
+| OQ-1 | Does JUCE's JACK backend re-assert `Surge XT:out_* → system:playback_*` after we disconnect it, without a Surge restart? If yes, the insert topology needs a different mechanism than a reconciler. | On the Pi with Phase 1 running: `jack_disconnect "Surge XT:out_1" system:playback_1 && sleep 60 && jack_lsp -c \| grep -A1 "Surge XT:out_1"`. **Do this before Task 8** — it is 60 seconds and it can invalidate §B.3. |
+| OQ-2 | Is the appliance's Python 3.13 or 3.14? Determines whether `audioop-lts` is the only route and whether the Task 1 golden can be regenerated on the appliance at all. | `mpe sysinfo` on the Pi, or add a `python-version` line to it. Not blocking — the golden is committed. |
+| OQ-3 | Is `mlockall` needed, or does jackd's client already do it for us? | Task 11: run the protocol once with and once without, compare p99.9. One variable, one comparison. |
+| OQ-4 | Does `jackd -s` (softmode, kept per spec §Technical Notes) mask looper-caused xruns from `set_xrun_callback`, or are they still reported? | Task 10: force an overrun with a deliberate `time.sleep(0.02)` in the callback and confirm the counter increments. If softmode hides them, criterion 9e needs a different xrun source and the §C.4 table's "0 xruns" clause is unverifiable as written. |
+
+## Rollback
+
+- Tasks 1–6 are additive: new files, no call-site changes. Revert is a file
+  deletion.
+- Task 5 changes `ClipMatrix`; revert restores the `bytes` mixer. `audioop-lts`
+  must come back into `requirements.txt` in the same revert.
+- Tasks 8–12: `MPE_LOOPER_ENABLED=0` disables the looper without touching the
+  graph. Full revert is `git revert` on `dev`; the Pi runs `main` until
+  promotion.
+- If Task 11's verdict is *stop*, Phase 1 stands on its own and the D5 guard
+  stays permanently. That is a shippable end state, not a failure.

--- a/config/99-usb-audio.rules
+++ b/config/99-usb-audio.rules
@@ -1,8 +1,9 @@
 # udev rules for USB audio device hot-plug support
-# Automatically restart Surge XT CLI when USB audio devices are connected/disconnected
+# Automatically restart the JACK graph when external USB audio devices connect/disconnect.
 #
-# This ensures that when you plug in a USB DAC after the system has booted,
-# Surge will restart and detect the newly connected device.
+# Skip-listed cards (HDMI, UAC2 gadget passthrough, snd-aloop) are filtered in
+# restart-audio-graph.sh — ATTR{id} cannot match on remove, so SOUND_CARD_ID is
+# stamped at add time and read from the udev db on remove.
 #
 # Installation:
 #   sudo cp 99-usb-audio.rules /etc/udev/rules.d/
@@ -10,20 +11,14 @@
 #
 # Testing:
 #   1. Plug/unplug USB audio device
-#   2. Check logs: sudo journalctl -u surge-xt-cli -f
-#   3. Verify service restarted: systemctl status surge-xt-cli
+#   2. Check logs: sudo journalctl -u mpe-jackd -f
+#   3. Verify graph restarted: mpe engine status
 
-# Skip HDMI and USB gadget passthrough card (bind/unbind via usb-audio-gadget.service)
-ACTION=="add|remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", ATTR{id}=="vc4hdmi*", GOTO="mpe_usb_audio_end"
-ACTION=="add|remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", ATTR{id}=="UAC2Gadget", GOTO="mpe_usb_audio_end"
-ACTION=="add|remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", ATTR{id}=="UAC2", GOTO="mpe_usb_audio_end"
-# Skip snd-aloop (calibration loads/unloads this; must not restart production Surge mid-run)
-ACTION=="add|remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", ATTR{id}=="Loopback", GOTO="mpe_usb_audio_end"
+# Persist card id for remove events (ATTR{} is gone once the card is unlinked).
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", ATTR{id}=="?*", ENV{SOUND_CARD_ID}="%s{id}"
 
 # Restart audio graph when external USB audio devices connect/disconnect.
 # restart-audio-graph.sh restarts mpe-jackd.service — the only audio engine
 # (spec D2, criterion 15). --no-block is inside the script.
-ACTION=="add", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", RUN+="@MPE_MODULE_REPO@/scripts/restart-audio-graph.sh"
-ACTION=="remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", RUN+="@MPE_MODULE_REPO@/scripts/restart-audio-graph.sh"
-
-LABEL="mpe_usb_audio_end"
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", RUN+="@MPE_MODULE_REPO@/scripts/restart-audio-graph.sh %E{SOUND_CARD_ID}"
+ACTION=="remove", SUBSYSTEM=="sound", KERNEL=="card[0-9]*", RUN+="@MPE_MODULE_REPO@/scripts/restart-audio-graph.sh %E{SOUND_CARD_ID}"

--- a/patch_browser/surge_audio.py
+++ b/patch_browser/surge_audio.py
@@ -1,4 +1,4 @@
-"""Surge ALSA buffer size and sample rate — persisted in /etc/mpe/mpe.env."""
+"""Surge audio settings — JACK graph buffer (display) and legacy Surge keys."""
 
 from __future__ import annotations
 
@@ -11,11 +11,13 @@ MPE_ENV_PATH = Path("/etc/mpe/mpe.env")
 SET_SURGE_AUDIO_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "set-surge-audio.sh"
 
 BUFFER_PRESETS: tuple[int, ...] = (32, 64, 128, 256, 512, 768, 1024, 2048)
+JACK_PERIODS_PRESETS: tuple[int, ...] = (2, 3, 4)
 SAMPLE_RATE_PRESETS: tuple[int, ...] = (44100, 48000)
 
-# Must stay in sync with the fallback in scripts/start-surge-cli.sh.
-# 768 drops voices under heavy MPE polyphony on Pi 4; 512 choked outright.
+# Legacy Surge key — still read by calibration and MIDI offset auto-derivation.
 DEFAULT_BUFFER = 1024
+DEFAULT_JACK_PERIOD = 256
+DEFAULT_JACK_PERIODS = 3
 DEFAULT_SAMPLE_RATE = 48000
 
 AUDIO_SWITCH_TIMEOUT_S = 45.0
@@ -48,10 +50,27 @@ def read_int_from_env_file(key: str, path: Path = MPE_ENV_PATH) -> int | None:
 
 
 def current_buffer_size() -> int:
+    """Legacy Surge buffer key — not the playing JACK period (see current_jack_period)."""
     return _read_env_int(
         "MPE_SURGE_BUFFER_SIZE",
         DEFAULT_BUFFER,
         valid=frozenset(BUFFER_PRESETS),
+    )
+
+
+def current_jack_period() -> int:
+    return _read_env_int(
+        "MPE_JACK_BUFFER",
+        DEFAULT_JACK_PERIOD,
+        valid=frozenset(BUFFER_PRESETS),
+    )
+
+
+def current_jack_periods() -> int:
+    return _read_env_int(
+        "MPE_JACK_PERIODS",
+        DEFAULT_JACK_PERIODS,
+        valid=frozenset(JACK_PERIODS_PRESETS),
     )
 
 
@@ -64,6 +83,7 @@ def current_sample_rate() -> int:
 
 
 def buffer_latency_ms(buffer: int | None = None, sample_rate: int | None = None) -> float:
+    """Single-period latency for a buffer size (legacy helper)."""
     buf = buffer if buffer is not None else current_buffer_size()
     rate = sample_rate if sample_rate is not None else current_sample_rate()
     if rate <= 0:
@@ -71,9 +91,34 @@ def buffer_latency_ms(buffer: int | None = None, sample_rate: int | None = None)
     return buf * 1000.0 / rate
 
 
+def graph_latency_ms(
+    period: int | None = None,
+    periods: int | None = None,
+    sample_rate: int | None = None,
+) -> float:
+    """End-to-end JACK server latency (period × periods)."""
+    jack_period = period if period is not None else current_jack_period()
+    jack_periods = periods if periods is not None else current_jack_periods()
+    rate = sample_rate if sample_rate is not None else current_sample_rate()
+    if rate <= 0:
+        return 0.0
+    return jack_period * jack_periods * 1000.0 / rate
+
+
 def buffer_option_label(buffer: int, sample_rate: int | None = None) -> str:
     ms = buffer_latency_ms(buffer, sample_rate)
     return f"{buffer} · {ms:.0f} ms"
+
+
+def graph_buffer_option_label(
+    period: int | None = None,
+    periods: int | None = None,
+    sample_rate: int | None = None,
+) -> str:
+    jack_period = period if period is not None else current_jack_period()
+    jack_periods = periods if periods is not None else current_jack_periods()
+    ms = graph_latency_ms(jack_period, jack_periods, sample_rate)
+    return f"{jack_period} × {jack_periods} · {ms:.0f} ms"
 
 
 def sample_rate_option_label(sample_rate: int) -> str:
@@ -83,7 +128,7 @@ def sample_rate_option_label(sample_rate: int) -> str:
 
 
 def buffer_settings_label() -> str:
-    return f"Audio buffer — {buffer_option_label(current_buffer_size())}"
+    return f"Audio buffer — {graph_buffer_option_label()}"
 
 
 def sample_rate_settings_label() -> str:

--- a/patch_browser/surge_monitor.py
+++ b/patch_browser/surge_monitor.py
@@ -11,6 +11,9 @@ from pathlib import Path
 OSC_PORT = 53280
 
 
+from patch_browser.audio_engine import read_engine_state
+
+
 class SurgeMonitor:
     """Monitors Surge XT CLI process health and provides restart capability."""
 
@@ -160,7 +163,19 @@ class SurgeMonitor:
             print(f"Error reading Surge log: {e}")
             return None
 
+    def _graph_failure_blocks_restart(self) -> tuple[bool, str | None]:
+        state = read_engine_state()
+        if state.get("state") != "failed":
+            return False, None
+        reason = state.get("reason", "")
+        if reason in ("no-server", "no-jack-device"):
+            return True, "Fix DAC / jackd first — audio graph unavailable"
+        return False, None
+
     def restart_surge(self):
+        blocked, message = self._graph_failure_blocks_restart()
+        if blocked:
+            return False, message or "Audio graph unavailable"
         try:
             print("Attempting to restart Surge XT CLI...")
             result = subprocess.run(
@@ -183,6 +198,7 @@ class SurgeMonitor:
 
     def get_status_summary(self):
         is_healthy, error = self.check_health()
+        blocked, block_reason = self._graph_failure_blocks_restart()
         if is_healthy:
             if self.surge_pid:
                 details = f"PID {self.surge_pid}"
@@ -195,6 +211,6 @@ class SurgeMonitor:
             }
         return {
             "status": "Not Running",
-            "details": error or "Unknown error",
-            "can_restart": True,
+            "details": block_reason or error or "Unknown error",
+            "can_restart": not blocked,
         }

--- a/patch_browser/touch_browser_settings.py
+++ b/patch_browser/touch_browser_settings.py
@@ -10,9 +10,8 @@ from patch_browser.geometry import Rect
 from patch_browser.scroll_widgets import draw_vertical_scroll_edge_hints
 from patch_browser.midi_sync_settings import settings_summary_lines
 from patch_browser.surge_audio import (
-    buffer_option_label,
-    current_buffer_size,
     current_sample_rate,
+    graph_buffer_option_label,
     sample_rate_option_label,
 )
 from patch_browser.touch_ui_constants import (
@@ -44,7 +43,7 @@ class TouchBrowserSettingsMixin:
     def _audio_settings_summary_lines(self) -> list[str]:
         return settings_detail_lines(
             profile_settings_label(),
-            buffer_option_label(current_buffer_size(), current_sample_rate()),
+            graph_buffer_option_label(),
             sample_rate_option_label(current_sample_rate()),
         )
 

--- a/patch_browser/touch_browser_surge_audio_modal.py
+++ b/patch_browser/touch_browser_surge_audio_modal.py
@@ -9,10 +9,12 @@ from patch_browser.surge_audio import (
     SAMPLE_RATE_PRESETS,
     apply_buffer,
     apply_sample_rate,
-    buffer_option_label,
-    current_buffer_size,
+    buffer_settings_label,
+    current_jack_period,
     current_sample_rate,
+    graph_buffer_option_label,
     sample_rate_option_label,
+    sample_rate_settings_label,
 )
 from patch_browser.touch_ui_constants import SETTINGS_ROW_GAP, SETTINGS_ROW_H, TAP_MOVE_THRESHOLD_PX
 from patch_browser.touch_ui_enums import Screen
@@ -22,11 +24,10 @@ class TouchBrowserSurgeAudioModalMixin:
     """Mixin — expects TouchPatchBrowser host attributes."""
 
     def buffer_settings_row_label(self) -> str:
-        buf = current_buffer_size()
-        return f"Audio buffer — {buffer_option_label(buf)}"
+        return buffer_settings_label()
 
     def sample_rate_settings_row_label(self) -> str:
-        return f"Sample rate — {sample_rate_option_label(current_sample_rate())}"
+        return sample_rate_settings_label()
 
     def _open_surge_buffer_modal(self) -> None:
         self._surge_buffer_option_rects = []
@@ -45,7 +46,7 @@ class TouchBrowserSurgeAudioModalMixin:
         self.screen_state = Screen.SETTINGS
 
     def _select_surge_buffer(self, buffer: int) -> None:
-        if buffer == current_buffer_size():
+        if buffer == current_jack_period():
             self._close_surge_audio_modal()
             return
         self._close_surge_audio_modal()
@@ -107,7 +108,7 @@ class TouchBrowserSurgeAudioModalMixin:
             inner_w,
         )
 
-        current = current_buffer_size()
+        current = current_jack_period()
         scroll = int(self._surge_buffer_scroll.scroll_pixels)
         clip = self.screen.get_clip()
         self.screen.set_clip(scroll_vp.pygame_rect)
@@ -117,7 +118,7 @@ class TouchBrowserSurgeAudioModalMixin:
                 continue
             self._draw_theme_choice(
                 screen_rect,
-                buffer_option_label(preset),
+                graph_buffer_option_label(preset),
                 selected=preset == current,
                 pressed=self._pressed(f"buffer:{preset}"),
             )

--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -297,6 +297,24 @@ mpe_systemctl() {
     sudo -n systemctl "$@"
 }
 
+# Cards whose bind/unbind must not restart the production graph (spec D2).
+# udev remove events cannot match ATTR{id}; restart-audio-graph.sh receives
+# %E{SOUND_CARD_ID} from the udev database instead (see 99-usb-audio.rules).
+mpe_should_skip_graph_restart_for_card() {
+    local card_id="${1:-}"
+    case "$card_id" in
+        vc4hdmi* | UAC2Gadget | UAC2 | Loopback) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Criterion 2* failure path — publish state and exit (start-surge-cli.sh).
+mpe_publish_jack_engine_failure() {
+    local reason="${1:?reason required}"
+    mpe_engine_state_write "$MPE_ENGINE_NAME" none failed "$reason" "$(mpe_looper_state_label)"
+    mpe_surge_state_write none ""
+}
+
 mpe_restart_audio_graph() {
     local unit
     unit="$(mpe_audio_graph_unit)"
@@ -429,7 +447,7 @@ mpe_surge_on_jack_graph() {
     if ! command -v jack_lsp >/dev/null 2>&1; then
         return 1
     fi
-    jack_lsp 2>/dev/null | grep -qi 'surge'
+    timeout 3 jack_lsp 2>/dev/null | grep -qi 'surge'
 }
 
 # Back-compat alias used by udev helper and profile scripts.

--- a/scripts/restart-audio-graph.sh
+++ b/scripts/restart-audio-graph.sh
@@ -17,6 +17,12 @@ source "$SCRIPT_DIR/lib/paths.sh"
 source "$SCRIPT_DIR/lib/audio-engine.sh"
 
 UNIT="$(mpe_audio_graph_unit)"
+CARD_ID="${1:-${SOUND_CARD_ID:-}}"
+
+if [ -n "$CARD_ID" ] && mpe_should_skip_graph_restart_for_card "$CARD_ID"; then
+    echo "restart-audio-graph: skipped (card=$CARD_ID)"
+    exit 0
+fi
 
 if mpe_restart_audio_graph; then
     echo "restart-audio-graph: restarted $UNIT"

--- a/scripts/start-jackd.sh
+++ b/scripts/start-jackd.sh
@@ -41,4 +41,4 @@ case "$current_state" in
 esac
 
 exec jackd -R -P"$JACK_PRIO" -s \
-    -d alsa -d "$HW_DEV" -r "$JACK_RATE" -p "$JACK_BUFFER" -n "$JACK_PERIODS"
+    -d alsa -P "$HW_DEV" -r "$JACK_RATE" -p "$JACK_BUFFER" -n "$JACK_PERIODS"

--- a/scripts/start-surge-cli.sh
+++ b/scripts/start-surge-cli.sh
@@ -148,8 +148,7 @@ if [ -z "$ACTIVE_ENGINE" ]; then
     ENGINE_STATE=failed
     engine_log "CRITICAL: engine=jack state=failed reason=$ENGINE_REASON — no graph server available. No ALSA fallback exists; the appliance stays silent until jackd recovers."
     engine_log "CRITICAL: see $LOG_FILE and 'journalctl -u mpe-jackd' for the cause; check the DAC connection"
-    mpe_engine_state_write "$MPE_ENGINE_NAME" none failed "$ENGINE_REASON" "$(mpe_looper_state_label)"
-    mpe_surge_state_write none ""
+    mpe_publish_jack_engine_failure "$ENGINE_REASON"
     exit 1
 fi
 

--- a/scripts/surge-watchdog.sh
+++ b/scripts/surge-watchdog.sh
@@ -73,21 +73,20 @@ _reconcile_engine() {
     if ! mpe_jack_server_ready; then
         waited=0
         while [ "$waited" -lt "$RECONCILE_BUDGET" ]; do
+            sleep 1
+            waited=$((waited + 1))
             if mpe_jack_server_ready; then
                 break
             fi
-            sleep 1
-            waited=$((waited + 1))
         done
-        if ! mpe_jack_server_ready; then
-            _supervisor_restart_surge "jackd-down"
-            return 0
-        fi
     fi
 
-    if mpe_jack_server_ready && ! mpe_surge_on_jack_graph; then
-        _supervisor_restart_surge "promote-to-jack"
+    if ! mpe_jack_server_ready; then
+        _supervisor_restart_surge "jackd-down"
+        return 0
     fi
+
+    _supervisor_restart_surge "promote-to-jack"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
@@ -95,15 +94,24 @@ log "=== Surge Watchdog Started (engine=jack) ==="
 
 while true; do
     if systemctl is-failed "$SURGE_SERVICE" &>/dev/null; then
-        log "ALERT: Surge service failed, cleaning user defaults"
-
-        if [ -f "$USER_DEFAULTS" ]; then
-            BACKUP="${USER_DEFAULTS}.corrupted_$(date +%Y%m%d_%H%M%S)"
-            mv "$USER_DEFAULTS" "$BACKUP"
-            log "Backed up corrupted file to: $BACKUP"
-        fi
+        engine_reason="$(mpe_engine_state_get reason)"
+        case "$engine_reason" in
+            no-server | no-jack-device)
+                log "ALERT: Surge failed while graph unavailable (reason=$engine_reason) — not treating user defaults as corrupt"
+                ;;
+            *)
+                log "ALERT: Surge service failed, cleaning user defaults"
+                ;;
+        esac
 
         if _supervisor_restart_surge "surge-failed"; then
+            if [ "$engine_reason" != "no-server" ] && [ "$engine_reason" != "no-jack-device" ]; then
+                if [ -f "$USER_DEFAULTS" ]; then
+                    BACKUP="${USER_DEFAULTS}.corrupted_$(date +%Y%m%d_%H%M%S)"
+                    mv "$USER_DEFAULTS" "$BACKUP"
+                    log "Backed up corrupted file to: $BACKUP"
+                fi
+            fi
             sleep 2
             if [ -f "$USER_DEFAULTS" ]; then
                 chmod 644 "$USER_DEFAULTS" || true

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -34,6 +34,8 @@ AUDIO_ENGINE_SH = REPO_ROOT / "scripts" / "lib" / "audio-engine.sh"
 ENGINE_GUARD_SH = REPO_ROOT / "scripts" / "lib" / "engine-guard.sh"
 SURGE_WATCHDOG_SH = REPO_ROOT / "scripts" / "surge-watchdog.sh"
 START_SURGE_CLI_SH = REPO_ROOT / "scripts" / "start-surge-cli.sh"
+RESTART_AUDIO_GRAPH_SH = REPO_ROOT / "scripts" / "restart-audio-graph.sh"
+START_JACKD_SH = REPO_ROOT / "scripts" / "start-jackd.sh"
 SET_SURGE_AUDIO_SH = REPO_ROOT / "scripts" / "set-surge-audio.sh"
 SURGE_SERVICE = REPO_ROOT / "config" / "surge-xt-cli.service"
 WATCHDOG_SERVICE = REPO_ROOT / "config" / "surge-watchdog.service"
@@ -494,11 +496,8 @@ LOG_FILE="{env.get('MPE_RUN_DIR', '/tmp')}/surge-cli.log"
 {stubs}
 source {AUDIO_ENGINE_SH}
 mpe_wait_for_jack_server() {{ return 1; }}
-JACK_READY_TIMEOUT="$(mpe_jack_ready_timeout)"
 ENGINE_REASON="no-server"
-ENGINE_STATE=failed
-mpe_engine_state_write "$MPE_ENGINE_NAME" none failed "$ENGINE_REASON" "$(mpe_looper_state_label)"
-mpe_surge_state_write none ""
+mpe_publish_jack_engine_failure "$ENGINE_REASON"
 exit 1
 """
         return _run_bash_script(body, env=env)
@@ -698,6 +697,80 @@ case "$dir" in */mpe) echo fallback ;; *) exit 9 ;; esac
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "fallback")
         self.assertIn("WARNING", result.stderr)
+
+
+class GraphRestartSkipTests(unittest.TestCase):
+    def test_skip_loopback_card(self) -> None:
+        body = f"""
+source {AUDIO_ENGINE_SH}
+mpe_should_skip_graph_restart_for_card Loopback && echo skip || echo restart
+"""
+        result = _run_bash_script(body, env=_bash_env())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "skip")
+
+    def test_external_dac_not_skipped(self) -> None:
+        body = f"""
+source {AUDIO_ENGINE_SH}
+mpe_should_skip_graph_restart_for_card Play3 && echo skip || echo restart
+"""
+        result = _run_bash_script(body, env=_bash_env())
+        self.assertEqual(result.stdout.strip(), "restart")
+
+    def test_restart_script_filters_skip_cards(self) -> None:
+        text = RESTART_AUDIO_GRAPH_SH.read_text(encoding="utf-8")
+        self.assertIn("mpe_should_skip_graph_restart_for_card", text)
+        self.assertIn("skipped", text)
+
+
+class JackEngineFailurePublishTests(unittest.TestCase):
+    def test_publish_writes_failed_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            body = f"""
+source {AUDIO_ENGINE_SH}
+mpe_publish_jack_engine_failure no-server
+"""
+            result = _run_bash_script(body, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            state = Path(tmp, "engine.state").read_text(encoding="utf-8")
+            self.assertIn("state=failed", state)
+            self.assertIn("reason=no-server", state)
+            self.assertIn("active=none", state)
+
+
+class JackEnvValidatorTests(unittest.TestCase):
+    def test_jack_period_defaults(self) -> None:
+        body = f"""
+source {AUDIO_ENGINE_SH}
+printf '%s' "$(mpe_jack_period)"
+"""
+        result = _run_bash_script(body, env=_bash_env())
+        self.assertEqual(result.stdout.strip(), "256")
+
+    def test_invalid_jack_period_falls_back(self) -> None:
+        body = f"""
+source {AUDIO_ENGINE_SH}
+printf '%s' "$(mpe_jack_period)"
+"""
+        result = _run_bash_script(body, env=_bash_env(MPE_JACK_BUFFER="9999"))
+        self.assertEqual(result.stdout.strip(), "256")
+        self.assertIn("WARNING", result.stderr)
+
+    def test_jack_periods_allowlist(self) -> None:
+        body = f"""
+source {AUDIO_ENGINE_SH}
+printf '%s' "$(mpe_jack_periods)"
+"""
+        result = _run_bash_script(body, env=_bash_env(MPE_JACK_PERIODS="4"))
+        self.assertEqual(result.stdout.strip(), "4")
+
+
+class StartJackdPlaybackOnlyTests(unittest.TestCase):
+    def test_alsa_backend_opens_playback_only(self) -> None:
+        text = START_JACKD_SH.read_text(encoding="utf-8")
+        self.assertIn('-d alsa -P "$HW_DEV"', text)
+        self.assertNotIn('-d alsa -d "$HW_DEV"', text)
 
 
 if __name__ == "__main__":

--- a/tests/test_surge_audio.py
+++ b/tests/test_surge_audio.py
@@ -30,10 +30,22 @@ class SurgeAudioTests(unittest.TestCase):
             self.assertEqual(surge_audio.read_int_from_env_file("MPE_SURGE_BUFFER_SIZE", path), 512)
             self.assertEqual(surge_audio.read_int_from_env_file("MPE_SURGE_SAMPLE_RATE", path), 48000)
 
-    @mock.patch.dict(os.environ, {"MPE_SURGE_BUFFER_SIZE": "768", "MPE_SURGE_SAMPLE_RATE": "48000"}, clear=False)
+    @mock.patch.dict(
+        os.environ,
+        {
+            "MPE_JACK_BUFFER": "256",
+            "MPE_JACK_PERIODS": "3",
+            "MPE_SURGE_SAMPLE_RATE": "48000",
+        },
+        clear=False,
+    )
     def test_settings_labels(self) -> None:
-        self.assertIn("768", surge_audio.buffer_settings_label())
+        self.assertIn("256 × 3", surge_audio.buffer_settings_label())
+        self.assertIn("16 ms", surge_audio.buffer_settings_label())
         self.assertIn("kHz", surge_audio.sample_rate_settings_label())
+
+    def test_graph_latency_ms(self) -> None:
+        self.assertAlmostEqual(surge_audio.graph_latency_ms(256, 3, 48000), 16.0)
 
     def test_option_labels(self) -> None:
         self.assertEqual(surge_audio.buffer_option_label(768, 48000), "768 · 16 ms")

--- a/tests/test_surge_monitor.py
+++ b/tests/test_surge_monitor.py
@@ -1,0 +1,36 @@
+"""Tests for SurgeMonitor graph-failure restart gating."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from patch_browser.surge_monitor import SurgeMonitor
+
+
+class SurgeMonitorRestartGateTests(unittest.TestCase):
+    @mock.patch("patch_browser.surge_monitor.read_engine_state")
+    @mock.patch("patch_browser.surge_monitor.subprocess.run")
+    def test_blocks_restart_when_graph_failed(self, run_mock: mock.Mock, state_mock: mock.Mock) -> None:
+        state_mock.return_value = {"state": "failed", "reason": "no-server"}
+        monitor = SurgeMonitor()
+        ok, message = monitor.restart_surge()
+        self.assertFalse(ok)
+        self.assertIn("graph", message.lower())
+        run_mock.assert_not_called()
+
+    @mock.patch("patch_browser.surge_monitor.read_engine_state")
+    def test_status_disables_restart_on_graph_failure(self, state_mock: mock.Mock) -> None:
+        state_mock.return_value = {"state": "failed", "reason": "no-jack-device"}
+        monitor = SurgeMonitor()
+        monitor.is_healthy = False
+        monitor.last_error = "Surge not running"
+        with mock.patch.object(monitor, "check_health", return_value=(False, "Surge not running")):
+            summary = monitor.get_status_summary()
+        self.assertFalse(summary["can_restart"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Lands synthesis quick-fix items 1–9 on `yolo/jack-drop-alsa-fallback` **before** the Gate C Pi soak (spec-mandated merge blocker).

- **P0:** udev remove blind spot — `SOUND_CARD_ID` + skip filter in `restart-audio-graph.sh` (Loopback calibration no longer restarts jackd)
- **P0:** watchdog corrupt-defaults arm gated on `reason=no-server|no-jack-device`; `mv` only after cooldown allows restart
- **P1:** jackd playback-only (`-P`) — frees ALSA capture for `usb-host-session` mic bridge
- **P1:** criterion 16 UI — touch labels read `MPE_JACK_BUFFER × PERIODS` (legacy Surge key kept for calibration/MIDI)
- **P1:** `mpe_publish_jack_engine_failure()` extracted for criterion 2*; UI Surge restart blocked on graph failure
- **P1:** commit + amend `looper-jack-client-spec.md` off retired `MPE_AUDIO_ENGINE`
- **P1:** CI shellcheck + glob shell tests
- **Docs:** dual-model review + audit artifacts in `Documents/reviews/`

## Test plan

- [x] `mpe test local all` — green on laptop
- [ ] Merge this PR into `yolo/jack-drop-alsa-fallback`
- [ ] **Gate C soak** on Pi (`jack-audio-engine-spec.md:452-459`) — five scenarios + 5b/14 after `-P` verify
- [ ] PR `jack-drop-alsa-fallback` → `dev` only after Gate C PASS

## Demo-worthy

No — internal prep for hardware verification. Mitch sees nothing until Gate C on the Pi.