### PR TITLE
Hermetic test isolation — Pi audio suite matches CI

### DIFF
--- a/docs/PATHS.md
+++ b/docs/PATHS.md
@@ -60,6 +60,18 @@ Touch HUD reads `engine.state` via `patch_browser/audio_engine.py`.
 
 Full list: [`config/mpe.env.example`](../config/mpe.env.example).
 
+### `MPE_ENV_FILE` (tests only)
+
+Subprocess unit tests set `MPE_ENV_FILE` so `paths.sh` does not read `/etc/mpe/mpe.env` on a configured Pi:
+
+| Value | Behavior |
+|-------|----------|
+| unset | Appliance default — source `/etc/mpe/mpe.env` when present |
+| empty (`MPE_ENV_FILE=`) | Hermetic — skip all env files; use process environment |
+| path to file | Source that file only (temp profile for subprocess tests) |
+
+Production systemd units never set this variable.
+
 ## Pi setup — reconfigure paths
 
 When you first set up (or move) the Pi, **verify or reconfigure** where repos and Surge paths live:

--- a/patch_browser/audio_profile.py
+++ b/patch_browser/audio_profile.py
@@ -13,6 +13,14 @@ PROFILE_OPTIONS: tuple[tuple[str, str, str], ...] = (
     ("usb-host", "USB direct", "Surge to PC when recording (analog mutes)"),
     ("usb-host-session", "USB session", "Analog stays on; mic return to PC"),
 )
+def profile_env_path() -> Path | None:
+    """Appliance canon file, or None when MPE_ENV_FILE='' (hermetic tests)."""
+    if "MPE_ENV_FILE" in os.environ:
+        raw = os.environ["MPE_ENV_FILE"].strip()
+        return Path(raw) if raw else None
+    return Path("/etc/mpe/mpe.env")
+
+
 MPE_ENV_PATH = Path("/etc/mpe/mpe.env")
 SET_PROFILE_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "set-audio-profile.sh"
 # Gadget wait (8s) + Surge restart without MIDI wait (~5–8s) + margin
@@ -50,7 +58,10 @@ def profile_switch_overlay_hint(profile: str) -> str:
 
 
 def current_profile() -> str:
-    from_file = read_profile_from_env_file(MPE_ENV_PATH)
+    path = profile_env_path()
+    if path is None:
+        return normalize_profile(os.environ.get("MPE_AUDIO_PROFILE"))
+    from_file = read_profile_from_env_file(path)
     if from_file is not None:
         return from_file
     return normalize_profile(os.environ.get("MPE_AUDIO_PROFILE"))

--- a/scripts/lib/paths.sh
+++ b/scripts/lib/paths.sh
@@ -8,7 +8,14 @@ else
 fi
 _MPE_MODULE_ROOT="$(cd "$_PATHS_LIB/../.." && pwd)"
 
-if [ -f /etc/mpe/mpe.env ]; then
+# MPE_ENV_FILE: test harness only — when set, skip /etc/mpe/mpe.env entirely.
+# Empty MPE_ENV_FILE = hermetic (process env only). Unset = appliance default.
+if [ -n "${MPE_ENV_FILE+x}" ]; then
+    if [ -n "$MPE_ENV_FILE" ] && [ -f "$MPE_ENV_FILE" ]; then
+        # shellcheck disable=SC1091
+        source "$MPE_ENV_FILE"
+    fi
+elif [ -f /etc/mpe/mpe.env ]; then
     # shellcheck disable=SC1091
     source /etc/mpe/mpe.env
 elif [ -f "${HOME:-/tmp}/.config/mpe/mpe.env" ]; then

--- a/tests/hermetic_env.py
+++ b/tests/hermetic_env.py
@@ -1,0 +1,32 @@
+"""Hermetic helpers — subprocess tests must not read /etc/mpe/mpe.env on the Pi."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_hermetic_mpe_env(tmp_dir: Path, profile: str, **extra: str) -> str:
+    """Write MPE_AUDIO_PROFILE (and extras) to a temp env file; return its path."""
+    path = tmp_dir / "mpe.env"
+    lines = [f"MPE_AUDIO_PROFILE={profile}"]
+    for key, value in extra.items():
+        lines.append(f"{key}={value}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def hermetic_env_skip_system() -> dict[str, str]:
+    """Set MPE_ENV_FILE so paths.sh skips /etc/mpe/mpe.env (process env only)."""
+    return {"MPE_ENV_FILE": ""}
+
+
+def hermetic_env_with_profile(tmp_dir: Path, profile: str, **extra: str) -> dict[str, str]:
+    """Return env updates pointing subprocesses at a temp appliance env file."""
+    return {"MPE_ENV_FILE": write_hermetic_mpe_env(tmp_dir, profile, **extra)}
+
+
+def isolated_path_prefix(tmp_dir: Path) -> str:
+    """Empty directory to prepend to PATH so jack_lsp and similar tools are absent."""
+    empty = tmp_dir / "isolated_bin"
+    empty.mkdir(exist_ok=True)
+    return str(empty)

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -15,6 +15,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tests.hermetic_env import isolated_path_prefix
+
 from patch_browser.audio_engine import (
     COOLDOWN_SEC,
     ENGINE_STATE_FILE,
@@ -415,9 +417,10 @@ source {AUDIO_ENGINE_SH}
 if mpe_jack_server_ready; then exit 9; fi
 echo ok
 """
