### PR TITLE
fix(audio): run jack_lsp as graph owner under sudo

### DIFF
--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -202,6 +202,45 @@ mpe_jack_server_running() {
     pgrep -x jackd >/dev/null 2>&1
 }
 
+# jackd runs as MPE_PI_USER (systemd User=). set-surge-audio.sh is invoked via
+# sudo for /etc/mpe writes, so graph probes as root cannot see the user's JACK
+# session — run jack_lsp as the graph owner instead.
+mpe_jack_graph_user() {
+    if [ -n "${MPE_PI_USER:-}" ]; then
+        printf '%s' "$MPE_PI_USER"
+        return 0
+    fi
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != root ]; then
+        printf '%s' "$SUDO_USER"
+        return 0
+    fi
+    if [ -f /etc/mpe/mpe.env ]; then
+        local u
+        u="$(grep -E '^MPE_PI_USER=' /etc/mpe/mpe.env 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d "'" || true)"
+        if [ -n "$u" ]; then
+            printf '%s' "$u"
+            return 0
+        fi
+    fi
+    id -un 2>/dev/null || printf '%s' "${USER:-root}"
+}
+
+mpe_jack_lsp() {
+    local timeout_s="${MPE_JACK_LSP_TIMEOUT_S:-3}"
+    if ! command -v jack_lsp >/dev/null 2>&1; then
+        return 127
+    fi
+    if [ "$(id -u)" -eq 0 ]; then
+        local owner
+        owner="$(mpe_jack_graph_user)"
+        if [ -n "$owner" ] && [ "$owner" != root ]; then
+            timeout "$timeout_s" sudo -u "$owner" -E jack_lsp "$@"
+            return $?
+        fi
+    fi
+    timeout "$timeout_s" jack_lsp "$@"
+}
+
 # Running is not the same as accepting clients. jack_lsp is a hard prerequisite
 # (spec assumptions: jack-example-tools installed). Both server-ready and graph
 # probes must agree — missing jack_lsp is not "server up".
@@ -212,7 +251,7 @@ mpe_jack_server_ready() {
         [ "$quiet" = 1 ] || echo "ERROR: jack_lsp not found — install jack-example-tools" >&2
         return 1
     fi
-    timeout 3 jack_lsp >/dev/null 2>&1
+    mpe_jack_lsp >/dev/null 2>&1
 }
 
 # Bounded readiness wait — never a fixed sleep (spec D3 boot ordering).
@@ -528,7 +567,7 @@ mpe_surge_on_jack_graph() {
     if ! command -v jack_lsp >/dev/null 2>&1; then
         return 1
     fi
-    timeout 3 jack_lsp 2>/dev/null | grep -qi 'surge'
+    mpe_jack_lsp 2>/dev/null | grep -qi 'surge'
 }
 
 # Back-compat alias used by udev helper and profile scripts.

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -465,6 +465,24 @@ echo ok
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "ok")
 
+    def test_jack_lsp_runs_as_graph_owner_when_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "sudo.log"
+            body = f"""
+source {AUDIO_ENGINE_SH}
+id() {{ case "$1" in -u) echo 0 ;; -un) echo root ;; *) command id "$@" ;; esac; }}
+export -f id
+sudo() {{ printf '%s\\n' "$*" >> "{log}"; :; }}
+export -f sudo
+export SUDO_USER=mitch
+export MPE_PI_USER=mitch
+mpe_jack_lsp >/dev/null 2>&1 || true
+cat "{log}"
+"""
+            result = _run_bash_script(body, env=_bash_env())
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("-u mitch", result.stdout)
+
 
 class NoAlsaPathTests(unittest.TestCase):
     """ALSA is not a reachable audio engine anywhere in the codebase (2026-08-12)."""

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -479,6 +479,8 @@ echo ok
 source {AUDIO_ENGINE_SH}
 id() {{ case "$1" in -u) echo 0 ;; -un) echo root ;; *) command id "$@" ;; esac; }}
 export -f id
+timeout() {{ shift; "$@"; }}
+export -f timeout
 sudo() {{ printf '%s\\n' "$*" >> "{log}"; :; }}
 export -f sudo
 export SUDO_USER=mitch

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -468,6 +468,13 @@ echo ok
     def test_jack_lsp_runs_as_graph_owner_when_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             log = Path(tmp) / "sudo.log"
+            bin_dir = Path(tmp) / "bin"
+            bin_dir.mkdir()
+            jack_stub = bin_dir / "jack_lsp"
+            jack_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            jack_stub.chmod(jack_stub.stat().st_mode | stat.S_IXUSR)
+            env = _bash_env()
+            env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
             body = f"""
 source {AUDIO_ENGINE_SH}
 id() {{ case "$1" in -u) echo 0 ;; -un) echo root ;; *) command id "$@" ;; esac; }}
@@ -479,7 +486,7 @@ export MPE_PI_USER=mitch
 mpe_jack_lsp >/dev/null 2>&1 || true
 cat "{log}"
 """
-            result = _run_bash_script(body, env=_bash_env())
+            result = _run_bash_script(body, env=env)
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("-u mitch", result.stdout)
 


### PR DESCRIPTION
## Summary
- Add `mpe_jack_graph_user()` and `mpe_jack_lsp()` so `jack_lsp` runs as `MPE_PI_USER`/`SUDO_USER` when invoked as root
- Use helpers in `mpe_jack_server_ready` and `mpe_surge_on_jack_graph`
- Add unit test `test_jack_lsp_runs_as_graph_owner_when_root`

## Context
`set-surge-audio.sh` runs as root but jackd is `User=MPE_PI_USER`. Root `jack_lsp` cannot see the session, so `mpe_wait_for_jack_server` always timed out at 30s.

## Test plan
- [x] unittest discover in tests/

Made with [Cursor](https://cursor.com)