### PR TITLE
Fix Gate C 2*: watchdog survives Surge hard-failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 Notable engineering work, grouped by session. Each per-topic doc under `docs/`
 carries the detailed technical narrative; this file is the chronological index.
 
+## 2026-08-13 — Watchdog survives Surge hard-failure (Gate C 2* fix)
+
+Branch `yolo/watchdog-binds-fix`, based on `yolo/jack-drop-alsa-fallback` @
+`b0266ef`. Gate C soak on the Pi exposed the bug: mask jackd → `state=failed`
+works, but `unmask` + `start` never promoted because `surge-watchdog.service`
+was `BindsTo=surge-xt-cli.service` — systemd stopped the supervisor with the
+service it supervises, leaving nothing to reset and promote Surge once jackd
+returned.
+
+- **`config/surge-watchdog.service`:** `BindsTo=surge-xt-cli.service` removed;
+  `After=surge-xt-cli.service` kept for ordering only. `Restart=always` already
+  present.
+- **Docs updated:** `Documents/specs/jack-audio-engine-spec.md` D3 + Technical
+  Notes; comment in `scripts/lib/audio-engine.sh` now describes tmpfs rationale
+  without the removed coupling.
+- **Tests:** `test_watchdog_not_bound_to_surge` and
+  `test_watchdog_restarts_always` in `tests/test_audio_engine.py`.
+
+**Soak impact:** rerun Gate C 2* promotion after merge to the soak branch.
+
 ## 2026-08-13 — ALSA removed entirely as a product audio path (JACK-only)
 
 Branch `yolo/jack-drop-alsa-fallback`, based on `dev` @ `daac891` (PR #49

--- a/Documents/specs/jack-audio-engine-spec.md
+++ b/Documents/specs/jack-audio-engine-spec.md
@@ -310,9 +310,13 @@ given a chance) without coupling liveness (Surge still attempts to start, and
 therefore still reports, even when jackd does not).
 
 **Liveness is reconciled by the existing supervisor instead.**
-`surge-watchdog.sh` already supervises Surge and is already `BindsTo=surge-xt-cli`.
-It gains an engine reconciliation check on its existing cadence — collapsed to
-the single-engine case (amended 2026-08-13; the `engine=alsa` ignore row and
+`surge-watchdog.sh` already supervises Surge on its existing cadence. **It is
+deliberately not `BindsTo=surge-xt-cli.service`** (amended 2026-08-13): under
+the hard-failure design Surge exits non-zero when jackd is absent, and `BindsTo`
+would kill the supervisor on exactly the event that requires it to stay alive
+and promote Surge later. Ordering is `After=surge-xt-cli.service` only. It gains
+an engine reconciliation check on its existing cadence — collapsed to the
+single-engine case (amended 2026-08-13; the `engine=alsa` ignore row and
 the `active=alsa` degraded-promotion row are removed, not just unreachable):
 
 | Observed | Action |
@@ -338,11 +342,11 @@ to. Rules:
 | jackd restarted < 15 s ago | do not restart Surge | jackd has `Restart=always`; let it settle rather than fight it |
 | 3 supervisor restarts without reaching `ok` | stop; `state=failed`, log loudly | Prevents an unbounded slow loop |
 
-**State lives in `/run/mpe/`, not memory.** The watchdog is
-`BindsTo=surge-xt-cli.service` (`surge-watchdog.service:3-4`), so it is itself
-restarted every time it restarts Surge — an in-memory timestamp would be wiped on
-exactly the event it exists to rate-limit. `/run` is tmpfs, so it also clears on
-reboot, which is the correct lifetime.
+**State lives in `/run/mpe/`, not memory.** The watchdog restarts Surge and is
+itself long-running but restartable (`Restart=always`, plus any operator or
+systemd restart) — an in-memory timestamp would be wiped on exactly the events
+it exists to rate-limit. `/run` is tmpfs, so it also clears on reboot, which is
+the correct lifetime.
 
 Boot ordering is explicit: `mpe-jackd.service` is `After=sound.target` and its
 `ExecStartPre` waits for the selected device to exist; Surge is `After=` jackd with
@@ -549,8 +553,9 @@ soak.)*
 
 ## Technical Notes
 
