### PR TITLE
fix(watchdog): defer supervisor restart during planned promote

### DIFF
--- a/scripts/surge-watchdog.sh
+++ b/scripts/surge-watchdog.sh
@@ -19,6 +19,9 @@ log() {
 
 _supervisor_restart_surge() {
     local reason="$1"
+    if mpe_planned_promote_flag_set; then
+        return 1
+    fi
     local now decision last count jackd_start looper_label
     now=$(date +%s)
     last=$(mpe_engine_reconcile_last_restart)

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -618,6 +618,36 @@ export -f _supervisor_restart_surge
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("RESTART:promote-to-jack", result.stderr)
 
+    def test_reconcile_defers_supervisor_restart_during_planned_promote(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            Path(tmp, "planned-promote").write_text("1\n", encoding="utf-8")
+            stubs = """
+mpe_surge_on_jack_graph() { return 1; }
+mpe_jack_server_ready() { return 0; }
+_supervisor_restart_surge() { echo "RESTART:$1" >&2; return 0; }
+export -f _supervisor_restart_surge
+"""
+            result = self._run_reconcile(env=env, stubs=stubs)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("RESTART:", result.stderr)
+
+    def test_supervisor_restart_defers_during_planned_promote(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            Path(tmp, "planned-promote").write_text("1\n", encoding="utf-8")
+            body = f"""
+source {SURGE_WATCHDOG_SH}
+mpe_systemctl() {{ printf '%s\\n' "$*" >> "{tmp}/systemctl.log"; return 0; }}
+export -f mpe_systemctl
+if _supervisor_restart_surge promote-to-jack; then exit 9; fi
+test ! -s "{tmp}/systemctl.log"
+echo deferred
+"""
+            result = _run_bash_script(body, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "deferred")
+
     def test_reconcile_survives_unwritable_state_publish(self) -> None:
         """State publish failure must not abort the supervisor reconcile path."""
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Guard _supervisor_restart_surge when /run/mpe/planned-promote is set
- Prevents watchdog racing mpe_promote_surge_planned (root cause of sample-rate smoke failure)

## Test plan
- [x] Unit tests for defer behavior
- [ ] Pi sample-rate toggle smoke after merge

Made with [Cursor](https://cursor.com)