-        env = _bash_env()
-        env["PATH"] = "/usr/bin:/bin"
-        result = _run_bash_script(body, env=env)
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env()
+            env["PATH"] = f"{isolated_path_prefix(Path(tmp))}:/usr/bin:/bin"
+            result = _run_bash_script(body, env=env)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "ok")
 
@@ -427,9 +430,10 @@ source {AUDIO_ENGINE_SH}
 if mpe_surge_on_jack_graph; then exit 9; fi
 echo ok
 """
-        env = _bash_env()
-        env["PATH"] = "/usr/bin:/bin"
-        result = _run_bash_script(body, env=env)
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env()
+            env["PATH"] = f"{isolated_path_prefix(Path(tmp))}:/usr/bin:/bin"
+            result = _run_bash_script(body, env=env)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "ok")
 

--- a/tests/test_audio_profile.py
+++ b/tests/test_audio_profile.py
@@ -23,16 +23,28 @@ class AudioProfileTests(unittest.TestCase):
         self.assertEqual(audio_profile.profile_option_label("standalone"), "Analog")
         self.assertEqual(audio_profile.profile_option_label("usb-host-session"), "USB session")
 
-    @mock.patch.dict(os.environ, {"MPE_AUDIO_PROFILE": "usb-host-session"}, clear=False)
+    @mock.patch.dict(
+        os.environ,
+        {"MPE_ENV_FILE": "", "MPE_AUDIO_PROFILE": "usb-host-session"},
+        clear=False,
+    )
     def test_header_badge_usb_session(self) -> None:
         self.assertEqual(audio_profile.header_badge_label(), "USB")
 
-    @mock.patch.dict(os.environ, {"MPE_AUDIO_PROFILE": "usb-host"}, clear=False)
+    @mock.patch.dict(
+        os.environ,
+        {"MPE_ENV_FILE": "", "MPE_AUDIO_PROFILE": "usb-host"},
+        clear=False,
+    )
     def test_header_badge_usb(self) -> None:
         self.assertEqual(audio_profile.header_badge_label(), "USB")
         self.assertTrue(audio_profile.settings_toggle_on())
 
-    @mock.patch.dict(os.environ, {"MPE_AUDIO_PROFILE": "standalone"}, clear=False)
+    @mock.patch.dict(
+        os.environ,
+        {"MPE_ENV_FILE": "", "MPE_AUDIO_PROFILE": "standalone"},
+        clear=False,
+    )
     def test_header_badge_analog(self) -> None:
         self.assertEqual(audio_profile.header_badge_label(), "Analog")
         self.assertFalse(audio_profile.settings_toggle_on())

--- a/tests/test_detect_audio_device.py
+++ b/tests/test_detect_audio_device.py
@@ -10,6 +10,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tests.hermetic_env import hermetic_env_with_profile
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DETECT_SCRIPT = REPO_ROOT / "scripts" / "detect-audio-device.sh"
 
@@ -43,9 +45,9 @@ def _run_detect(
         fake_surge.chmod(fake_surge.stat().st_mode | stat.S_IXUSR)
 
         env = os.environ.copy()
-        env["MPE_AUDIO_PROFILE"] = profile
         env["HOME"] = tmp
         env["MPE_UAC2_HOST_STREAMING_FLAG"] = str(Path(tmp) / "host-streaming")
+        env.update(hermetic_env_with_profile(Path(tmp), profile))
         if extra_env:
             env.update(extra_env)
         return subprocess.run(

--- a/tests/test_mpe_env_file.py
+++ b/tests/test_mpe_env_file.py
@@ -1,0 +1,60 @@
+"""paths.sh respects MPE_ENV_FILE for hermetic subprocess tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests.hermetic_env import hermetic_env_skip_system, hermetic_env_with_profile
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PATHS_SH = REPO_ROOT / "scripts" / "lib" / "paths.sh"
+
+
+class MpeEnvFileTests(unittest.TestCase):
+    def _profile_from_paths(self, env: dict[str, str]) -> str:
+        body = f"""
+source {PATHS_SH}
+printf '%s' "${{MPE_AUDIO_PROFILE:-}}"
+"""
+        result = subprocess.run(
+            ["bash", "-c", body],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout
+
+    def test_empty_mpe_env_file_uses_process_env(self) -> None:
+        env = os.environ.copy()
+        env.update(hermetic_env_skip_system())
+        env["MPE_AUDIO_PROFILE"] = "usb-host"
+        self.assertEqual(self._profile_from_paths(env), "usb-host")
+
+    def test_mpe_env_file_overrides_process_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = os.environ.copy()
+            env["MPE_AUDIO_PROFILE"] = "standalone"
+            env.update(hermetic_env_with_profile(Path(tmp), "usb-host-session"))
+            self.assertEqual(self._profile_from_paths(env), "usb-host-session")
+
+    @mock.patch.dict(
+        os.environ,
+        {"MPE_ENV_FILE": "", "MPE_AUDIO_PROFILE": "usb-host"},
+        clear=False,
+    )
+    def test_profile_env_path_none_when_hermetic(self) -> None:
+        from patch_browser import audio_profile
+
+        self.assertIsNone(audio_profile.profile_env_path())
+        self.assertEqual(audio_profile.current_profile(), "usb-host")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_uac2_stall_watchdog.py
+++ b/tests/test_uac2_stall_watchdog.py
@@ -10,6 +10,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tests.hermetic_env import hermetic_env_skip_system, hermetic_env_with_profile
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WATCHDOG_SCRIPT = REPO_ROOT / "scripts" / "uac2-stall-watchdog.sh"
 
@@ -70,7 +72,6 @@ class Uac2HostRouteWatchdogTests(unittest.TestCase):
         env = os.environ.copy()
         env.update(
             {
-                "MPE_AUDIO_PROFILE": "usb-host",
                 "MPE_UAC2_ASOUND_ROOT": str(asound),
                 "MPE_UAC2_WATCHDOG_POLL": poll_seconds,
                 "MPE_UAC2_WATCHDOG_COOLDOWN": cooldown,
@@ -81,6 +82,7 @@ class Uac2HostRouteWatchdogTests(unittest.TestCase):
                 "PATH": f"{bin_dir}:{env.get('PATH', '')}",
             }
         )
+        env.update(hermetic_env_with_profile(tmp_path, "usb-host"))
 
         proc = subprocess.Popen(
             ["timeout", "10", "bash", str(scripts_dir / "uac2-stall-watchdog.sh")],
@@ -151,7 +153,6 @@ class Uac2HostRouteWatchdogTests(unittest.TestCase):
         env = os.environ.copy()
         env.update(
             {
-                "MPE_AUDIO_PROFILE": "usb-host-session",
                 "MPE_UAC2_ASOUND_ROOT": str(asound),
                 "MPE_UAC2_WATCHDOG_POLL": "1",
                 "MPE_UAC2_WATCHDOG_COOLDOWN": "0",
@@ -162,6 +163,7 @@ class Uac2HostRouteWatchdogTests(unittest.TestCase):
                 "PATH": f"{bin_dir}:{env.get('PATH', '')}",
             }
         )
+        env.update(hermetic_env_with_profile(tmp_path, "usb-host-session"))
 
         proc = subprocess.Popen(
             ["timeout", "10", "bash", str(scripts_dir / "uac2-stall-watchdog.sh")],
@@ -187,6 +189,7 @@ class Uac2HostRouteWatchdogTests(unittest.TestCase):
     def test_exits_immediately_on_standalone_profile(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             env = os.environ.copy()
+            env.update(hermetic_env_skip_system())
             env["MPE_AUDIO_PROFILE"] = "standalone"
             env["MPE_UAC2_WATCHDOG_LOG"] = str(Path(tmp) / "log")
             result = subprocess.run(


### PR DESCRIPTION
## Summary

- Add `MPE_ENV_FILE` test hook in `paths.sh` and `audio_profile.py` so subprocess/unit tests skip `/etc/mpe/mpe.env` on a configured Pi (production unchanged when unset).
- Shared `tests/hermetic_env.py` helpers; wire detect, UAC2 watchdog, profile badge, and JackLsp probe tests.
- New `tests/test_mpe_env_file.py` locks the contract; document in `docs/PATHS.md`.

## Why

`mpe test pi audio --allow-partial` was masking 13 failures caused by appliance env bleed, not product bugs. Same suite should pass on laptop, CI, and Pi without `--allow-partial`.

## Test plan

- [x] `mpe test local audio` — 138 tests OK
- [ ] Merge companion mpe-cli PR (suite registry)
- [ ] Deploy to Pi → `mpe test pi audio` (no `--allow-partial`) — expect 138/138