-- `surge-watchdog.service` is `BindsTo=surge-xt-cli.service`, so it follows Surge
-  automatically and needs no separate ordering against jackd.
+- `surge-watchdog.service` is `After=surge-xt-cli.service` (not `BindsTo`), so
+  it starts after Surge but survives a Surge hard-failure and can promote once
+  jackd recovers.
 - jackd `-s` (softmode) prevents an xrun from tearing down the graph. Appropriate
   for a live instrument; keep it in the unit.
 - jackd's main thread is `SCHED_OTHER` by design — only the audio thread is RT.

--- a/config/surge-watchdog.service
+++ b/config/surge-watchdog.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Surge XT Crash Watchdog
+# Ordering only — NOT BindsTo. The watchdog must survive a hard Surge failure
+# (no-server/no-jack-device) so it can promote Surge once jackd recovers.
+# BindsTo made the supervisor die with the process it supervises (Gate C 2*).
 After=surge-xt-cli.service
-BindsTo=surge-xt-cli.service
 
 [Service]
 Type=simple

--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -7,9 +7,9 @@
 # that will not start is a hard failure, not a route to an alternate engine.
 #
 # Runtime state lives in /run/mpe (tmpfs). It must NOT live in a shell variable:
-# surge-watchdog.service is BindsTo=surge-xt-cli.service, so the supervisor is
-# itself restarted every time it restarts Surge — in-memory cooldown state would
-# be wiped on exactly the event it rate-limits (spec D3).
+# the watchdog restarts Surge and can itself be restarted (Restart=always) or
+# re-run across Surge restarts — in-memory cooldown state would be wiped on
+# exactly the events it rate-limits (spec D3).
 
 # Published in engine.state's `engine=` field as a static, non-configurable
 # constant — nothing reads MPE_AUDIO_ENGINE anymore, but `mpe engine status`

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -211,6 +211,18 @@ class RuntimeDirectoryPreserveTests(unittest.TestCase):
         wants = _systemd_unit_directives(sections, "Wants")
         self.assertIn("surge-watchdog.service", wants)
 
+    def test_watchdog_not_bound_to_surge(self) -> None:
+        # Gate C 2*: the watchdog must survive a hard Surge failure to promote
+        # once jackd recovers. BindsTo kills the supervisor with the supervised.
+        sections = _systemd_sections(WATCHDOG_SERVICE.read_text(encoding="utf-8"))
+        self.assertEqual([], _systemd_unit_directives(sections, "BindsTo"))
+        after = _systemd_unit_directives(sections, "After")
+        self.assertIn("surge-xt-cli.service", after)
+
+    def test_watchdog_restarts_always(self) -> None:
+        text = WATCHDOG_SERVICE.read_text(encoding="utf-8")
+        self.assertIn("Restart=always", text)
+
 
 def _systemd_sections(text: str) -> dict[str, list[str]]:
     """Parse a unit file into section -> non-empty, non-comment lines."""


### PR DESCRIPTION
## Summary

Gate C soak on the Pi found that **criterion 2\* promotion never happens**: after `mpe engine mask-jackd` + Surge hard-failure, `mpe engine unmask-jackd` + `mpe engine start-jackd` brings jackd back but nothing promotes Surge.

**Root cause:** `surge-watchdog.service` was `BindsTo=surge-xt-cli.service`. When `start-surge-cli.sh` exits 1 on `no-server`, Surge enters `failed` and systemd stops the watchdog with it. The supervisor that is supposed to `reset-failed` and restart Surge is dead.

**Fix:** `BindsTo` → `After=` (ordering only). `Restart=always` already present.

## Changes

- `config/surge-watchdog.service` — remove `BindsTo`, keep `After=surge-xt-cli.service`
- `Documents/specs/jack-audio-engine-spec.md` — update D3 reconciliation text, tmpfs rationale, Technical Notes
- `scripts/lib/audio-engine.sh` — update tmpfs rationale comment
- `tests/test_audio_engine.py` — add `test_watchdog_not_bound_to_surge` + `test_watchdog_restarts_always`
- `CHANGELOG.md` — session entry

## Test evidence

- `mpe test local all` — 440+ tests pass
- `mpe test local audio` — 135 tests pass (including new watchdog unit assertions)

## Soak verification needed

After merge to `yolo/jack-drop-alsa-fallback`, rerun Gate C 2\* on Pi:

1. `mpe engine mask-jackd` && `mpe restart surge` → expect `state=failed`
2. `mpe engine unmask-jackd` && `mpe engine start-jackd` → expect promotion to `state=ok` without manual Surge restart


Made with [Cursor](https://cursor.com)