### PR TITLE
Hermetic Pi fixes — jack_lsp PATH and mpe-services env

### DIFF
--- a/scripts/lib/mpe-services.sh
+++ b/scripts/lib/mpe-services.sh
@@ -26,6 +26,17 @@ mpe_read_appliance_env_var() {
 
 # Reload runtime profile from the appliance env file.
 mpe_source_appliance_env() {
+    if [ -n "${MPE_ENV_FILE+x}" ]; then
+        if [ -n "$MPE_ENV_FILE" ] && [ -f "$MPE_ENV_FILE" ]; then
+            # shellcheck disable=SC1091
+            set -a
+            source "$MPE_ENV_FILE"
+            set +a
+        fi
+        MPE_AUDIO_PROFILE="${MPE_AUDIO_PROFILE:-standalone}"
+        export MPE_AUDIO_PROFILE
+        return 0
+    fi
     if [ ! -f /etc/mpe/mpe.env ]; then
         return 0
     fi

--- a/tests/hermetic_env.py
+++ b/tests/hermetic_env.py
@@ -30,3 +30,8 @@ def isolated_path_prefix(tmp_dir: Path) -> str:
     empty = tmp_dir / "isolated_bin"
     empty.mkdir(exist_ok=True)
     return str(empty)
+
+
+def isolated_path_only(tmp_dir: Path) -> str:
+    """PATH containing no system binaries — use for missing-tool probe tests."""
+    return isolated_path_prefix(tmp_dir)

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -15,7 +15,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from tests.hermetic_env import isolated_path_prefix
+from tests.hermetic_env import isolated_path_only
 
 from patch_browser.audio_engine import (
     COOLDOWN_SEC,
@@ -419,7 +419,7 @@ echo ok
 """
         with tempfile.TemporaryDirectory() as tmp:
             env = _bash_env()
-            env["PATH"] = f"{isolated_path_prefix(Path(tmp))}:/usr/bin:/bin"
+            env["PATH"] = isolated_path_only(Path(tmp))
             result = _run_bash_script(body, env=env)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "ok")
@@ -432,7 +432,7 @@ echo ok
 """
         with tempfile.TemporaryDirectory() as tmp:
             env = _bash_env()
-            env["PATH"] = f"{isolated_path_prefix(Path(tmp))}:/usr/bin:/bin"
+            env["PATH"] = isolated_path_only(Path(tmp))
             result = _run_bash_script(body, env=env)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "ok")

--- a/tests/test_start_uac2_watchdog.py
+++ b/tests/test_start_uac2_watchdog.py
@@ -9,6 +9,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tests.hermetic_env import hermetic_env_skip_system, hermetic_env_with_profile
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 START_SCRIPT = REPO_ROOT / "scripts" / "start-uac2-watchdog-if-needed.sh"
 SURGE_UNIT = REPO_ROOT / "config" / "surge-xt-cli.service"
@@ -27,14 +29,14 @@ class StartUac2WatchdogTests(unittest.TestCase):
 
     def test_skips_when_not_usb_host(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
+            env = os.environ.copy()
+            env.update(hermetic_env_skip_system())
+            env["MPE_AUDIO_PROFILE"] = "standalone"
             result = subprocess.run(
                 ["bash", str(START_SCRIPT)],
                 capture_output=True,
                 text=True,
-                env={
-                    **os.environ,
-                    "MPE_AUDIO_PROFILE": "standalone",
-                },
+                env=env,
                 check=False,
             )
             self.assertEqual(result.returncode, 0, msg=result.stderr)
@@ -53,15 +55,14 @@ class StartUac2WatchdogTests(unittest.TestCase):
                 encoding="utf-8",
             )
             systemctl.chmod(systemctl.stat().st_mode | stat.S_IXUSR)
+            env = os.environ.copy()
+            env.update(hermetic_env_with_profile(tmp_path, "usb-host-session"))
+            env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
             result = subprocess.run(
                 ["bash", str(START_SCRIPT)],
                 capture_output=True,
                 text=True,
-                env={
-                    **os.environ,
-                    "MPE_AUDIO_PROFILE": "usb-host-session",
-                    "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
-                },
+                env=env,
                 check=False,
             )
             self.assertEqual(result.returncode, 0, msg=result.stderr)

--- a/tests/test_uac2_stall_watchdog.py
+++ b/tests/test_uac2_stall_watchdog.py
@@ -208,7 +208,8 @@ class Uac2HostRouteWatchdogTests(unittest.TestCase):
         )
         self.assertTrue(restart_marker.exists())
         self.assertTrue(streaming_flag.is_file())
-        self.assertIn("capture opened", log_file.read_text(encoding="utf-8"))
+        log = log_file.read_text(encoding="utf-8")
+        self.assertIn("Surge → UAC2", log)
 
     def test_host_capture_close_restarts_surge_to_idle(self) -> None:
         restart_marker, streaming_flag, log_file, _bridge = self._run_watchdog(


### PR DESCRIPTION
## Summary

Follow-up to #53 — four tests still failed on Pi:

- JackLsp probes: PATH still included `/usr/bin` (jack_lsp present)
- `start-uac2-watchdog-if-needed.sh`: `mpe_source_appliance_env` ignored `MPE_ENV_FILE`
- UAC2 capture test: race hits "already capturing" log line instead of "capture opened"

## Test plan

- [x] `mpe test local audio` — 138 OK
- [ ] Merge → `mpe looper deploy dev` → `mpe test pi audio` — 138/138