### PR TITLE
Planned audio promote path, 30s cooldown, switch toasts

### DIFF
--- a/patch_browser/audio_engine.py
+++ b/patch_browser/audio_engine.py
@@ -22,9 +22,11 @@ VALID_ENGINE_STATES = frozenset({"ok", "recovering", "failed"})
 VALID_LOOPER_LABELS = frozenset({"guarded", "enabled", "off"})
 
 ENGINE_STATE_FILE = Path("/run/mpe/engine.state")
+RECONCILE_STATE_FILE = Path("/run/mpe/engine-reconcile.state")
+JACK_STATE_FILE = Path("/run/mpe/jack.state")
 ENGINE_STATE_MAX_BYTES = 4096
 
-COOLDOWN_SEC = 90
+COOLDOWN_SEC = 30
 # 15s was sized for an ALSA-contention hazard (Surge holding the tier device on
 # the fallback path) that no longer exists — ALSA is not a reachable engine at
 # all now. jackd is typically ready in ~6s on the Sound Blaster Play! 3; 5s
@@ -74,6 +76,87 @@ def reconcile_cooldown_decide(
         return "skip_cooldown", f"last supervisor restart {elapsed}s ago (< {cooldown_sec}s)"
 
     return "proceed", f"cooldown satisfied ({elapsed}s since last restart)"
+
+
+def read_reconcile_state(path: Path | None = None) -> dict[str, str]:
+    """Parse supervisor reconcile state (cooldown counter)."""
+    target = path or RECONCILE_STATE_FILE
+    return read_engine_state(target)
+
+
+def read_jack_state(path: Path | None = None) -> dict[str, str]:
+    target = path or JACK_STATE_FILE
+    return read_engine_state(target)
+
+
+def _parse_epoch(value: str | None) -> int:
+    if not value:
+        return 0
+    try:
+        parsed = int(value.strip())
+    except ValueError:
+        return 0
+    return parsed if parsed > 0 else 0
+
+
+def audio_switch_progress_message(
+    engine: dict[str, str] | None,
+    reconcile: dict[str, str] | None = None,
+    *,
+    now: int | None = None,
+    jack: dict[str, str] | None = None,
+) -> tuple[str, str | None, float]:
+    """Overlay hint + optional toast while a planned audio switch runs.
+
+    Returns ``(overlay_hint, toast_message_or_none, toast_seconds)``.
+    """
+    import time as _time
+
+    engine = engine or {}
+    reconcile = reconcile or {}
+    jack = jack or {}
+    now_ts = now if now is not None else int(_time.time())
+
+    state = engine.get("state") or ""
+    reason = engine.get("reason") or ""
+    active = engine.get("active") or ""
+
+    if state == "ok" and active == "jack":
+        return "Audio restored", "Audio ready", 2.0
+
+    if state == "failed":
+        if reason == "no-server":
+            return "JACK server failed — check DAC", "Audio failed — check DAC", 4.0
+        if reason == "supervisor-exhausted":
+            return (
+                "Recovery paused — replug DAC or wait",
+                f"Recovery paused — wait {COOLDOWN_SEC}s or replug DAC",
+                5.0,
+            )
+        return "Audio failed", "Audio failed — check connection", 4.0
+
+    last_restart = _parse_epoch(reconcile.get("last_restart"))
+    restart_count = _parse_epoch(reconcile.get("restarts"))
+    if restart_count > 0 and last_restart > 0:
+        since = now_ts - last_restart
+        if since < COOLDOWN_SEC:
+            remaining = COOLDOWN_SEC - since
+            hint = f"Waiting to retry ({remaining}s)…"
+            toast = f"Recovery paused — {remaining}s until retry"
+            return hint, toast, min(float(remaining + 1), 8.0)
+
+    jack_started = _parse_epoch(jack.get("started"))
+    if jack_started > 0 and (now_ts - jack_started) < JACKD_SETTLE_SEC:
+        return "JACK server starting…", "Restarting audio engine…", 3.0
+
+    if reason == "promote-planned":
+        return "Reconnecting Surge…", "Reconnecting Surge to JACK…", 3.0
+    if reason in {"settings-change", "profile-change"}:
+        return "Restarting JACK server…", "Applying audio settings…", 3.0
+    if reason == "promote-timeout":
+        return "Surge reconnect slow — still trying…", "Still reconnecting Surge…", 3.0
+
+    return "Restarting audio…", "Applying audio settings…", 3.0
 
 
 def read_engine_state(path: Path | None = None) -> dict[str, str]:

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -223,6 +223,8 @@ class TouchPatchBrowser(
         self._surge_audio_switch_hint = ""
         self._surge_audio_switch_started = 0.0
         self._surge_audio_result_queue: queue.SimpleQueue[tuple[bool, str]] = queue.SimpleQueue()
+        self._audio_switch_progress_hint = ""
+        self._last_audio_switch_toast_at = 0.0
         self._midi_sync_switching = False
         self._midi_sync_switch_started = 0.0
         self._midi_sync_result_queue: queue.SimpleQueue[tuple[bool, str]] = queue.SimpleQueue()
@@ -374,6 +376,7 @@ class TouchPatchBrowser(
             self._drain_evdev_touch_queue()
             self._poll_audio_profile_switch()
             self._poll_surge_audio_switch()
+            self._poll_engine_recovery_toast()
             self._poll_midi_sync_switch()
             self._poll_wifi_work()
             self._handle_screen_recorder_signals()

--- a/patch_browser/touch_browser_draw.py
+++ b/patch_browser/touch_browser_draw.py
@@ -814,7 +814,9 @@ class TouchBrowserDrawMixin:
         from patch_browser.audio_profile import profile_switch_overlay_hint
 
         target = getattr(self, "_audio_profile_switch_target", None)
-        hint = profile_switch_overlay_hint(target) if target else "Restarting Surge for new audio route"
+        progress = getattr(self, "_audio_switch_progress_hint", "") or ""
+        static = profile_switch_overlay_hint(target) if target else "Restarting Surge for new audio route"
+        hint = progress or static
         draw_wrapped_text_in_rect(
             self.screen,
             self.font_sm,

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -282,9 +282,62 @@ class TouchBrowserPrefsMixin:
         else:
             self._toast("Dynamic voice limit off", 1.8)
 
+    def _refresh_audio_switch_progress(self) -> None:
+        """Update overlay hint + toast while buffer/rate/profile switches run."""
+        monitor = getattr(self, "engine_monitor", None)
+        if monitor is None:
+            return
+        from patch_browser.audio_engine import (
+            audio_switch_progress_message,
+            read_jack_state,
+            read_reconcile_state,
+        )
+
+        hint, toast, toast_sec = audio_switch_progress_message(
+            monitor.snapshot(),
+            read_reconcile_state(),
+            jack=read_jack_state(),
+        )
+        if hint:
+            self._audio_switch_progress_hint = hint
+            if getattr(self, "_surge_audio_switching", False):
+                self._surge_audio_switch_hint = hint
+        if toast:
+            now = time.monotonic()
+            if now - getattr(self, "_last_audio_switch_toast_at", 0.0) >= 2.0:
+                self._toast(toast, toast_sec)
+                self._last_audio_switch_toast_at = now
+
+    def _poll_engine_recovery_toast(self) -> None:
+        """Surface unplanned recovery / cooldown while the user is not in a settings overlay."""
+        if getattr(self, "_surge_audio_switching", False) or getattr(
+            self, "_audio_profile_switching", False
+        ):
+            return
+        monitor = getattr(self, "engine_monitor", None)
+        if monitor is None:
+            return
+        snap = monitor.snapshot()
+        if snap.get("state") not in {"recovering", "failed"}:
+            return
+        from patch_browser.audio_engine import audio_switch_progress_message, read_jack_state, read_reconcile_state
+
+        _, toast, toast_sec = audio_switch_progress_message(
+            snap,
+            read_reconcile_state(),
+            jack=read_jack_state(),
+        )
+        if not toast:
+            return
+        now = time.monotonic()
+        if now - getattr(self, "_last_audio_switch_toast_at", 0.0) >= 2.0:
+            self._toast(toast, toast_sec)
+            self._last_audio_switch_toast_at = now
+
     def _finish_audio_profile_switch(self, ok: bool, message: str) -> None:
         self._audio_profile_switching = False
         self._audio_profile_switch_target = None
+        self._audio_switch_progress_hint = ""
         if ok:
             self._toast(message, 3.0)
             patch = self.loaded_patch_info or self._pending_last_patch
@@ -310,6 +363,7 @@ class TouchBrowserPrefsMixin:
         except queue.Empty:
             from patch_browser.audio_profile import PROFILE_SWITCH_TIMEOUT_S
 
+            self._refresh_audio_switch_progress()
             elapsed = time.monotonic() - self._audio_profile_switch_started
             if elapsed > PROFILE_SWITCH_TIMEOUT_S + 5.0:
                 self._finish_audio_profile_switch(
@@ -340,8 +394,10 @@ class TouchBrowserPrefsMixin:
         self._audio_profile_switching = True
         self._audio_profile_switch_target = profile
         self._audio_profile_switch_started = time.monotonic()
+        self._audio_switch_progress_hint = ""
+        self._last_audio_switch_toast_at = 0.0
         label = profile_option_label(profile)
-        self._toast(f"Switching to {label}…", 1.5)
+        self._toast(f"Switching to {label}…", 2.0)
 
         def _worker() -> None:
             ok, message = apply_profile(profile)
@@ -356,6 +412,7 @@ class TouchBrowserPrefsMixin:
     def _finish_surge_audio_switch(self, ok: bool, message: str) -> None:
         self._surge_audio_switching = False
         self._surge_audio_switch_hint = ""
+        self._audio_switch_progress_hint = ""
         if ok:
             self._toast(message, 3.0)
             patch = self.loaded_patch_info or self._pending_last_patch
@@ -379,6 +436,7 @@ class TouchBrowserPrefsMixin:
         except queue.Empty:
             from patch_browser.surge_audio import AUDIO_SWITCH_TIMEOUT_S
 
+            self._refresh_audio_switch_progress()
             elapsed = time.monotonic() - self._surge_audio_switch_started
             if elapsed > AUDIO_SWITCH_TIMEOUT_S + 5.0:
                 self._finish_surge_audio_switch(
@@ -401,7 +459,9 @@ class TouchBrowserPrefsMixin:
         self._surge_audio_switching = True
         self._surge_audio_switch_hint = hint
         self._surge_audio_switch_started = time.monotonic()
-        self._toast(hint, 1.5)
+        self._audio_switch_progress_hint = hint
+        self._last_audio_switch_toast_at = 0.0
+        self._toast(hint, 2.0)
 
         def _worker_wrapper() -> None:
             ok, message = worker()

--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -334,23 +334,104 @@ mpe_restart_audio_graph() {
 }
 
 # ---------------------------------------------------------------------------
+# Planned operator graph changes (touch UI settings / profile switch)
+# ---------------------------------------------------------------------------
+
+mpe_planned_promote_flag_file() {
+    printf '%s' "${MPE_PLANNED_PROMOTE_FLAG:-$(mpe_run_dir)/planned-promote}"
+}
+
+mpe_planned_promote_flag_set() {
+    [ -f "$(mpe_planned_promote_flag_file)" ]
+}
+
+mpe_planned_promote_flag_mark() {
+    local file
+    file="$(mpe_planned_promote_flag_file)"
+    date +%s >"$file" 2>/dev/null || true
+    chmod 0644 "$file" 2>/dev/null || true
+}
+
+mpe_planned_promote_flag_clear() {
+    rm -f "$(mpe_planned_promote_flag_file)" 2>/dev/null || true
+}
+
+mpe_wait_for_surge_on_graph() {
+    local timeout="${1:-30}"
+    local waited=0
+    local step_ms=250
+    while :; do
+        if mpe_surge_on_jack_graph; then
+            return 0
+        fi
+        if [ "$waited" -ge "$((timeout * 1000))" ]; then
+            return 1
+        fi
+        sleep 0.25
+        waited=$((waited + step_ms))
+    done
+}
+
+# Operator-initiated device/buffer/rate/profile changes: restart jackd, sync-wait
+# for the server, promote Surge once, and return only when the graph is ok. The
+# passive watchdog path (settle + 5 s poll) is for unplanned recovery only.
+mpe_promote_surge_planned() {
+    local reason="${1:-planned-graph-change}"
+    local timeout="${MPE_PLANNED_PROMOTE_TIMEOUT:-30}"
+    local looper_label surge_service
+    looper_label="$(mpe_looper_state_label)"
+    surge_service="surge-xt-cli.service"
+
+    mpe_planned_promote_flag_mark
+    mpe_engine_state_write "$MPE_ENGINE_NAME" none recovering "$reason" "$looper_label"
+
+    if ! mpe_restart_audio_graph; then
+        mpe_planned_promote_flag_clear
+        mpe_engine_state_write "$MPE_ENGINE_NAME" none failed "graph-restart" "$looper_label"
+        return 1
+    fi
+
+    if ! mpe_wait_for_jack_server "$timeout"; then
+        mpe_planned_promote_flag_clear
+        mpe_engine_state_write "$MPE_ENGINE_NAME" none failed "no-server" "$looper_label"
+        return 1
+    fi
+
+    mpe_engine_state_write "$MPE_ENGINE_NAME" jack recovering "promote-planned" "$looper_label"
+    mpe_systemctl reset-failed "$surge_service" >/dev/null 2>&1 || true
+    if ! mpe_systemctl restart "$surge_service"; then
+        mpe_planned_promote_flag_clear
+        mpe_engine_state_write "$MPE_ENGINE_NAME" jack failed "promote-failed" "$looper_label"
+        return 1
+    fi
+
+    if ! mpe_wait_for_surge_on_graph "$timeout"; then
+        mpe_planned_promote_flag_clear
+        mpe_engine_state_write "$MPE_ENGINE_NAME" jack recovering "promote-timeout" "$looper_label"
+        return 1
+    fi
+
+    mpe_engine_reconcile_reset
+    mpe_engine_state_write "$MPE_ENGINE_NAME" jack ok "" "$looper_label"
+    mpe_planned_promote_flag_clear
+    return 0
+}
+
+# ---------------------------------------------------------------------------
 # Supervisor cooldown (spec D3)
 # ---------------------------------------------------------------------------
 #
 # The watchdog polls every 5 s while Surge has RestartSec=10 and StartLimitBurst=5.
 # An uncooled supervisor exhausts the burst budget in ~25 s and leaves Surge dead
 # until manual intervention — worse than the fault it responds to. Hence: first
-# restart immediate, then >= 90 s apart, never while jackd is still settling, and
-# escalate to state=failed after 3 tries.
+# restart immediate, then a cooldown between subsequent supervisor restarts, never
+# while jackd is still settling, and escalate to state=failed after 3 tries.
 #
 # Start-limit window matches surge-xt-cli.service [Unit]: StartLimitBurst=5 over
-# StartLimitIntervalSec=300. The watchdog cooldown below is sized to stay inside
-# that budget (first restart immediate, then >= 90 s apart). When the burst is
-# exhausted, `systemctl is-failed surge-xt-cli` becomes true and the watchdog's
-# corrupt-defaults recovery arm can reset the unit — a path that has not yet run
-# on hardware since the interval key lived in [Service] until fixed.
+# StartLimitIntervalSec=300. Cooldown is sized to stay inside that budget while
+# keeping unplanned recovery retries practical for the operator (30 s default).
 
-MPE_ENGINE_COOLDOWN_DEFAULT=90
+MPE_ENGINE_COOLDOWN_DEFAULT=30
 # 15s was sized for an ALSA-contention hazard (Surge holding the tier device
 # on the fallback path while jackd tried to reclaim it) that no longer exists
 # — ALSA is not a reachable engine at all now. jackd itself is typically ready

--- a/scripts/research/graph-recovery-spike.sh
+++ b/scripts/research/graph-recovery-spike.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Tier-3 research: jackd/Surge recovery paths (run on Pi only).
+# Non-destructive intent: restores original rate/buffer at end.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=scripts/lib/paths.sh
+source "$REPO_ROOT/scripts/lib/paths.sh"
+# shellcheck source=scripts/lib/audio-engine.sh
+source "$REPO_ROOT/scripts/lib/audio-engine.sh"
+
+ENV_FILE="/etc/mpe/mpe.env"
+LOG="/tmp/mpe-graph-recovery-spike-$(date +%Y%m%d-%H%M%S).log"
+exec > >(tee -a "$LOG") 2>&1
+
+section() { echo ""; echo "========== $* =========="; }
+
+now_ms() { date +%s%3N; }
+
+surge_on_graph() {
+    mpe_surge_on_jack_graph
+}
+
+alsa_playback_format() {
+    local f
+    for f in /proc/asound/card*/pcm0p/sub0/hw_params; do
+        if [ -r "$f" ] && grep -q 'format:' "$f" 2>/dev/null; then
+            grep '^format:' "$f" | head -1
+            grep '^rate:' "$f" | head -1
+            grep '^buffer_size:' "$f" | head -1
+            return 0
+        fi
+    done
+    echo "format: (no open playback hw_params)"
+}
+
+jack_server_info() {
+    if command -v jack_bufsize >/dev/null 2>&1 && pgrep -x jackd >/dev/null; then
+        echo "jack_bufsize: $(jack_bufsize 2>/dev/null || echo '?')"
+    fi
+    if command -v jack_samplerate >/dev/null 2>&1 && pgrep -x jackd >/dev/null; then
+        echo "jack_samplerate: $(jack_samplerate 2>/dev/null || echo '?')"
+    fi
+}
+
+poll_surge_reconnect() {
+    local label="$1"
+    local timeout_s="${2:-30}"
+    local start end elapsed t0
+    t0="$(now_ms)"
+    start=$(date +%s)
+    end=$((start + timeout_s))
+    while [ "$(date +%s)" -lt "$end" ]; do
+        if surge_on_graph; then
+            elapsed=$(( $(now_ms) - t0 ))
+            echo "${label}: surge_on_graph=yes elapsed_ms=${elapsed}"
+            return 0
+        fi
+        sleep 0.25
+    done
+    elapsed=$(( $(now_ms) - t0 ))
+    echo "${label}: surge_on_graph=no elapsed_ms=${elapsed} TIMEOUT"
+    return 1
+}
+
+wait_jack_ready() {
+    local timeout_s="${1:-20}"
+    local t0 waited
+    t0="$(now_ms)"
+    waited=0
+    while [ "$waited" -lt "$timeout_s" ]; do
+        if mpe_jack_server_ready; then
+            echo "jack_ready elapsed_ms=$(( $(now_ms) - t0 ))"
+            return 0
+        fi
+        sleep 0.25
+        waited=$((waited + 1))
+    done
+    echo "jack_ready TIMEOUT elapsed_ms=$(( $(now_ms) - t0 ))"
+    return 1
+}
+
+read_env_var() {
+    local key="$1"
+    grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+ORIG_RATE="$(read_env_var MPE_SURGE_SAMPLE_RATE)"
+ORIG_BUFFER="$(read_env_var MPE_JACK_BUFFER)"
+ORIG_SURGE_BUFFER="$(read_env_var MPE_SURGE_BUFFER_SIZE)"
+[ -z "$ORIG_RATE" ] && ORIG_RATE=48000
+[ -z "$ORIG_BUFFER" ] && ORIG_BUFFER=256
+[ -z "$ORIG_SURGE_BUFFER" ] && ORIG_SURGE_BUFFER="$ORIG_BUFFER"
+
+section "BASELINE $(date -Iseconds)"
+echo "env: rate=$ORIG_RATE jack_buffer=$ORIG_BUFFER surge_buffer=$ORIG_SURGE_BUFFER profile=${MPE_AUDIO_PROFILE:-?}"
+echo "surge_on_graph: $(surge_on_graph && echo yes || echo no)"
+alsa_playback_format
+jack_server_info
+jack_lsp 2>/dev/null | grep -i surge || echo "(no surge in jack_lsp)"
+
+# --- Test B: live jack_bufsize (no jackd restart) ---
+section "TEST B: jack_bufsize live resize (no jackd restart)"
+if command -v jack_bufsize >/dev/null 2>&1 && pgrep -x jackd >/dev/null; then
+    cur="$(jack_bufsize 2>/dev/null || echo 0)"
+    alt=512
+    [ "$cur" = "512" ] && alt=256
+    echo "current_buf=$cur trying alt=$alt"
+    echo "before resize:"
+    alsa_playback_format
+    t0="$(now_ms)"
+    jack_bufsize "$alt" 2>&1 || true
+    echo "jack_bufsize cmd elapsed_ms=$(( $(now_ms) - t0 ))"
+    sleep 0.5
+    echo "after resize to $alt:"
+    alsa_playback_format
+    jack_server_info
+    echo "restoring buffer via jackd restart..."
+    sudo -n systemctl restart mpe-jackd.service
+    wait_jack_ready 20 || true
+    poll_surge_reconnect "B-restore-watchdog" 25 || true
+else
+    echo "SKIP: jack_bufsize or jackd unavailable"
+fi
+
+# --- Test A: jackd restart only (Surge left running) ---
+section "TEST A: jackd restart only — does Surge reconnect without Surge restart?"
+surge_pid_before="$(pgrep -f surge-xt-cli | head -1 || true)"
+echo "surge_pid_before=$surge_pid_before"
+t0="$(now_ms)"
+sudo -n systemctl restart --no-block mpe-jackd.service
+echo "jackd restart issued elapsed_ms=$(( $(now_ms) - t0 ))"
+wait_jack_ready 20 || true
+if poll_surge_reconnect "A-jackd-only" 30; then
+    surge_pid_after="$(pgrep -f surge-xt-cli | head -1 || true)"
+    echo "surge_pid_after=$surge_pid_after same_process=$([ "$surge_pid_before" = "$surge_pid_after" ] && echo yes || echo no)"
+else
+    echo "Surge did NOT reconnect within 30s — watchdog promote path required"
+    surge_pid_after="$(pgrep -f surge-xt-cli | head -1 || true)"
+    echo "surge_pid_after=$surge_pid_after (watchdog may restart soon)"
+    sleep 8
+    poll_surge_reconnect "A-after-watchdog-wait" 20 || true
+fi
+
+# --- Test D: jackd restart + immediate Surge restart (planned promote) ---
+section "TEST D: jackd restart + sync Surge restart (planned promote path)"
+surge_pid_before="$(pgrep -f surge-xt-cli | head -1 || true)"
+t0="$(now_ms)"
+sudo -n systemctl restart --no-block mpe-jackd.service
+wait_jack_ready 20 || true
+t_jack=$(( $(now_ms) - t0 ))
+sudo -n systemctl restart surge-xt-cli.service
+t_total=$(( $(now_ms) - t0 ))
+poll_surge_reconnect "D-sync-promote" 15 || true
+surge_pid_after="$(pgrep -f surge-xt-cli | head -1 || true)"
+echo "jack_ready_ms=$t_jack total_to_surge_on_graph_ms=$t_total surge_pid changed=$([ "$surge_pid_before" != "$surge_pid_after" ] && echo yes || echo no)"
+alsa_playback_format
+
+# --- Test C: production set-surge-audio sample-rate toggle ---
+section "TEST C: set-surge-audio sample-rate toggle (watchdog path)"
+toggle_rate=44100
+[ "$ORIG_RATE" = "44100" ] && toggle_rate=48000
+echo "toggling $ORIG_RATE -> $toggle_rate via set-surge-audio.sh"
+t0="$(now_ms)"
+sudo -n "$REPO_ROOT/scripts/set-surge-audio.sh" --sample-rate "$toggle_rate"
+echo "set-surge-audio returned elapsed_ms=$(( $(now_ms) - t0 )) (async jackd — still measuring recovery)"
+t_start="$t0"
+if poll_surge_reconnect "C-watchdog-path" 35; then
+    echo "C total silence window estimate_ms=$(( $(now_ms) - t_start ))"
+else
+    echo "C FAILED to recover within 35s"
+fi
+alsa_playback_format
+jack_server_info
+
+section "RESTORE original rate=$ORIG_RATE"
+t0="$(now_ms)"
+sudo -n "$REPO_ROOT/scripts/set-surge-audio.sh" --sample-rate "$ORIG_RATE"
+poll_surge_reconnect "restore-rate" 35 || true
+echo "restore elapsed_ms=$(( $(now_ms) - t0 ))"
+alsa_playback_format
+
+section "DONE log=$LOG"

--- a/scripts/set-audio-profile.sh
+++ b/scripts/set-audio-profile.sh
@@ -54,9 +54,11 @@ uac2_host_streaming_clear
 profile_switch_flag_mark
 # shellcheck source=lib/audio-engine.sh
 source "$SCRIPT_DIR/lib/audio-engine.sh"
-restart_audio_graph
+if ! mpe_promote_surge_planned "profile-change"; then
+    echo "ERROR: profile graph change failed — check journalctl -u mpe-jackd -u surge-xt-cli" >&2
+    exit 1
+fi
 # profile_switch_flag_mark: consumed by start-surge-cli.sh on the next Surge start
-# (skips USB MIDI wait). jackd restart alone does not restart Surge, so the flag
-# persists until Surge is next started — e.g. manual restart or supervisor reconcile.
+# (skips USB MIDI wait).
 
-echo "MPE_AUDIO_PROFILE=$PROFILE saved — restarting $(mpe_audio_graph_unit) (audio returns after graph settles)"
+echo "MPE_AUDIO_PROFILE=$PROFILE saved — audio graph restored"

--- a/scripts/set-surge-audio.sh
+++ b/scripts/set-surge-audio.sh
@@ -126,7 +126,10 @@ if [ -n "$BUFFER" ]; then
     _update_env_var MPE_JACK_BUFFER "$BUFFER"
     export MPE_JACK_BUFFER="$BUFFER"
 fi
-mpe_restart_audio_graph
+if ! mpe_promote_surge_planned "settings-change"; then
+    echo "ERROR: audio graph change failed — check journalctl -u mpe-jackd -u surge-xt-cli" >&2
+    exit 1
+fi
 
 echo -n "Applied"
 [ -n "$BUFFER" ] && echo -n " buffer=$BUFFER"

--- a/scripts/surge-watchdog.sh
+++ b/scripts/surge-watchdog.sh
@@ -64,6 +64,10 @@ _reconcile_engine() {
 
     looper_label="$(mpe_looper_state_label)"
 
+    if mpe_planned_promote_flag_set; then
+        return 0
+    fi
+
     if mpe_surge_on_jack_graph; then
         mpe_engine_state_write "$MPE_ENGINE_NAME" jack ok "" "$looper_label"
         mpe_engine_reconcile_reset

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -103,10 +103,10 @@ class ReconcileCooldownTests(unittest.TestCase):
         )
         self.assertEqual(action, "proceed")
 
-    def test_respects_90s_cooldown(self) -> None:
+    def test_respects_cooldown_window(self) -> None:
         action, _ = reconcile_cooldown_decide(
             1000,
-            last_supervisor_restart=950,
+            last_supervisor_restart=980,
             supervisor_restarts_without_ok=1,
             jackd_last_start=800,
         )
@@ -124,8 +124,8 @@ class ReconcileCooldownTests(unittest.TestCase):
         self.assertEqual(action, "skip_jackd_settling")
 
     def test_proceeds_once_settle_window_elapses(self) -> None:
-        # jackd started 10s ago — past the 5s settle window and past the 90s
-        # cooldown (last restart 200s ago), so the supervisor may act.
+        # jackd started 10s ago — past the 5s settle window and past cooldown
+        # (last restart 200s ago), so the supervisor may act.
         action, _ = reconcile_cooldown_decide(
             1000,
             last_supervisor_restart=800,
@@ -144,7 +144,7 @@ class ReconcileCooldownTests(unittest.TestCase):
         self.assertEqual(action, "escalate_failed")
 
     def test_constants_match_spec(self) -> None:
-        self.assertEqual(COOLDOWN_SEC, 90)
+        self.assertEqual(COOLDOWN_SEC, 30)
         self.assertEqual(JACKD_SETTLE_SEC, 5)
         self.assertEqual(MAX_SUPERVISOR_RESTARTS, 3)
 
@@ -178,7 +178,7 @@ class BashReconcileParityTests(unittest.TestCase):
         self.assertEqual(_run_bash_reconcile(1000, 0, 0, 900), "restart")
 
     def test_bash_cooldown(self) -> None:
-        self.assertEqual(_run_bash_reconcile(1000, 950, 1, 800), "cooldown")
+        self.assertEqual(_run_bash_reconcile(1000, 980, 1, 800), "cooldown")
 
     def test_bash_jackd_settling(self) -> None:
         self.assertEqual(_run_bash_reconcile(1000, 800, 0, 997), "jackd-settling")
@@ -321,6 +321,34 @@ mpe_audio_graph_unit
         result = _run_bash_script(body, env=_bash_env())
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "mpe-jackd.service")
+
+    def test_planned_promote_sync_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            on_graph = Path(tmp) / "on-graph"
+            body = f"""
+source {AUDIO_ENGINE_SH}
+mpe_jack_server_ready() {{ [ "$1" = "1" ] && return 0; return 1; }}
+mpe_surge_on_jack_graph() {{ [ -f "{on_graph}" ]; }}
+mpe_restart_audio_graph() {{ printf 'graph-restart\\n'; return 0; }}
+mpe_systemctl() {{
+  printf '%s\\n' "$*" >> "{tmp}/systemctl.log"
+  case "$*" in
+    restart\ surge-xt-cli.service) touch "{on_graph}" ;;
+  esac
+  return 0
+}}
+export -f mpe_jack_server_ready mpe_surge_on_jack_graph mpe_restart_audio_graph mpe_systemctl
+mpe_promote_surge_planned settings-change
+printf 'state=%s\\n' "$(mpe_engine_state_get state)"
+grep -c 'restart surge-xt-cli.service' "{tmp}/systemctl.log" || true
+"""
+            result = _run_bash_script(body, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            lines = result.stdout.strip().splitlines()
+            self.assertEqual(lines[0], "graph-restart")
+            self.assertEqual(lines[1], "state=ok")
+            self.assertEqual(lines[2], "1")
 
 
 class StateFileLifecycleTests(unittest.TestCase):
@@ -485,7 +513,7 @@ class NoAlsaPathTests(unittest.TestCase):
         hypothetical. It must unconditionally take the graph-restart path."""
         text = SET_SURGE_AUDIO_SH.read_text(encoding="utf-8")
         self.assertNotIn("mpe_audio_engine", text)
-        self.assertIn("mpe_restart_audio_graph", text)
+        self.assertIn("mpe_promote_surge_planned", text)
         self.assertNotIn("systemctl restart surge-xt-cli.service", text)
 
     def test_set_surge_audio_is_valid_bash(self) -> None:

--- a/tests/test_audio_switch_progress.py
+++ b/tests/test_audio_switch_progress.py
@@ -1,0 +1,50 @@
+"""Tests for touch UI audio-switch progress hints and cooldown toasts."""
+
+from __future__ import annotations
+
+import unittest
+
+from patch_browser.audio_engine import COOLDOWN_SEC, audio_switch_progress_message
+
+
+class AudioSwitchProgressTests(unittest.TestCase):
+    def test_ok_state(self) -> None:
+        hint, toast, sec = audio_switch_progress_message(
+            {"state": "ok", "active": "jack"},
+            now=1000,
+        )
+        self.assertEqual(hint, "Audio restored")
+        self.assertEqual(toast, "Audio ready")
+        self.assertEqual(sec, 2.0)
+
+    def test_cooldown_shows_remaining_seconds(self) -> None:
+        now = 1000
+        hint, toast, sec = audio_switch_progress_message(
+            {"state": "recovering", "active": "jack", "reason": "promote-to-jack"},
+            {"last_restart": str(now - 12), "restarts": "1"},
+            now=now,
+        )
+        remaining = COOLDOWN_SEC - 12
+        self.assertIn(f"{remaining}s", hint)
+        self.assertIn(f"{remaining}s", toast or "")
+        self.assertEqual(sec, 8.0)
+
+    def test_settings_change_hint(self) -> None:
+        hint, toast, _ = audio_switch_progress_message(
+            {"state": "recovering", "reason": "settings-change"},
+            now=1000,
+        )
+        self.assertIn("JACK", hint)
+        self.assertEqual(toast, "Applying audio settings…")
+
+    def test_failed_supervisor_exhausted(self) -> None:
+        hint, toast, _ = audio_switch_progress_message(
+            {"state": "failed", "reason": "supervisor-exhausted"},
+            now=1000,
+        )
+        self.assertIn("paused", hint.lower())
+        self.assertIn(str(COOLDOWN_SEC), toast or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `mpe_promote_surge_planned()` for operator-initiated buffer/rate/profile changes: sync-wait for jackd, one Surge restart, graph ok before returning (~8–15s vs ~20–30s passive watchdog path).
- Watchdog defers while `/run/mpe/planned-promote` is set to avoid double-restart races.
- Reduce supervisor cooldown default from 90s to 30s (still under `StartLimitBurst=5`; override via `MPE_ENGINE_COOLDOWN_S`).
- Touch UI: overlay + toast refresh during audio switches, including live cooldown countdown; background toast during unplanned recovery.
- Add `scripts/research/graph-recovery-spike.sh` for Pi reruns; tests for planned promote and progress hints.

## Test plan
- [x] `mpe test local audio` — 143 OK
- [x] `mpe test local touch` — 94 OK
- [ ] Pi deploy to `dev` and smoke: sample-rate toggle + profile switch (overlay tracks progress, audio back faster)
- [ ] Optional: `mpe engine kill-jackd` — toast shows cooldown countdown if supervisor retries