### PR TITLE
feat(looper): APC faders → loop level, as a control-surface layer

### DIFF
--- a/docs/PI-GITHUB-ACCESS.md
+++ b/docs/PI-GITHUB-ACCESS.md
@@ -1,0 +1,62 @@
+# Pi GitHub access (classic PAT)
+
+The Pi pulls **`MPE-Sound-Module`** (and **`MPE-Library`** when cloned) over **HTTPS** with a **classic personal access token** stored root-owned under `/etc/mpe/`. It does **not** use MitchSchwartz SSH keys or the **M-Ferda** machine account.
+
+| Identity | Role |
+|----------|------|
+| **Laptop** | MitchSchwartz — SSH or gh, full owner |
+| **Pi (`mitch`)** | Classic PAT — **pull only** in practice; stored in `/etc/mpe/git-credentials` |
+| **Racknerd (`om-yolo`)** | Separate OneCLI `github-mpe-module` secret — not the Pi PAT |
+
+## Create the classic token (GitHub UI)
+
+1. GitHub → **Settings** → **Developer settings** → **Personal access tokens** → **Tokens (classic)** → **Generate new token (classic)**.
+2. **Note:** `mpe-pi-git-pull`
+3. **Expiration:** pick one (90d / 1y — calendar reminder to rotate).
+4. **Scopes:** **`repo`** (required for private `git pull` with classic tokens; there is no read-only classic scope for private repos).
+5. Generate and copy the token once (`ghp_…`).
+
+Do **not** paste the token in chat, argv, or git.
+
+## Install on the Pi
+
+From the laptop (token in env var, not history):
+
+```bash
+cd ~/Documents/GitHub/MPE-Module
+printf '%s' "$GITHUB_TOKEN" | ssh mitch@raspberrypi2.local \
+  'sudo bash -s -- --stdin' < scripts/setup-pi-github-pat.sh
+```
+
+Or on the Pi after pulling this script:
+
+```bash
+printf '%s' "$GITHUB_TOKEN" | sudo ./scripts/setup-pi-github-pat.sh --local --stdin
+```
+
+Verify:
+
+```bash
+ssh mitch@raspberrypi2.local \
+  'GIT_TERMINAL_PROMPT=0 git -C ~/MPE-Module ls-remote origin HEAD'
+```
+
+## Retire M-Ferda (manual, after PAT works)
+
+1. **MPE-Sound-Module** → Settings → Collaborators → remove **M-Ferda**.
+2. **MPE-Library** → same (if that repo is still used on the Pi).
+3. **M-Ferda** account → Settings → SSH keys → delete Pi device keys.
+4. On Pi: remove `~/.ssh/config` `Host github.com` block if present (optional cleanup).
+
+**Keep `om-yolo`** — Racknerd YOLO uses it via OneCLI; that path is unrelated to Pi `git pull`.
+
+## Rotation
+
+1. Generate a new classic token.
+2. Re-run `setup-pi-github-pat.sh`.
+3. Revoke the old token in GitHub.
+
+## Related
+
+- Maintainer history: OM-Repo `internal/projects/mpe-synth-launch/maintainer/PI-GITHUB-ISOLATION.md` (superseded by this doc for Pi auth).
+- Racknerd deploy boundary: `docs/racknerd-pi-access-spec.md` — Pi `git checkout` only via future `mpe-yolo-remote.sh` deploy tokens + `pi_soak` gate.

--- a/scripts/setup-pi-github-pat.sh
+++ b/scripts/setup-pi-github-pat.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Install a GitHub classic PAT for Pi git pull (HTTPS only).
+#
+# From laptop (after PAT created in GitHub UI):
+#   printf '%s' "$GITHUB_TOKEN" | ssh mitch@raspberrypi2.local \
+#     'sudo bash -s -- --stdin' < scripts/setup-pi-github-pat.sh
+#
+# On Pi:
+#   printf '%s' "$GITHUB_TOKEN" | sudo ./scripts/setup-pi-github-pat.sh --local --stdin
+#
+# Token never belongs in argv, chat, or git. Rotate via GitHub → revoke old → re-run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/paths.sh
+source "$SCRIPT_DIR/lib/paths.sh"
+
+LOCAL=false
+FROM_STDIN=false
+TOKEN=""
+PI_USER="${MPE_PI_USER:-mitch}"
+CRED_FILE="/etc/mpe/git-credentials"
+ENV_FILE="/etc/mpe/github.env"
+
+usage() {
+    cat <<'EOF'
+Usage: setup-pi-github-pat.sh [--local] --stdin
+
+  --local   Run on the Pi (required when invoked via SSH from laptop).
+  --stdin   Read classic PAT from stdin (one line, no echo).
+
+Writes:
+  /etc/mpe/git-credentials   root:mitch 640  — git credential store
+  /etc/mpe/github.env        root:mitch 640  — GITHUB_TOKEN= (for future deploy hooks)
+
+Configures git for PI_USER:
+  credential.helper store --file=/etc/mpe/git-credentials
+  remote.origin.url → https://github.com/MitchSchwartz/… (module + library)
+
+Verify: GIT_TERMINAL_PROMPT=0 git -C ~/MPE-Module ls-remote origin HEAD
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --local) LOCAL=true ;;
+        --stdin) FROM_STDIN=true ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ "$EUID" -ne 0 ]; then
+    echo "ERROR: run as root (sudo)." >&2
+    exit 1
+fi
+
+if [ "$FROM_STDIN" != true ]; then
+    echo "ERROR: pass --stdin; do not put the token on the command line." >&2
+    exit 1
+fi
+
+IFS= read -r TOKEN || true
+TOKEN="${TOKEN//$'\n'/}"
+TOKEN="${TOKEN//$'\r'/}"
+
+if [ -z "$TOKEN" ]; then
+    echo "ERROR: empty token on stdin." >&2
+    exit 1
+fi
+
+case "$TOKEN" in
+    ghp_*|github_pat_*) ;;
+    *)
+        echo "ERROR: token does not look like a GitHub PAT (expected ghp_… or github_pat_…)." >&2
+        exit 1
+        ;;
+esac
+
+mkdir -p /etc/mpe
+install -m 640 -o root -g "$PI_USER" /dev/null "$CRED_FILE"
+printf 'https://x-access-token:%s@github.com\n' "$TOKEN" > "$CRED_FILE"
+chmod 640 "$CRED_FILE"
+chown root:"$PI_USER" "$CRED_FILE"
+
+{
+    echo "# Pi GitHub classic PAT — git pull only. Rotate: revoke in GitHub, re-run setup."
+    echo "# Mitch-only. Not for Racknerd (om-yolo uses separate OneCLI secret)."
+    printf 'GITHUB_TOKEN=%s\n' "$TOKEN"
+} > "$ENV_FILE"
+chmod 640 "$ENV_FILE"
+chown root:"$PI_USER" "$ENV_FILE"
+
+_as_mitch() {
+    sudo -u "$PI_USER" -H env HOME="/home/$PI_USER" "$@"
+}
+
+_git_https_remote() {
+    local repo="$1"
+    echo "https://github.com/MitchSchwartz/${repo}.git"
+}
+
+_configure_repo() {
+    local dir="$1"
+    local repo="$2"
+    if [ ! -d "$dir/.git" ]; then
+        echo "  skip $dir (not a git repo)"
+        return 0
+    fi
+    local url
+    url="$(_git_https_remote "$repo")"
+    echo "  $dir → $url"
+    _as_mitch git -C "$dir" remote set-url origin "$url"
+    _as_mitch git -C "$dir" config credential.helper "store --file=$CRED_FILE"
+}
+
+echo "Configuring git credential helper for $PI_USER ..."
+_as_mitch git config --global credential.helper "store --file=$CRED_FILE"
+
+# Drop any user-owned credential files from older setups.
+for old in "/home/$PI_USER/.git-credentials" "/home/$PI_USER/.config/git/credentials"; do
+    if [ -f "$old" ]; then
+        echo "Removing legacy credential file: $old"
+        rm -f "$old"
+    fi
+done
+
+if [ -f "/home/$PI_USER/.ssh/config" ] && grep -q 'Host github.com' "/home/$PI_USER/.ssh/config" 2>/dev/null; then
+    echo "NOTE: ~/.ssh/config still has a github.com Host block (M-Ferda era)."
+    echo "      HTTPS + PAT is authoritative now; remove the SSH block when convenient."
+fi
+
+MODULE_DIR="${MPE_MODULE_REPO:-/home/$PI_USER/MPE-Module}"
+LIBRARY_DIR="${MPE_PERSONAL_REPO:-/home/$PI_USER/MPE-Library}"
+
+echo "Setting HTTPS remotes ..."
+_configure_repo "$MODULE_DIR" "MPE-Sound-Module"
+_configure_repo "$LIBRARY_DIR" "MPE-Library"
+
+echo "Verifying GitHub access ..."
+if ! _as_mitch env GIT_TERMINAL_PROMPT=0 git -C "$MODULE_DIR" ls-remote origin HEAD >/dev/null 2>&1; then
+    echo "ERROR: git ls-remote failed for MPE-Module — check token scope (classic: repo)." >&2
+    exit 1
+fi
+echo "✓ MPE-Module ls-remote OK"
+
+if [ -d "$LIBRARY_DIR/.git" ]; then
+    if _as_mitch env GIT_TERMINAL_PROMPT=0 git -C "$LIBRARY_DIR" ls-remote origin HEAD >/dev/null 2>&1; then
+        echo "✓ MPE-Library ls-remote OK"
+    else
+        echo "WARN: MPE-Library ls-remote failed (clone missing or token lacks repo access)." >&2
+    fi
+fi
+
+echo ""
+echo "Done. Credentials: $CRED_FILE (640 root:$PI_USER)"
+echo "Next (GitHub UI, Mitch-only):"
+echo "  1. Remove M-Ferda collaborator from MPE-Sound-Module (+ MPE-Library if used)"
+echo "  2. Revoke M-Ferda SSH keys on the M-Ferda account (if any remain)"
+echo "  3. Keep om-yolo for Racknerd — separate from Pi PAT"

--- a/scripts/setup-pi-github-pat.sh
+++ b/scripts/setup-pi-github-pat.sh
@@ -5,29 +5,32 @@
 #   printf '%s' "$GITHUB_TOKEN" | ssh mitch@raspberrypi2.local \
 #     'sudo bash -s -- --stdin' < scripts/setup-pi-github-pat.sh
 #
-# On Pi:
-#   printf '%s' "$GITHUB_TOKEN" | sudo ./scripts/setup-pi-github-pat.sh --local --stdin
+# On Pi (from repo):
+#   printf '%s' "$GITHUB_TOKEN" | sudo ./scripts/setup-pi-github-pat.sh --stdin
+#
+# On Pi (standalone copy in /tmp):
+#   printf '%s' "$GITHUB_TOKEN" | sudo bash /tmp/setup-pi-github-pat.sh --stdin
 #
 # Token never belongs in argv, chat, or git. Rotate via GitHub → revoke old → re-run.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# shellcheck source=lib/paths.sh
-source "$SCRIPT_DIR/lib/paths.sh"
+if [ -f "$SCRIPT_DIR/lib/paths.sh" ]; then
+    # shellcheck source=lib/paths.sh
+    source "$SCRIPT_DIR/lib/paths.sh"
+elif [ -f /etc/mpe/mpe.env ]; then
+    # Standalone run (e.g. /tmp/setup-pi-github-pat.sh) — load appliance paths only.
+    # shellcheck disable=SC1091
+    source /etc/mpe/mpe.env
+fi
 
-LOCAL=false
 FROM_STDIN=false
-TOKEN=""
-PI_USER="${MPE_PI_USER:-mitch}"
-CRED_FILE="/etc/mpe/git-credentials"
-ENV_FILE="/etc/mpe/github.env"
 
 usage() {
     cat <<'EOF'
-Usage: setup-pi-github-pat.sh [--local] --stdin
+Usage: setup-pi-github-pat.sh --stdin
 
-  --local   Run on the Pi (required when invoked via SSH from laptop).
   --stdin   Read classic PAT from stdin (one line, no echo).
 
 Writes:
@@ -44,13 +47,17 @@ EOF
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --local) LOCAL=true ;;
         --stdin) FROM_STDIN=true ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
     esac
     shift
 done
+
+PI_USER="${MPE_PI_USER:-mitch}"
+TOKEN=""
+CRED_FILE="/etc/mpe/git-credentials"
+ENV_FILE="/etc/mpe/github.env"
 
 if [ "$EUID" -ne 0 ]; then
     echo "ERROR: run as root (sudo)." >&2

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -20,10 +20,10 @@ from apc_footswitch import (  # noqa: E402
     reset_all_loops,
     stop_all_loops,
 )
-from apc_faders import fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
+from apc_faders import MASTER, fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
 from apc_grid import NUM_LOOPS, loop_index_for_note  # noqa: E402
 from apc_transport import ShiftHoldCombo, resolve_apc_transport_notes  # noqa: E402
-from loop_mix import CoalescingSender, LoopMix  # noqa: E402
+from loop_mix import SL_MASTER_CONTROL, CoalescingSender, LoopMix  # noqa: E402
 from sl_bench_listener import SlBenchStateListener  # noqa: E402
 from sl_grid_state import GridState, display_bpm  # noqa: E402
 from sl_grid_sync import (  # noqa: E402
@@ -240,10 +240,26 @@ def main() -> int:
         """
         faders.flush(now=time.monotonic())
 
+    master_announced = False
+
     def handle_cc(cc: int, value: int) -> None:
+        nonlocal master_announced
         fader = fader_for_cc(cc, loop_fader_ccs=loop_fader_ccs, master_cc=master_cc)
         if fader is None:
             return
+        if fader == MASTER and not master_announced:
+            # UNVERIFIED: every other /set in this repo is an engine setting
+            # (tempo, sync_source, fade_samples) — nothing has ever written a
+            # level at engine scope. If SooperLooper has no global control by
+            # this name the message is dropped in silence, and the symptom is
+            # "the master fader does nothing". Say what we are sending, once,
+            # so that failure is readable instead of mysterious.
+            master_announced = True
+            print(
+                f"faders: master -> /set {SL_MASTER_CONTROL} "
+                f"(control name unverified against the engine)",
+                flush=True,
+            )
         faders.submit(mix.messages_for(fader, value), now=time.monotonic())
 
     def maybe_track_transport() -> None:

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -82,7 +82,7 @@ def main() -> int:
     apc_variant = os.environ.get("MPE_APC_VARIANT", "").strip() or None
     track_reset_hold_ms = float(os.environ.get("MPE_APC_TRACK_RESET_HOLD_MS", "3000"))
     sync_mode = os.environ.get("MPE_SL_SYNC_MODE", "grid").strip().lower()
-    fader_interval_ms = float(os.environ.get("MPE_APC_FADER_INTERVAL_MS", "20"))
+    fader_interval_ms = float(os.environ.get("MPE_APC_FADER_INTERVAL_MS", "10"))
 
     try:
         import rtmidi
@@ -231,20 +231,17 @@ def main() -> int:
             fs.poll_hold()
             fs.poll_led()
 
-    def flush_faders() -> None:
-        """Push whatever the coalescer is holding.
-
-        Called from the idle branch, which is the only place that runs after
-        the last CC of a drag. Without it the value a fader came to rest at
-        stays pending forever and the surface lies about the level.
-        """
-        faders.flush(now=time.monotonic())
+    def tick_faders() -> None:
+        """Ramp smoothed wet toward targets between CC events."""
+        faders.tick(now=time.monotonic())
 
     def handle_cc(cc: int, value: int) -> None:
         fader = fader_for_cc(cc, loop_fader_ccs=loop_fader_ccs, master_cc=master_cc)
         if fader is None:
             return
-        faders.submit(mix.messages_for(fader, value), now=time.monotonic())
+        now = time.monotonic()
+        faders.submit(mix.messages_for(fader, value), now=now)
+        faders.tick(now=now)
 
     def maybe_track_transport() -> None:
         if track_reset.poll_long():
@@ -268,7 +265,7 @@ def main() -> int:
         if packet is None:
             poll_holds()
             maybe_track_transport()
-            flush_faders()
+            tick_faders()
             state_listener.maybe_reregister()
             time.sleep(0.002)
             continue

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -20,8 +20,10 @@ from apc_footswitch import (  # noqa: E402
     reset_all_loops,
     stop_all_loops,
 )
+from apc_faders import fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
 from apc_grid import NUM_LOOPS, loop_index_for_note  # noqa: E402
 from apc_transport import ShiftHoldCombo, resolve_apc_transport_notes  # noqa: E402
+from loop_mix import CoalescingSender, LoopMix  # noqa: E402
 from sl_bench_listener import SlBenchStateListener  # noqa: E402
 from sl_grid_state import GridState, display_bpm  # noqa: E402
 from sl_grid_sync import (  # noqa: E402
@@ -52,6 +54,11 @@ def _format_midi(msg: list[int]) -> str:
     if cmd in (0x90, 0x80) and len(msg) >= 3:
         kind = "note_on" if cmd == 0x90 and msg[2] > 0 else "note_off"
         return f"ch={ch} {kind} note=0x{msg[1]:02X}({msg[1]}) vel={msg[2]}"
+    # Faders are CC. Without this branch --dump-midi renders them as raw hex,
+    # which is exactly the tool you reach for to confirm which CC each fader
+    # sends on an unfamiliar APC variant.
+    if cmd == 0xB0 and len(msg) >= 3:
+        return f"ch={ch} cc={msg[1]} value={msg[2]}"
     return " ".join(f"0x{b:02X}" for b in msg)
 
 
@@ -75,6 +82,7 @@ def main() -> int:
     apc_variant = os.environ.get("MPE_APC_VARIANT", "").strip() or None
     track_reset_hold_ms = float(os.environ.get("MPE_APC_TRACK_RESET_HOLD_MS", "3000"))
     sync_mode = os.environ.get("MPE_SL_SYNC_MODE", "grid").strip().lower()
+    fader_interval_ms = float(os.environ.get("MPE_APC_FADER_INTERVAL_MS", "20"))
 
     try:
         import rtmidi
@@ -182,8 +190,19 @@ def main() -> int:
         else:
             print("bench: no grid to restore — next take defines one", flush=True)
 
+    loop_fader_ccs, master_cc, _fader_label = resolve_fader_ccs(
+        port_name, variant=apc_variant
+    )
+    mix = LoopMix(num_loops=num_loops)
+    faders = CoalescingSender(_send, interval_s=fader_interval_ms / 1000.0)
+
+    def on_wet(loop_index: int, value: float) -> None:
+        mix.seed_from_engine(loop_index, value)
+
     by_loop = footswitches_by_loop(footswitches)
-    state_listener = SlBenchStateListener(by_loop, on_global=on_engine_settings)
+    state_listener = SlBenchStateListener(
+        by_loop, on_global=on_engine_settings, on_wet=on_wet
+    )
     state_listener.start()
     state_listener.register(osc, num_loops=num_loops)
 
@@ -199,7 +218,9 @@ def main() -> int:
         f"Shift=0x{shift_note:02X} StopAll=0x{stop_all_note:02X} | "
         f"short tap=cycle hold>={hold_ms:.0f}ms clear | "
         f"Shift+StopAll release=stop all | "
-        f"Shift+StopAll held>={track_reset_hold_ms:.0f}ms=clear all",
+        f"Shift+StopAll held>={track_reset_hold_ms:.0f}ms=clear all | "
+        f"faders CC{loop_fader_ccs[0]}..{loop_fader_ccs[-1]} -> loop columns "
+        f"(N and N+8), CC{master_cc} -> loop bus",
         flush=True,
     )
     if args.dump_midi:
@@ -209,6 +230,21 @@ def main() -> int:
         for fs in footswitches:
             fs.poll_hold()
             fs.poll_led()
+
+    def flush_faders() -> None:
+        """Push whatever the coalescer is holding.
+
+        Called from the idle branch, which is the only place that runs after
+        the last CC of a drag. Without it the value a fader came to rest at
+        stays pending forever and the surface lies about the level.
+        """
+        faders.flush(now=time.monotonic())
+
+    def handle_cc(cc: int, value: int) -> None:
+        fader = fader_for_cc(cc, loop_fader_ccs=loop_fader_ccs, master_cc=master_cc)
+        if fader is None:
+            return
+        faders.submit(mix.messages_for(fader, value), now=time.monotonic())
 
     def maybe_track_transport() -> None:
         if track_reset.poll_long():
@@ -232,6 +268,7 @@ def main() -> int:
         if packet is None:
             poll_holds()
             maybe_track_transport()
+            flush_faders()
             state_listener.maybe_reregister()
             time.sleep(0.002)
             continue
@@ -248,6 +285,14 @@ def main() -> int:
 
         st, n = msg[0], msg[1]
         vel = msg[2] if len(msg) > 2 else 0
+
+        if is_control_change(st) and len(msg) >= 3:
+            handle_cc(n, vel)
+            poll_holds()
+            maybe_track_transport()
+            state_listener.maybe_reregister()
+            continue
+
         down = midi_note_down(st, vel)
         if down is not None and n in (shift_note, stop_all_note):
             label = "Shift" if n == shift_note else "StopAll"

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -20,7 +20,7 @@ from apc_footswitch import (  # noqa: E402
     reset_all_loops,
     stop_all_loops,
 )
-from apc_faders import fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
+from apc_faders import MASTER, fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
 from apc_grid import NUM_LOOPS, loop_index_for_note, loops_for_column  # noqa: E402
 from apc_transport import ShiftHoldCombo, resolve_apc_transport_notes  # noqa: E402
 from loop_mix import CoalescingSender, LoopMix  # noqa: E402
@@ -249,6 +249,7 @@ def main() -> int:
         for loop in affected:
             faders.seed_current(f"/sl/{loop}/set", mix.wet_for(loop))
         faders.submit(mix.messages_for(fader, value), now=now)
+        faders.tick(now=now)
 
     def maybe_track_transport() -> None:
         if track_reset.poll_long():

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -20,10 +20,10 @@ from apc_footswitch import (  # noqa: E402
     reset_all_loops,
     stop_all_loops,
 )
-from apc_faders import MASTER, fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
+from apc_faders import fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
 from apc_grid import NUM_LOOPS, loop_index_for_note  # noqa: E402
 from apc_transport import ShiftHoldCombo, resolve_apc_transport_notes  # noqa: E402
-from loop_mix import SL_MASTER_CONTROL, CoalescingSender, LoopMix  # noqa: E402
+from loop_mix import CoalescingSender, LoopMix  # noqa: E402
 from sl_bench_listener import SlBenchStateListener  # noqa: E402
 from sl_grid_state import GridState, display_bpm  # noqa: E402
 from sl_grid_sync import (  # noqa: E402
@@ -220,7 +220,7 @@ def main() -> int:
         f"Shift+StopAll release=stop all | "
         f"Shift+StopAll held>={track_reset_hold_ms:.0f}ms=clear all | "
         f"faders CC{loop_fader_ccs[0]}..{loop_fader_ccs[-1]} -> loop columns "
-        f"(N and N+8), CC{master_cc} -> loop bus",
+        f"(N and N+8), CC{master_cc} -> all loops (master)",
         flush=True,
     )
     if args.dump_midi:
@@ -240,26 +240,10 @@ def main() -> int:
         """
         faders.flush(now=time.monotonic())
 
-    master_announced = False
-
     def handle_cc(cc: int, value: int) -> None:
-        nonlocal master_announced
         fader = fader_for_cc(cc, loop_fader_ccs=loop_fader_ccs, master_cc=master_cc)
         if fader is None:
             return
-        if fader == MASTER and not master_announced:
-            # UNVERIFIED: every other /set in this repo is an engine setting
-            # (tempo, sync_source, fade_samples) — nothing has ever written a
-            # level at engine scope. If SooperLooper has no global control by
-            # this name the message is dropped in silence, and the symptom is
-            # "the master fader does nothing". Say what we are sending, once,
-            # so that failure is readable instead of mysterious.
-            master_announced = True
-            print(
-                f"faders: master -> /set {SL_MASTER_CONTROL} "
-                f"(control name unverified against the engine)",
-                flush=True,
-            )
         faders.submit(mix.messages_for(fader, value), now=time.monotonic())
 
     def maybe_track_transport() -> None:

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -249,7 +249,6 @@ def main() -> int:
         for loop in affected:
             faders.seed_current(f"/sl/{loop}/set", mix.wet_for(loop))
         faders.submit(mix.messages_for(fader, value), now=now)
-        faders.tick(now=now)
 
     def maybe_track_transport() -> None:
         if track_reset.poll_long():

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -21,7 +21,7 @@ from apc_footswitch import (  # noqa: E402
     stop_all_loops,
 )
 from apc_faders import fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
-from apc_grid import NUM_LOOPS, loop_index_for_note  # noqa: E402
+from apc_grid import NUM_LOOPS, loop_index_for_note, loops_for_column  # noqa: E402
 from apc_transport import ShiftHoldCombo, resolve_apc_transport_notes  # noqa: E402
 from loop_mix import CoalescingSender, LoopMix  # noqa: E402
 from sl_bench_listener import SlBenchStateListener  # noqa: E402
@@ -240,6 +240,14 @@ def main() -> int:
         if fader is None:
             return
         now = time.monotonic()
+        if fader == MASTER:
+            affected = range(num_loops)
+        elif isinstance(fader, int):
+            affected = [n for n in loops_for_column(fader) if n < num_loops]
+        else:
+            affected = ()
+        for loop in affected:
+            faders.seed_current(f"/sl/{loop}/set", mix.wet_for(loop))
         faders.submit(mix.messages_for(fader, value), now=now)
         faders.tick(now=now)
 

--- a/scripts/sooperlooper/README.md
+++ b/scripts/sooperlooper/README.md
@@ -47,12 +47,21 @@ per-loop control needs either banking or the reserved controller rows.
 audio graph runs `Surge → system:playback` in parallel with
 `Surge → SooperLooper → common_out → playback`, and the live path must fail open
 (DECISIONS.md). Live level stays on the per-patch Vol fader on the touch screen.
-The engine-side control name is `MPE_SL_MASTER_CONTROL` — also unverified.
+⚠️ **The master fader may be inert until its control name is confirmed.** Every
+other `/set` in this repo is an engine *setting* (`tempo`, `sync_source`,
+`fade_samples`); nothing has ever written a level at engine scope, so a global
+`wet` is assumed, not known. If SooperLooper has no such control the message is
+dropped in silence — no error, no log. The bench therefore prints the path and
+control name the first time the master moves. Override with
+`MPE_SL_MASTER_CONTROL` once the real name is read off the SL source on the Pi.
 
 **Faders don't move on their own.** They have no motors, so at startup their
 physical positions mean nothing. Levels are seeded from the engine's reported
 `wet`, and a fader stays inert until it crosses the value it is supposed to be
-at. A fader that appears dead has not been picked up yet — sweep it.
+at. A fader that appears dead has not been picked up yet — **sweep it all the
+way to the top**, which is where levels sit until something lowers them. Until
+it crosses, a fader is inert across nearly all of its travel; that is pickup
+working, not a fault.
 
 Level composition lives in one place, `loop_mix.wet_for()`:
 `wet = taper(user gain) × auto_law(active loops)`. The `loop_gain/N` backstop

--- a/scripts/sooperlooper/README.md
+++ b/scripts/sooperlooper/README.md
@@ -30,7 +30,7 @@ is stale — those files are gone.
 | **3** | 24–31 | 8–15 | Clip pads |
 | 1, 2, 4–7 | — | — | Per-loop controllers (future) |
 | **Faders 1–8** | CC 48–55 | column: N *and* N+8 | Loop level |
-| **Master fader** | CC 56 | loop bus | Loop-mix master |
+| **Master fader** | CC 56 | all 16 | Loop-mix master |
 
 Mapping: `apc_grid.py` · 16-pad footswitch: `../sooperlooper-apc-bench.py` (rows 0 + 3)
 
@@ -43,17 +43,19 @@ per-loop control needs either banking or the reserved controller rows.
 `apc_faders.py` (mirroring how `apc_transport.py` resolves Shift/Stop-All, which
 *do* differ between mk1 and mk2). Confirm with `--dump-midi` and move each fader.
 
-**Master = loop bus only.** It scales `common_out`, not the live synth: the
+**Master = loops only.** It scales the loop mix, not the live synth: the
 audio graph runs `Surge → system:playback` in parallel with
 `Surge → SooperLooper → common_out → playback`, and the live path must fail open
 (DECISIONS.md). Live level stays on the per-patch Vol fader on the touch screen.
-⚠️ **The master fader may be inert until its control name is confirmed.** Every
-other `/set` in this repo is an engine *setting* (`tempo`, `sync_source`,
-`fade_samples`); nothing has ever written a level at engine scope, so a global
-`wet` is assumed, not known. If SooperLooper has no such control the message is
-dropped in silence — no error, no log. The bench therefore prints the path and
-control name the first time the master moves. Override with
-`MPE_SL_MASTER_CONTROL` once the real name is read off the SL source on the Pi.
+**The master is arithmetic, not a bus control.** An engine-global `/set wet`
+would be the obvious mapping, but every global this system sends is a *setting*
+(`tempo`, `sync_source`, `fade_samples`) — nothing has ever written a level at
+engine scope, so that control is unproven, and OSC drops a message to a control
+the engine lacks in silence. So the master is a factor in `wet_for()` and moves
+all 16 loops over per-loop `wet`, which is proven live. Loops sum into
+`common_out` through plain `jack_connect` with no gain or limiter stage, so
+scaling all 16 is exactly equal to scaling the bus. One master move is 16 OSC
+messages, capped by the same coalescer as the rest.
 
 **Faders don't move on their own.** They have no motors, so at startup their
 physical positions mean nothing. Levels are seeded from the engine's reported
@@ -64,7 +66,9 @@ it crosses, a fader is inert across nearly all of its travel; that is pickup
 working, not a fault.
 
 Level composition lives in one place, `loop_mix.wet_for()`:
-`wet = taper(user gain) × auto_law(active loops)`. The `loop_gain/N` backstop
+`wet = taper(user gain) × taper(master) × auto_law(active loops)`. The three
+contributions meet in one multiply, always recomputed in full from state we own,
+so nothing compounds. The `loop_gain/N` backstop
 (DECISIONS.md) is off by default (`MPE_SL_LOOP_GAIN_LAW=1`); the point of the
 seam is that nothing else ever writes `wet`.
 

--- a/scripts/sooperlooper/README.md
+++ b/scripts/sooperlooper/README.md
@@ -29,8 +29,35 @@ is stale — those files are gone.
 | **0** (bottom) | 0–7 | 0–7 | Clip pads |
 | **3** | 24–31 | 8–15 | Clip pads |
 | 1, 2, 4–7 | — | — | Per-loop controllers (future) |
+| **Faders 1–8** | CC 48–55 | column: N *and* N+8 | Loop level |
+| **Master fader** | CC 56 | loop bus | Loop-mix master |
 
 Mapping: `apc_grid.py` · 16-pad footswitch: `../sooperlooper-apc-bench.py` (rows 0 + 3)
+
+**Faders:** one fader per grid *column*, so fader N moves both clips stacked in
+that column (loop N on row 0 and loop N+8 on row 3). Eight faders cover all 16
+loops with no bank button. This is a starting semantic, not the final one —
+per-loop control needs either banking or the reserved controller rows.
+
+⚠️ **CC numbers unverified against hardware.** They are resolved per variant in
+`apc_faders.py` (mirroring how `apc_transport.py` resolves Shift/Stop-All, which
+*do* differ between mk1 and mk2). Confirm with `--dump-midi` and move each fader.
+
+**Master = loop bus only.** It scales `common_out`, not the live synth: the
+audio graph runs `Surge → system:playback` in parallel with
+`Surge → SooperLooper → common_out → playback`, and the live path must fail open
+(DECISIONS.md). Live level stays on the per-patch Vol fader on the touch screen.
+The engine-side control name is `MPE_SL_MASTER_CONTROL` — also unverified.
+
+**Faders don't move on their own.** They have no motors, so at startup their
+physical positions mean nothing. Levels are seeded from the engine's reported
+`wet`, and a fader stays inert until it crosses the value it is supposed to be
+at. A fader that appears dead has not been picked up yet — sweep it.
+
+Level composition lives in one place, `loop_mix.wet_for()`:
+`wet = taper(user gain) × auto_law(active loops)`. The `loop_gain/N` backstop
+(DECISIONS.md) is off by default (`MPE_SL_LOOP_GAIN_LAW=1`); the point of the
+seam is that nothing else ever writes `wet`.
 
 **Grid sync:** two states, not a pile of settings — `set_grid_active(active=)`.
 Off until the first take lands (so it records instantly), then on for every clip

--- a/scripts/sooperlooper/README.md
+++ b/scripts/sooperlooper/README.md
@@ -59,11 +59,9 @@ messages, capped by the same coalescer as the rest.
 
 **Faders don't move on their own.** They have no motors, so at startup their
 physical positions mean nothing. Levels are seeded from the engine's reported
-`wet`, and a fader stays inert until it crosses the value it is supposed to be
-at. A fader that appears dead has not been picked up yet — **sweep it all the
-way to the top**, which is where levels sit until something lowers them. Until
-it crosses, a fader is inert across nearly all of its travel; that is pickup
-working, not a fault.
+`wet`. The first touch **anchors** relative pickup (no jump); movement after
+that applies delta from where you grabbed. Output is smoothed (~45 ms default,
+`MPE_APC_FADER_SMOOTH_MS`) so fast drags track cleanly.
 
 Level composition lives in one place, `loop_mix.wet_for()`:
 `wet = taper(user gain) × taper(master) × auto_law(active loops)`. The three

--- a/scripts/sooperlooper/apc_faders.py
+++ b/scripts/sooperlooper/apc_faders.py
@@ -1,0 +1,86 @@
+"""APC mini faders ↔ control identity (eval + future product).
+
+Nine physical faders: eight above the grid columns, one master on the right.
+This module answers exactly one question — "which fader is this CC?" — and
+answers it as a pure function. No MIDI, no OSC, no clock.
+
+Variant-aware on purpose. The mk1/mk2 divergence is a known hazard here:
+apc_transport.py exists solely because Shift and Stop-All sit on different
+notes on the two surfaces. The fader CCs are *believed* to agree (48–55 plus
+56) but that has not been confirmed against hardware, so the two variants get
+separate constants and go through the same resolve-by-port-name path. If they
+turn out to differ, one constant changes and nothing else does.
+
+Confirm with: sooperlooper-apc-bench.py --dump-midi, then move each fader.
+
+What a fader is *bound to* is not decided here — see loop_mix.py. A fader is a
+control identity; the binding is a separate layer, because these faders are
+going to mean pan or filter as well as level.
+"""
+
+from __future__ import annotations
+
+# The master fader is not fader index 8 — it is a different kind of thing,
+# addressing the loop bus rather than a grid column. Naming it as a string
+# keeps that distinction in the type instead of in a comment.
+MASTER = "master"
+
+FaderId = int | str  # 0–7, or MASTER
+
+# APC mini mk2 (Communication Protocol v1.0)
+CC_FADER_BASE_MK2 = 48
+CC_MASTER_MK2 = 56
+
+# APC mini mk1 (original)
+CC_FADER_BASE_MK1 = 48
+CC_MASTER_MK1 = 56
+
+NUM_LOOP_FADERS = 8
+CC_MIN = 0
+CC_MAX = 127
+
+
+def resolve_fader_ccs(
+    port_name: str,
+    *,
+    variant: str | None = None,
+) -> tuple[tuple[int, ...], int, str]:
+    """Return (loop_fader_ccs, master_cc, label) for the connected APC.
+
+    Mirrors resolve_apc_transport_notes() deliberately: same argument shape,
+    same explicit-variant-then-port-name precedence, same mk1 default. One
+    surface, one way of asking what it is.
+    """
+    explicit = (variant or "").strip().lower()
+    if explicit in ("mk2", "mkii", "2"):
+        return _ccs(CC_FADER_BASE_MK2), CC_MASTER_MK2, "mk2"
+    if explicit in ("mk1", "1", "original", "mini"):
+        return _ccs(CC_FADER_BASE_MK1), CC_MASTER_MK1, "mk1"
+
+    name = port_name.lower()
+    if "mk2" in name or "mkii" in name:
+        return _ccs(CC_FADER_BASE_MK2), CC_MASTER_MK2, "mk2"
+    return _ccs(CC_FADER_BASE_MK1), CC_MASTER_MK1, "mk1"
+
+
+def _ccs(base: int) -> tuple[int, ...]:
+    return tuple(base + i for i in range(NUM_LOOP_FADERS))
+
+
+def fader_for_cc(
+    cc: int,
+    *,
+    loop_fader_ccs: tuple[int, ...],
+    master_cc: int,
+) -> FaderId | None:
+    """Fader index 0–7, MASTER, or None if this CC is not a fader."""
+    if cc == master_cc:
+        return MASTER
+    try:
+        return loop_fader_ccs.index(cc)
+    except ValueError:
+        return None
+
+
+def is_control_change(status: int) -> bool:
+    return (status & 0xF0) == 0xB0

--- a/scripts/sooperlooper/apc_grid.py
+++ b/scripts/sooperlooper/apc_grid.py
@@ -41,6 +41,18 @@ def loop_index_for_note(note: int) -> int | None:
     return loop_index_for_pad(rc[0], rc[1])
 
 
+def loops_for_column(col: int) -> tuple[int, ...]:
+    """Loops sharing grid column `col`, top row first — (col, 8+col).
+
+    Derived from all_loop_pads() rather than computed independently, so the
+    fader layer follows the pad layout by construction. Change LOOP_CLIP_ROWS
+    and the faders move with the pads instead of quietly disagreeing.
+    """
+    if not 0 <= col <= 7:
+        raise ValueError(f"column out of range: {col}")
+    return tuple(loop for _row, c, loop in all_loop_pads() if c == col)
+
+
 def all_loop_pads() -> list[tuple[int, int, int]]:
     """(row, col, loop_index) for all 16 clip pads."""
     out: list[tuple[int, int, int]] = []

--- a/scripts/sooperlooper/loop_mix.py
+++ b/scripts/sooperlooper/loop_mix.py
@@ -181,6 +181,12 @@ class LoopMix:
             return
         if abs(wet - self.wet_for(loop)) <= WET_ECHO_TOLERANCE:
             return
+        # While a column fader is in hand, engine wet often lags our composed
+        # target — we update user_gain before OSC lands. Treat that as in-flight,
+        # not an external change, or pickup re-arms and the fader goes dead.
+        for col in range(8):
+            if loop in loops_for_column(col) and col in self._pickup_anchor:
+                return
         cc = self._user_cc_from_composed_wet(loop, wet)
         if abs(cc - self.user_gain[loop]) <= PICKUP_TOLERANCE_CC:
             return
@@ -350,7 +356,21 @@ class CoalescingSender:
             if (now - self._last_sent) >= self._interval_s:
                 self.flush(now=now)
         else:
+            if self._has_pending_motion():
+                self._prime_tick(now)
             self.tick(now=now)
+
+    def _has_pending_motion(self) -> bool:
+        for path, target in self._target_wet.items():
+            cur = self._current_wet.get(path, target)
+            if abs(target - cur) > self._smooth_snap:
+                return True
+        return False
+
+    def _prime_tick(self, now: float) -> None:
+        """Ensure the next tick has elapsed time so the first step emits."""
+        if self._last_tick == float("-inf") or (now - self._last_tick) <= 0:
+            self._last_tick = now - max(self._interval_s, 0.001)
 
     def tick(self, *, now: float) -> None:
         if not self._target_wet or self._smooth_tau_s <= 0:
@@ -371,6 +391,9 @@ class CoalescingSender:
                 self._current_wet[path] = nxt
                 moved = True
         if moved and (now - self._last_sent) >= self._interval_s:
+            self._emit_current(now=now)
+        elif self._has_pending_motion() and (now - self._last_sent) >= self._interval_s:
+            # Snap threshold can leave moved=False while target != current.
             self._emit_current(now=now)
 
     def flush(self, *, now: float) -> None:

--- a/scripts/sooperlooper/loop_mix.py
+++ b/scripts/sooperlooper/loop_mix.py
@@ -332,6 +332,11 @@ class CoalescingSender:
         self._last_sent = float("-inf")
         self._last_tick = float("-inf")
 
+    def seed_current(self, path: str, wet: float) -> None:
+        """Set ramp start to engine truth before the first send on ``path``."""
+        if path not in self._current_wet:
+            self._current_wet[path] = max(0.0, min(1.0, float(wet)))
+
     def submit(self, messages: list[tuple[str, list]], *, now: float) -> None:
         for path, args in messages:
             self._pending_meta[path] = args
@@ -339,6 +344,7 @@ class CoalescingSender:
                 target = float(args[1])
                 self._target_wet[path] = target
                 if path not in self._current_wet:
+                    # Unseeded: assume engine already at target (tests / master).
                     self._current_wet[path] = target
         if self._smooth_tau_s <= 0:
             if (now - self._last_sent) >= self._interval_s:

--- a/scripts/sooperlooper/loop_mix.py
+++ b/scripts/sooperlooper/loop_mix.py
@@ -45,11 +45,6 @@ from enum import Enum
 from apc_faders import CC_MAX, MASTER, FaderId
 from apc_grid import loops_for_column
 
-# The loop-bus master. UNVERIFIED against the engine — SooperLooper source is
-# not available off the Pi. Kept as one named constant so confirming it is a
-# one-line change. Check src/control_osc.cpp on the Pi before trusting it.
-SL_MASTER_CONTROL = os.environ.get("MPE_SL_MASTER_CONTROL", "wet")
-
 # Bottom of fader travel must mean silence. A log taper cannot reach zero, so
 # the bottom of the range is snapped to it explicitly. Without this the fader
 # bottoms out at a quiet-but-audible level, which reads as a bug.
@@ -137,6 +132,9 @@ class LoopMix:
     num_loops: int = 16
     mode: FaderMode = FaderMode.LEVEL
     user_gain: dict[int, int] = field(default_factory=dict)
+    # The master is a factor in the composition below, not a message of its
+    # own. See messages_for() for why it is not an engine-global control.
+    master_gain: int = CC_MAX
     active_loops: int = 0
     _picked_up: set[FaderId] = field(default_factory=set)
     # Where each fader must cross before it may write. Held per fader rather
@@ -192,12 +190,24 @@ class LoopMix:
         """(path, args) to send for this fader movement. [] if suppressed."""
         raw = max(0, min(CC_MAX, int(raw)))
         if fader == MASTER:
-            # Nothing is stored: the master is a bus control, so it cannot take
-            # part in wet_for() composition, and there is no per-loop truth to
-            # seed it from. It is a straight pass-through by design.
-            param = PARAMETERS[FaderMode.LEVEL]
-            value = fader_taper(raw, floor_db=param.floor_db, ceil_db=param.ceil_db)
-            return [("/set", [SL_MASTER_CONTROL, value])]
+            # Arithmetic in the control layer, not a bus control (DECISIONS.md
+            # :468). An engine-global `/set wet` would be the obvious mapping,
+            # but nothing in this system has ever written a *level* at engine
+            # scope — every global we send is a setting (tempo, sync_source,
+            # fade_samples) — so that control is unproven, and an OSC message
+            # to a control SooperLooper does not have is dropped in silence.
+            # Per-loop `wet` is proven live (eval 2026-08-14). Since loops sum
+            # into common_out through plain jack_connect with no gain or
+            # limiter stage, scaling all 16 is exactly equal to scaling the
+            # bus — the same result over a control we know exists.
+            #
+            # Master stays exempt from pickup: there is no engine truth to
+            # seed it from, so gating it would leave it permanently inert.
+            # The cost is chosen, not overlooked — its first move jumps all 16
+            # loops at once. That jump is downward from stored unity, which is
+            # the safe direction, and the alternative is a dead fader.
+            self.master_gain = raw
+            return self._all_loop_messages()
 
         if not isinstance(fader, int) or not 0 <= fader <= 7:
             return []
@@ -233,14 +243,23 @@ class LoopMix:
     # -- composition ------------------------------------------------------
 
     def wet_for(self, loop: int) -> float:
-        """The single point where the user's gain and the automatic law meet."""
+        """The single point where every contribution to a loop's level meets.
+
+        Three factors, one multiply: what the user asked this loop to sit at,
+        the master, and the automatic backstop law. Everything is recomputed
+        in full from state we own, so nothing here compounds and no two
+        writers of `wet` can fight.
+        """
         param = PARAMETERS[self.mode]
         user = fader_taper(
             self.user_gain.get(loop, CC_MAX),
             floor_db=param.floor_db,
             ceil_db=param.ceil_db,
         )
-        return max(0.0, min(1.0, user * auto_law(self.active_loops)))
+        master = fader_taper(
+            self.master_gain, floor_db=param.floor_db, ceil_db=param.ceil_db
+        )
+        return max(0.0, min(1.0, user * master * auto_law(self.active_loops)))
 
 
 def _wet_to_cc(wet: float, param: Parameter) -> int:

--- a/scripts/sooperlooper/loop_mix.py
+++ b/scripts/sooperlooper/loop_mix.py
@@ -57,6 +57,10 @@ FADER_CEIL_DB = float(os.environ.get("MPE_APC_FADER_CEIL_DB", "0.0"))
 # exact crossing can leave a fader permanently inert.
 PICKUP_TOLERANCE_CC = int(os.environ.get("MPE_APC_FADER_PICKUP_CC", "2"))
 
+# Engine `wet` echoes include master and auto-law — compare composed level,
+# not per-column fader CC, or master moves corrupt user_gain.
+WET_ECHO_TOLERANCE = float(os.environ.get("MPE_APC_FADER_WET_ECHO", "1e-4"))
+
 # Off by default: the backstop law is planned, not yet agreed as always-on.
 # The seam exists from the first commit so that turning it on is a config
 # change rather than a refactor of who writes `wet`.
@@ -162,13 +166,21 @@ class LoopMix:
         permanently inert, since a fader can never cross a target that moves to
         meet it 10 times a second.
 
+        Echo detection compares against ``wet_for(loop)`` — the full composite
+        of column fader, master, and auto-law — not ``user_gain`` CC. Inverting
+        composed wet into CC and comparing to the column fader corrupts
+        ``user_gain`` whenever the master moves.
+
         A value we did *not* ask for is different: something else changed the
         level, our stored gain is stale, and the physical fader is now lying
-        about it. Adopt it and make the fader earn control back.
+        about it. Back out master and law, adopt the implied column fader
+        position, and make the fader earn control back.
         """
         if loop not in self.user_gain:
             return
-        cc = _wet_to_cc(wet, PARAMETERS[self.mode])
+        if abs(wet - self.wet_for(loop)) <= WET_ECHO_TOLERANCE:
+            return
+        cc = self._user_cc_from_composed_wet(loop, wet)
         if abs(cc - self.user_gain[loop]) <= PICKUP_TOLERANCE_CC:
             return
         self.user_gain[loop] = cc
@@ -176,6 +188,17 @@ class LoopMix:
             if loop in loops_for_column(col):
                 self._picked_up.discard(col)
                 self._pickup_ref[col] = cc
+
+    def _user_cc_from_composed_wet(self, loop: int, wet: float) -> int:
+        """Column-fader CC implied by a composed engine ``wet`` level."""
+        param = PARAMETERS[self.mode]
+        master = fader_taper(
+            self.master_gain, floor_db=param.floor_db, ceil_db=param.ceil_db
+        )
+        law = auto_law(self.active_loops)
+        divisor = max(master * law, 1e-9)
+        user_amp = max(0.0, min(1.0, wet / divisor))
+        return _wet_to_cc(user_amp, param)
 
     def note_active_loops(self, count: int) -> list[tuple[str, list]]:
         """Loop count changed → recompute every loop, do not nudge any."""

--- a/scripts/sooperlooper/loop_mix.py
+++ b/scripts/sooperlooper/loop_mix.py
@@ -29,10 +29,10 @@ loop is re-emitted rather than nudged.
 **Physical position is not truth.** The faders have no motors, so they send
 nothing until moved and their positions at startup are unknown. Taking the
 first CC at face value means the first touch of a fader mid-jam jumps the level
-— loud, and exactly when you least want it. So gains are seeded from what the
-engine reports, and a fader is ignored until it *crosses* the value it is
-supposed to be at (pickup). Until then it is a lie about a number we already
-know.
+— loud, and exactly when you least want it. So the first CC *anchors* relative
+pickup (no level change); movement after that applies delta from the anchor
+against the stored column level. Output wet is smoothed toward the target so
+fast drags and misaligned surfaces do not step or jump.
 """
 
 from __future__ import annotations
@@ -60,6 +60,10 @@ PICKUP_TOLERANCE_CC = int(os.environ.get("MPE_APC_FADER_PICKUP_CC", "2"))
 # Engine `wet` echoes include master and auto-law — compare composed level,
 # not per-column fader CC, or master moves corrupt user_gain.
 WET_ECHO_TOLERANCE = float(os.environ.get("MPE_APC_FADER_WET_ECHO", "1e-4"))
+
+# Output smoothing — one-pole follow toward target wet (0 = off).
+FADER_SMOOTH_MS = float(os.environ.get("MPE_APC_FADER_SMOOTH_MS", "45"))
+FADER_SMOOTH_SNAP = float(os.environ.get("MPE_APC_FADER_SMOOTH_SNAP", "0.004"))
 
 # Off by default: the backstop law is planned, not yet agreed as always-on.
 # The seam exists from the first commit so that turning it on is a config
@@ -141,12 +145,9 @@ class LoopMix:
     master_gain: int = CC_MAX
     active_loops: int = 0
     _picked_up: set[FaderId] = field(default_factory=set)
-    # Where each fader must cross before it may write. Held per fader rather
-    # than read off one of the column's loops, because the two loops in a
-    # column can legitimately disagree — the engine seeds them independently,
-    # and a single fader has no way to express the difference. Picking one
-    # loop's value arbitrarily would mean a seed on the other loop silently
-    # failed to re-arm anything.
+    # Relative pickup: first CC anchors; later CCs apply delta from here.
+    _pickup_anchor: dict[int, int] = field(default_factory=dict)
+    # Stored column level the relative delta is applied against.
     _pickup_ref: dict[int, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -187,6 +188,7 @@ class LoopMix:
         for col in range(8):
             if loop in loops_for_column(col):
                 self._picked_up.discard(col)
+                self._pickup_anchor.pop(col, None)
                 self._pickup_ref[col] = cc
 
     def _user_cc_from_composed_wet(self, loop: int, wet: float) -> int:
@@ -239,22 +241,28 @@ class LoopMix:
         if not loops:
             return []
 
-        if not self._accept(fader, raw, loops):
+        if not self._accept(fader, raw):
             return []
 
+        effective = self._effective_cc(fader, raw)
         for loop in loops:
-            self.user_gain[loop] = raw
-        self._pickup_ref[fader] = raw
+            self.user_gain[loop] = effective
+        self._pickup_ref[fader] = effective
         return [self._message_for_loop(loop) for loop in loops]
 
-    def _accept(self, fader: int, raw: int, loops: list[int]) -> bool:
-        """Pickup: a fader may write once it has crossed where it should be."""
-        if fader in self._picked_up:
+    def _accept(self, fader: int, raw: int) -> bool:
+        """Relative pickup: anchor on first touch, no jump; then delta applies."""
+        if fader in self._pickup_anchor:
             return True
-        if abs(raw - self._pickup_ref.get(fader, CC_MAX)) <= PICKUP_TOLERANCE_CC:
-            self._picked_up.add(fader)
-            return True
+        self._pickup_anchor[fader] = raw
+        self._picked_up.add(fader)
         return False
+
+    def _effective_cc(self, fader: int, raw: int) -> int:
+        """Map physical travel to column level via anchor + stored ref."""
+        anchor = self._pickup_anchor[fader]
+        ref = self._pickup_ref.get(fader, CC_MAX)
+        return max(0, min(CC_MAX, ref + (raw - anchor)))
 
     def _message_for_loop(self, loop: int) -> tuple[str, list]:
         param = PARAMETERS[self.mode]
@@ -296,36 +304,81 @@ def _wet_to_cc(wet: float, param: Parameter) -> int:
 
 
 class CoalescingSender:
-    """Rate-limits a dragging fader without ever losing where it stopped.
+    """Rate-limits OSC sends; optional wet smoothing for fader drags.
 
-    A fast drag produces a CC every few milliseconds; forwarding all of them
-    floods the engine. Dropping the *last* one is far worse than the flood
-    it prevents: the fader ends up physically somewhere the engine never heard
-    about, so the surface is lying about the level until the fader is touched
-    again. So intermediate values are dropped freely and the endpoint is always
-    flushed.
+    Targets update immediately on submit; ``tick`` ramps current wet toward
+    target with a one-pole filter so fast moves and misaligned pickup do not
+    step or jump. ``flush`` snaps to target (end of drag / idle).
     """
 
-    def __init__(self, send, *, interval_s: float = 0.02) -> None:
+    def __init__(
+        self,
+        send,
+        *,
+        interval_s: float = 0.02,
+        smooth_tau_s: float | None = None,
+        smooth_snap: float | None = None,
+    ) -> None:
         self._send = send
         self._interval_s = interval_s
-        self._pending: dict[str, list] = {}
-        # -inf, not 0.0: the caller's clock is monotonic and starts near zero,
-        # so a zero here makes the very first movement of a fader wait out a
-        # full interval. The first touch is exactly the one that must not be
-        # swallowed.
+        tau_ms = FADER_SMOOTH_MS
+        self._smooth_tau_s = (
+            smooth_tau_s if smooth_tau_s is not None else (tau_ms / 1000.0 if tau_ms > 0 else 0.0)
+        )
+        self._smooth_snap = smooth_snap if smooth_snap is not None else FADER_SMOOTH_SNAP
+        self._target_wet: dict[str, float] = {}
+        self._current_wet: dict[str, float] = {}
+        self._pending_meta: dict[str, list] = {}
         self._last_sent = float("-inf")
+        self._last_tick = float("-inf")
 
     def submit(self, messages: list[tuple[str, list]], *, now: float) -> None:
         for path, args in messages:
-            self._pending[path] = args
-        if (now - self._last_sent) >= self._interval_s:
-            self.flush(now=now)
+            self._pending_meta[path] = args
+            if len(args) >= 2 and args[0] == "wet":
+                target = float(args[1])
+                self._target_wet[path] = target
+                if path not in self._current_wet:
+                    self._current_wet[path] = target
+        if self._smooth_tau_s <= 0:
+            if (now - self._last_sent) >= self._interval_s:
+                self.flush(now=now)
+        else:
+            self.tick(now=now)
+
+    def tick(self, *, now: float) -> None:
+        if not self._target_wet or self._smooth_tau_s <= 0:
+            return
+        dt = now - self._last_tick if self._last_tick > float("-inf") else 0.0
+        self._last_tick = now
+        if dt <= 0:
+            return
+        alpha = 1.0 - math.exp(-dt / self._smooth_tau_s)
+        moved = False
+        for path, target in self._target_wet.items():
+            cur = self._current_wet.get(path, target)
+            if abs(target - cur) <= self._smooth_snap:
+                nxt = target
+            else:
+                nxt = cur + alpha * (target - cur)
+            if abs(nxt - cur) > 1e-6:
+                self._current_wet[path] = nxt
+                moved = True
+        if moved and (now - self._last_sent) >= self._interval_s:
+            self._emit_current(now=now)
 
     def flush(self, *, now: float) -> None:
-        if not self._pending:
+        if not self._target_wet and not self._pending_meta:
             return
-        for path, args in self._pending.items():
-            self._send(path, args)
-        self._pending.clear()
+        for path, target in self._target_wet.items():
+            self._current_wet[path] = target
+        self._emit_current(now=now)
+
+    def _emit_current(self, *, now: float) -> None:
+        if not self._current_wet:
+            return
+        for path, wet in self._current_wet.items():
+            meta = self._pending_meta.get(path, ["wet"])
+            control = meta[0] if meta else "wet"
+            self._send(path, [control, wet])
         self._last_sent = now

--- a/scripts/sooperlooper/loop_mix.py
+++ b/scripts/sooperlooper/loop_mix.py
@@ -137,7 +137,6 @@ class LoopMix:
     num_loops: int = 16
     mode: FaderMode = FaderMode.LEVEL
     user_gain: dict[int, int] = field(default_factory=dict)
-    master_gain: int = CC_MAX
     active_loops: int = 0
     _picked_up: set[FaderId] = field(default_factory=set)
     # Where each fader must cross before it may write. Held per fader rather
@@ -159,13 +158,21 @@ class LoopMix:
     def seed_from_engine(self, loop: int, wet: float) -> None:
         """Adopt the engine's reported level as truth for this loop.
 
-        Called from the OSC state listener. Re-arms pickup: the stored value
-        moved, so whatever the physical fader is resting at no longer matches
-        it and must be crossed again before it may write.
+        Called from the OSC state listener, which streams `wet` continuously —
+        so the common case is the engine echoing back a value we just set. That
+        must be a no-op. Re-arming pickup on every echo would leave every fader
+        permanently inert, since a fader can never cross a target that moves to
+        meet it 10 times a second.
+
+        A value we did *not* ask for is different: something else changed the
+        level, our stored gain is stale, and the physical fader is now lying
+        about it. Adopt it and make the fader earn control back.
         """
         if loop not in self.user_gain:
             return
         cc = _wet_to_cc(wet, PARAMETERS[self.mode])
+        if abs(cc - self.user_gain[loop]) <= PICKUP_TOLERANCE_CC:
+            return
         self.user_gain[loop] = cc
         for col in range(8):
             if loop in loops_for_column(col):
@@ -185,7 +192,9 @@ class LoopMix:
         """(path, args) to send for this fader movement. [] if suppressed."""
         raw = max(0, min(CC_MAX, int(raw)))
         if fader == MASTER:
-            self.master_gain = raw
+            # Nothing is stored: the master is a bus control, so it cannot take
+            # part in wet_for() composition, and there is no per-loop truth to
+            # seed it from. It is a straight pass-through by design.
             param = PARAMETERS[FaderMode.LEVEL]
             value = fader_taper(raw, floor_db=param.floor_db, ceil_db=param.ceil_db)
             return [("/set", [SL_MASTER_CONTROL, value])]

--- a/scripts/sooperlooper/loop_mix.py
+++ b/scripts/sooperlooper/loop_mix.py
@@ -1,0 +1,280 @@
+"""Fader → loop parameter: the gain store, the taper, and the emission plan.
+
+Same contract as loop_model.py, and for the same reason: everything that
+decides *what to send* is a pure function over held state, and the caller does
+the I/O. No OSC, no MIDI, no clock in this module. Tests drive it with plain
+integers and assert on the returned messages.
+
+Three rules hold this together.
+
+**State lives per (loop, parameter), never on the fader.** A fader is a
+write-only *view* onto a set of loops. Fader 0 writes loops 0 and 8 because
+apc_grid.loops_for_column(0) says those share the column — not because the
+fader owns them. This is what keeps the future cheap: banking, per-loop
+deviation, a touch-screen mixer and "this fader means pan now" are all new
+views over the same store rather than a rewrite of it.
+
+**`wet` is derived, never modified.** SooperLooper's per-loop `wet` has two
+claimants: the user's fader, and the `loop_gain/N` backstop law planned in
+DECISIONS.md:468 ("arithmetic in the control layer, not DSP"). Two writers on
+one control drift, and the drift looks like a hardware fault rather than a
+design error. So there is exactly one composition point,
+
+    wet_for(loop) = taper(user_gain[loop]) * auto_law(active_loops)
+
+and it is always recomputed in full from state we own. We never read the
+engine's current `wet` and adjust it. When the active-loop count changes, every
+loop is re-emitted rather than nudged.
+
+**Physical position is not truth.** The faders have no motors, so they send
+nothing until moved and their positions at startup are unknown. Taking the
+first CC at face value means the first touch of a fader mid-jam jumps the level
+— loud, and exactly when you least want it. So gains are seeded from what the
+engine reports, and a fader is ignored until it *crosses* the value it is
+supposed to be at (pickup). Until then it is a lie about a number we already
+know.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+
+from apc_faders import CC_MAX, MASTER, FaderId
+from apc_grid import loops_for_column
+
+# The loop-bus master. UNVERIFIED against the engine — SooperLooper source is
+# not available off the Pi. Kept as one named constant so confirming it is a
+# one-line change. Check src/control_osc.cpp on the Pi before trusting it.
+SL_MASTER_CONTROL = os.environ.get("MPE_SL_MASTER_CONTROL", "wet")
+
+# Bottom of fader travel must mean silence. A log taper cannot reach zero, so
+# the bottom of the range is snapped to it explicitly. Without this the fader
+# bottoms out at a quiet-but-audible level, which reads as a bug.
+SILENCE_CC = int(os.environ.get("MPE_APC_FADER_SILENCE_CC", "1"))
+
+FADER_FLOOR_DB = float(os.environ.get("MPE_APC_FADER_FLOOR_DB", "-40.0"))
+FADER_CEIL_DB = float(os.environ.get("MPE_APC_FADER_CEIL_DB", "0.0"))
+
+# Pickup tolerance in CC steps. Faders are noisy near the detent; requiring an
+# exact crossing can leave a fader permanently inert.
+PICKUP_TOLERANCE_CC = int(os.environ.get("MPE_APC_FADER_PICKUP_CC", "2"))
+
+# Off by default: the backstop law is planned, not yet agreed as always-on.
+# The seam exists from the first commit so that turning it on is a config
+# change rather than a refactor of who writes `wet`.
+AUTO_LAW_ENABLED = os.environ.get("MPE_SL_LOOP_GAIN_LAW", "0").strip() not in (
+    "", "0", "off", "false",
+)
+LOOP_GAIN = float(os.environ.get("MPE_SL_LOOP_GAIN", "1.0"))
+
+
+class FaderMode(Enum):
+    """What the eight loop faders currently mean.
+
+    One member today. Pan and LFO filter are named in the roadmap and land as
+    new members plus new Parameter descriptors — not as new writers of `wet`.
+    """
+
+    LEVEL = "level"
+
+
+@dataclass(frozen=True)
+class Parameter:
+    """An SL control a fader can be bound to, and how travel maps onto it."""
+
+    control: str
+    floor_db: float = FADER_FLOOR_DB
+    ceil_db: float = FADER_CEIL_DB
+    default: float = 1.0
+
+
+PARAMETERS: dict[FaderMode, Parameter] = {
+    FaderMode.LEVEL: Parameter(control="wet"),
+}
+
+
+def fader_taper(raw: int, *, floor_db: float, ceil_db: float) -> float:
+    """CC 0–127 → linear 0.0–1.0, even dB per unit of travel.
+
+    Same shape as the touch browser's Vol fader
+    (patch_browser/patch_normalization.py::volume_fader_to_amp_linear) but not
+    the same function: that one is bound to Surge amp/volume, patch gain and a
+    normalisation cap. Only the law is shared, deliberately duplicated rather
+    than coupling the looper control path to the patch browser.
+    """
+    if raw <= SILENCE_CC:
+        return 0.0
+    t = max(0.0, min(1.0, raw / CC_MAX))
+    log_min = math.log(10.0 ** (floor_db / 20.0))
+    log_max = math.log(10.0 ** (ceil_db / 20.0))
+    return math.exp(log_min + t * (log_max - log_min))
+
+
+def auto_law(active_loops: int) -> float:
+    """The loop_gain/N backstop from DECISIONS.md:468.
+
+    Keeps stacked loops from summing into the limiter. Identity while
+    disabled — the point of it being here regardless is that there is only ever
+    one place where the automatic law and the user's fader are combined.
+    """
+    if not AUTO_LAW_ENABLED or active_loops <= 0:
+        return 1.0
+    return LOOP_GAIN / active_loops
+
+
+@dataclass
+class LoopMix:
+    """Held state: what the user has asked each loop to sit at.
+
+    Gains are stored as CC values (0–127), not as tapered floats, so pickup
+    comparisons happen in the same units the hardware speaks and the taper
+    stays a pure display of them.
+    """
+
+    num_loops: int = 16
+    mode: FaderMode = FaderMode.LEVEL
+    user_gain: dict[int, int] = field(default_factory=dict)
+    master_gain: int = CC_MAX
+    active_loops: int = 0
+    _picked_up: set[FaderId] = field(default_factory=set)
+    # Where each fader must cross before it may write. Held per fader rather
+    # than read off one of the column's loops, because the two loops in a
+    # column can legitimately disagree — the engine seeds them independently,
+    # and a single fader has no way to express the difference. Picking one
+    # loop's value arbitrarily would mean a seed on the other loop silently
+    # failed to re-arm anything.
+    _pickup_ref: dict[int, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for loop in range(self.num_loops):
+            self.user_gain.setdefault(loop, CC_MAX)
+        for col in range(8):
+            self._pickup_ref.setdefault(col, CC_MAX)
+
+    # -- state seeding ----------------------------------------------------
+
+    def seed_from_engine(self, loop: int, wet: float) -> None:
+        """Adopt the engine's reported level as truth for this loop.
+
+        Called from the OSC state listener. Re-arms pickup: the stored value
+        moved, so whatever the physical fader is resting at no longer matches
+        it and must be crossed again before it may write.
+        """
+        if loop not in self.user_gain:
+            return
+        cc = _wet_to_cc(wet, PARAMETERS[self.mode])
+        self.user_gain[loop] = cc
+        for col in range(8):
+            if loop in loops_for_column(col):
+                self._picked_up.discard(col)
+                self._pickup_ref[col] = cc
+
+    def note_active_loops(self, count: int) -> list[tuple[str, list]]:
+        """Loop count changed → recompute every loop, do not nudge any."""
+        if count == self.active_loops:
+            return []
+        self.active_loops = count
+        return self._all_loop_messages()
+
+    # -- emission ---------------------------------------------------------
+
+    def messages_for(self, fader: FaderId, raw: int) -> list[tuple[str, list]]:
+        """(path, args) to send for this fader movement. [] if suppressed."""
+        raw = max(0, min(CC_MAX, int(raw)))
+        if fader == MASTER:
+            self.master_gain = raw
+            param = PARAMETERS[FaderMode.LEVEL]
+            value = fader_taper(raw, floor_db=param.floor_db, ceil_db=param.ceil_db)
+            return [("/set", [SL_MASTER_CONTROL, value])]
+
+        if not isinstance(fader, int) or not 0 <= fader <= 7:
+            return []
+
+        loops = [n for n in loops_for_column(fader) if n < self.num_loops]
+        if not loops:
+            return []
+
+        if not self._accept(fader, raw, loops):
+            return []
+
+        for loop in loops:
+            self.user_gain[loop] = raw
+        self._pickup_ref[fader] = raw
+        return [self._message_for_loop(loop) for loop in loops]
+
+    def _accept(self, fader: int, raw: int, loops: list[int]) -> bool:
+        """Pickup: a fader may write once it has crossed where it should be."""
+        if fader in self._picked_up:
+            return True
+        if abs(raw - self._pickup_ref.get(fader, CC_MAX)) <= PICKUP_TOLERANCE_CC:
+            self._picked_up.add(fader)
+            return True
+        return False
+
+    def _message_for_loop(self, loop: int) -> tuple[str, list]:
+        param = PARAMETERS[self.mode]
+        return (f"/sl/{loop}/set", [param.control, self.wet_for(loop)])
+
+    def _all_loop_messages(self) -> list[tuple[str, list]]:
+        return [self._message_for_loop(loop) for loop in range(self.num_loops)]
+
+    # -- composition ------------------------------------------------------
+
+    def wet_for(self, loop: int) -> float:
+        """The single point where the user's gain and the automatic law meet."""
+        param = PARAMETERS[self.mode]
+        user = fader_taper(
+            self.user_gain.get(loop, CC_MAX),
+            floor_db=param.floor_db,
+            ceil_db=param.ceil_db,
+        )
+        return max(0.0, min(1.0, user * auto_law(self.active_loops)))
+
+
+def _wet_to_cc(wet: float, param: Parameter) -> int:
+    """Inverse of fader_taper, for adopting an engine-reported level."""
+    if wet <= 0.0:
+        return 0
+    log_min = math.log(10.0 ** (param.floor_db / 20.0))
+    log_max = math.log(10.0 ** (param.ceil_db / 20.0))
+    t = (math.log(max(wet, 1e-9)) - log_min) / (log_max - log_min)
+    return max(0, min(CC_MAX, round(t * CC_MAX)))
+
+
+class CoalescingSender:
+    """Rate-limits a dragging fader without ever losing where it stopped.
+
+    A fast drag produces a CC every few milliseconds; forwarding all of them
+    floods the engine. Dropping the *last* one is far worse than the flood
+    it prevents: the fader ends up physically somewhere the engine never heard
+    about, so the surface is lying about the level until the fader is touched
+    again. So intermediate values are dropped freely and the endpoint is always
+    flushed.
+    """
+
+    def __init__(self, send, *, interval_s: float = 0.02) -> None:
+        self._send = send
+        self._interval_s = interval_s
+        self._pending: dict[str, list] = {}
+        # -inf, not 0.0: the caller's clock is monotonic and starts near zero,
+        # so a zero here makes the very first movement of a fader wait out a
+        # full interval. The first touch is exactly the one that must not be
+        # swallowed.
+        self._last_sent = float("-inf")
+
+    def submit(self, messages: list[tuple[str, list]], *, now: float) -> None:
+        for path, args in messages:
+            self._pending[path] = args
+        if (now - self._last_sent) >= self._interval_s:
+            self.flush(now=now)
+
+    def flush(self, *, now: float) -> None:
+        if not self._pending:
+            return
+        for path, args in self._pending.items():
+            self._send(path, args)
+        self._pending.clear()
+        self._last_sent = now

--- a/scripts/sooperlooper/loop_mix.py
+++ b/scripts/sooperlooper/loop_mix.py
@@ -181,12 +181,6 @@ class LoopMix:
             return
         if abs(wet - self.wet_for(loop)) <= WET_ECHO_TOLERANCE:
             return
-        # While a column fader is in hand, engine wet often lags our composed
-        # target — we update user_gain before OSC lands. Treat that as in-flight,
-        # not an external change, or pickup re-arms and the fader goes dead.
-        for col in range(8):
-            if loop in loops_for_column(col) and col in self._pickup_anchor:
-                return
         cc = self._user_cc_from_composed_wet(loop, wet)
         if abs(cc - self.user_gain[loop]) <= PICKUP_TOLERANCE_CC:
             return
@@ -339,7 +333,7 @@ class CoalescingSender:
         self._last_tick = float("-inf")
 
     def seed_current(self, path: str, wet: float) -> None:
-        """Set ramp start to engine truth before the first send on ``path``."""
+        """Start the ramp from engine truth — avoids a first-send crackle."""
         if path not in self._current_wet:
             self._current_wet[path] = max(0.0, min(1.0, float(wet)))
 
@@ -350,27 +344,12 @@ class CoalescingSender:
                 target = float(args[1])
                 self._target_wet[path] = target
                 if path not in self._current_wet:
-                    # Unseeded: assume engine already at target (tests / master).
                     self._current_wet[path] = target
         if self._smooth_tau_s <= 0:
             if (now - self._last_sent) >= self._interval_s:
                 self.flush(now=now)
         else:
-            if self._has_pending_motion():
-                self._prime_tick(now)
             self.tick(now=now)
-
-    def _has_pending_motion(self) -> bool:
-        for path, target in self._target_wet.items():
-            cur = self._current_wet.get(path, target)
-            if abs(target - cur) > self._smooth_snap:
-                return True
-        return False
-
-    def _prime_tick(self, now: float) -> None:
-        """Ensure the next tick has elapsed time so the first step emits."""
-        if self._last_tick == float("-inf") or (now - self._last_tick) <= 0:
-            self._last_tick = now - max(self._interval_s, 0.001)
 
     def tick(self, *, now: float) -> None:
         if not self._target_wet or self._smooth_tau_s <= 0:
@@ -391,9 +370,6 @@ class CoalescingSender:
                 self._current_wet[path] = nxt
                 moved = True
         if moved and (now - self._last_sent) >= self._interval_s:
-            self._emit_current(now=now)
-        elif self._has_pending_motion() and (now - self._last_sent) >= self._interval_s:
-            # Snap threshold can leave moved=False while target != current.
             self._emit_current(now=now)
 
     def flush(self, *, now: float) -> None:

--- a/scripts/sooperlooper/sl_bench_listener.py
+++ b/scripts/sooperlooper/sl_bench_listener.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 LISTEN_HOST = os.environ.get("MPE_SL_BENCH_LISTEN_HOST", "127.0.0.1")
 LISTEN_PORT = int(os.environ.get("MPE_SL_BENCH_LISTEN_PORT", "9953"))
 UPDATE_MS = int(os.environ.get("MPE_SL_BENCH_STATE_MS", "100"))
+WET_UPDATE_MS = int(os.environ.get("MPE_SL_BENCH_WET_MS", "500"))
 REREGISTER_S = float(os.environ.get("MPE_SL_BENCH_REREGISTER_S", "15"))
 
 # The engine-wide control the bench watches to notice a restart. Slow on
@@ -23,9 +24,13 @@ GLOBAL_UPDATE_MS = int(os.environ.get("MPE_SL_BENCH_SENTINEL_MS", "1000"))
 
 class SlBenchStateListener:
     def __init__(self, by_loop: dict[int, LoopFootswitch],
-                 on_global=None) -> None:
+                 on_global=None, on_wet=None) -> None:
         self._by_loop = by_loop
         self._on_global = on_global
+        # Seeds the fader layer from engine truth. Without it the faders have
+        # no idea where the levels actually are, and their first movement is a
+        # jump rather than a pickup.
+        self._on_wet = on_wet
         self._server: object | None = None
         self._thread: threading.Thread | None = None
         self._last_register = 0.0
@@ -33,6 +38,12 @@ class SlBenchStateListener:
         self._num_loops = 16
 
     def on_update(self, _addr: str, loop_index: int, control: str, value: float) -> None:
+        if control == "wet":
+            # Handled before the footswitch lookup: the fader layer wants this
+            # even for loops with no pad bound to them.
+            if self._on_wet is not None:
+                self._on_wet(int(loop_index), float(value))
+            return
         fs = self._by_loop.get(loop_index)
         if fs is None:
             return
@@ -60,6 +71,13 @@ class SlBenchStateListener:
                     f"/sl/{loop}/register_auto_update",
                     [ctrl, UPDATE_MS, returl, retpath],
                 )
+            # Slower than state on purpose. This only has to notice a level
+            # changed by something other than us; polling it at pad-blink rate
+            # would cost a datagram per loop per 100 ms for no benefit.
+            client.send_message(
+                f"/sl/{loop}/register_auto_update",
+                ["wet", WET_UPDATE_MS, returl, retpath],
+            )
         # Global (no /sl/N prefix) — verified against control_osc.cpp:178 and
         # live on the engine: replies carry loop index -2. This is how the bench
         # notices the engine restarted underneath it, which otherwise leaves the

--- a/tests/test_apc_bench.py
+++ b/tests/test_apc_bench.py
@@ -101,9 +101,9 @@ class FaderDispatchTests(unittest.TestCase):
         self.feed(self.ccs[2], 64)
         self.assertEqual([p for p, _ in self.sent], ["/sl/2/set", "/sl/10/set"])
 
-    def test_master_drives_the_loop_bus(self) -> None:
+    def test_master_drives_every_loop(self) -> None:
         self.feed(self.master, 64)
-        self.assertEqual([p for p, _ in self.sent], ["/set"])
+        self.assertEqual([p for p, _ in self.sent], [f"/sl/{n}/set" for n in range(16)])
 
     def test_non_fader_cc_is_ignored(self) -> None:
         self.feed(7, 100)

--- a/tests/test_apc_bench.py
+++ b/tests/test_apc_bench.py
@@ -43,5 +43,78 @@ class ApcBenchFootswitchTests(unittest.TestCase):
             self.assertIn(pad_note(3, col), by_note)
 
 
+def _bench_module():
+    """Load the bench script — its filename has a hyphen, so no plain import."""
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parent.parent / "scripts" / "sooperlooper-apc-bench.py"
+    spec = importlib.util.spec_from_file_location("sooperlooper_apc_bench", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DumpMidiTests(unittest.TestCase):
+    def test_decodes_control_change(self) -> None:
+        # --dump-midi is the tool used to confirm which CC each fader sends on
+        # an unfamiliar APC. Rendering faders as raw hex defeats the purpose.
+        bench = _bench_module()
+        self.assertEqual(bench._format_midi([0xB0, 48, 100]), "ch=0 cc=48 value=100")
+
+    def test_still_decodes_notes(self) -> None:
+        bench = _bench_module()
+        self.assertIn("note_on", bench._format_midi([0x90, 0, 127]))
+
+    def test_control_change_is_not_treated_as_a_note(self) -> None:
+        bench = _bench_module()
+        self.assertIsNone(bench.midi_note_down(0xB0, 100))
+
+
+class FaderDispatchTests(unittest.TestCase):
+    """Fake CC in → assert the OSC calls, the way the footswitch tests do."""
+
+    def setUp(self) -> None:
+        from scripts.sooperlooper.apc_faders import fader_for_cc, resolve_fader_ccs
+        from scripts.sooperlooper.loop_mix import CoalescingSender, LoopMix
+
+        self.ccs, self.master, _ = resolve_fader_ccs("APC mini mk2")
+        self.mix = LoopMix(num_loops=16)
+        self.sent: list = []
+        self.faders = CoalescingSender(
+            lambda path, args: self.sent.append((path, args)), interval_s=0.0
+        )
+        self._fader_for_cc = fader_for_cc
+
+    def feed(self, cc: int, value: int, *, now: float = 0.0) -> None:
+        fader = self._fader_for_cc(
+            cc, loop_fader_ccs=self.ccs, master_cc=self.master
+        )
+        if fader is None:
+            return
+        self.faders.submit(self.mix.messages_for(fader, value), now=now)
+        self.faders.flush(now=now)
+
+    def test_a_fader_drives_both_loops_of_its_column(self) -> None:
+        self.feed(self.ccs[2], 127)  # cross pickup
+        self.sent.clear()
+        self.feed(self.ccs[2], 64)
+        self.assertEqual([p for p, _ in self.sent], ["/sl/2/set", "/sl/10/set"])
+
+    def test_master_drives_the_loop_bus(self) -> None:
+        self.feed(self.master, 64)
+        self.assertEqual([p for p, _ in self.sent], ["/set"])
+
+    def test_non_fader_cc_is_ignored(self) -> None:
+        self.feed(7, 100)
+        self.assertEqual(self.sent, [])
+
+    def test_first_touch_does_not_jump_the_level(self) -> None:
+        # Faders have no motors: at startup their position is unknown, so an
+        # uncrossed fader must not write.
+        self.feed(self.ccs[0], 0)
+        self.assertEqual(self.sent, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_apc_bench.py
+++ b/tests/test_apc_bench.py
@@ -82,7 +82,9 @@ class FaderDispatchTests(unittest.TestCase):
         self.mix = LoopMix(num_loops=16)
         self.sent: list = []
         self.faders = CoalescingSender(
-            lambda path, args: self.sent.append((path, args)), interval_s=0.0
+            lambda path, args: self.sent.append((path, args)),
+            interval_s=0.0,
+            smooth_tau_s=0.0,
         )
         self._fader_for_cc = fader_for_cc
 
@@ -93,12 +95,12 @@ class FaderDispatchTests(unittest.TestCase):
         if fader is None:
             return
         self.faders.submit(self.mix.messages_for(fader, value), now=now)
-        self.faders.flush(now=now)
+        self.faders.tick(now=now)
 
     def test_a_fader_drives_both_loops_of_its_column(self) -> None:
-        self.feed(self.ccs[2], 127)  # cross pickup
+        self.feed(self.ccs[2], 64)  # anchor
         self.sent.clear()
-        self.feed(self.ccs[2], 64)
+        self.feed(self.ccs[2], 50)
         self.assertEqual([p for p, _ in self.sent], ["/sl/2/set", "/sl/10/set"])
 
     def test_master_drives_every_loop(self) -> None:
@@ -110,10 +112,10 @@ class FaderDispatchTests(unittest.TestCase):
         self.assertEqual(self.sent, [])
 
     def test_first_touch_does_not_jump_the_level(self) -> None:
-        # Faders have no motors: at startup their position is unknown, so an
-        # uncrossed fader must not write.
-        self.feed(self.ccs[0], 0)
+        self.feed(self.ccs[0], 40)
         self.assertEqual(self.sent, [])
+        self.feed(self.ccs[0], 30)
+        self.assertTrue(self.sent)
 
 
 if __name__ == "__main__":

--- a/tests/test_apc_faders.py
+++ b/tests/test_apc_faders.py
@@ -1,0 +1,64 @@
+import unittest
+
+from apc_faders import (
+    MASTER,
+    NUM_LOOP_FADERS,
+    fader_for_cc,
+    is_control_change,
+    resolve_fader_ccs,
+)
+
+
+class ResolveFaderCcs(unittest.TestCase):
+    def test_explicit_variant_wins_over_port_name(self):
+        _ccs, _master, label = resolve_fader_ccs("APC MINI mk2", variant="mk1")
+        self.assertEqual(label, "mk1")
+
+    def test_port_name_detects_mk2(self):
+        _ccs, _master, label = resolve_fader_ccs("APC mini mk2 MIDI 1")
+        self.assertEqual(label, "mk2")
+
+    def test_unknown_port_falls_back_to_mk1(self):
+        _ccs, _master, label = resolve_fader_ccs("some other surface")
+        self.assertEqual(label, "mk1")
+
+    def test_eight_contiguous_loop_faders_plus_a_distinct_master(self):
+        for variant in ("mk1", "mk2"):
+            ccs, master, _ = resolve_fader_ccs("", variant=variant)
+            self.assertEqual(len(ccs), NUM_LOOP_FADERS, variant)
+            self.assertEqual(len(set(ccs)), NUM_LOOP_FADERS, variant)
+            self.assertNotIn(master, ccs, variant)
+            self.assertEqual(list(ccs), sorted(ccs), variant)
+
+
+class FaderForCc(unittest.TestCase):
+    def setUp(self):
+        self.ccs, self.master, _ = resolve_fader_ccs("", variant="mk2")
+
+    def _lookup(self, cc):
+        return fader_for_cc(cc, loop_fader_ccs=self.ccs, master_cc=self.master)
+
+    def test_each_loop_cc_maps_to_its_index(self):
+        for index, cc in enumerate(self.ccs):
+            self.assertEqual(self._lookup(cc), index)
+
+    def test_master_cc_maps_to_master_not_to_index_eight(self):
+        self.assertEqual(self._lookup(self.master), MASTER)
+
+    def test_unrelated_cc_is_not_a_fader(self):
+        self.assertIsNone(self._lookup(7))
+        self.assertIsNone(self._lookup(self.master + 1))
+
+
+class IsControlChange(unittest.TestCase):
+    def test_recognises_cc_on_every_channel(self):
+        for channel in range(16):
+            self.assertTrue(is_control_change(0xB0 | channel))
+
+    def test_rejects_note_messages(self):
+        self.assertFalse(is_control_change(0x90))
+        self.assertFalse(is_control_change(0x80))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_apc_grid.py
+++ b/tests/test_apc_grid.py
@@ -6,6 +6,7 @@ from scripts.sooperlooper.apc_grid import (
     all_loop_pads,
     loop_index_for_note,
     loop_index_for_pad,
+    loops_for_column,
     pad_note,
 )
 
@@ -32,6 +33,28 @@ class ApcGridTests(unittest.TestCase):
 
     def test_sixteen_clip_pads(self) -> None:
         self.assertEqual(len(all_loop_pads()), 16)
+
+    def test_column_pairs_the_two_clip_rows(self) -> None:
+        for col in range(8):
+            self.assertEqual(loops_for_column(col), (col, 8 + col))
+
+    def test_columns_partition_every_loop_exactly_once(self) -> None:
+        seen = [loop for col in range(8) for loop in loops_for_column(col)]
+        self.assertEqual(sorted(seen), list(range(16)))
+
+    def test_column_agrees_with_the_pad_layout(self) -> None:
+        # The point of deriving from all_loop_pads(): faders cannot drift away
+        # from the pads by keeping their own copy of the layout.
+        for col in range(8):
+            from_pads = tuple(
+                loop for _row, c, loop in all_loop_pads() if c == col
+            )
+            self.assertEqual(loops_for_column(col), from_pads)
+
+    def test_column_out_of_range_raises(self) -> None:
+        for col in (-1, 8):
+            with self.assertRaises(ValueError):
+                loops_for_column(col)
 
 
 if __name__ == "__main__":

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -2,7 +2,7 @@ import unittest
 
 import loop_mix
 from apc_faders import CC_MAX, MASTER
-from loop_mix import CoalescingSender, LoopMix, fader_taper
+from loop_mix import PICKUP_TOLERANCE_CC, CoalescingSender, LoopMix, fader_taper
 
 
 def _picked_up(mix, fader):
@@ -81,6 +81,17 @@ class Pickup(unittest.TestCase):
         self.assertEqual(mix.messages_for(0, 10), [])
         self.assertTrue(mix.messages_for(0, CC_MAX))
         self.assertTrue(mix.messages_for(0, 10))  # now live
+
+    def test_a_fader_resting_at_the_bottom_escapes_by_sweeping_to_the_top(self):
+        # The actual state after every bench restart: gains seeded at CC_MAX
+        # while the physical fader is wherever it was left. With a tolerance of
+        # a couple of CC steps that fader is inert across nearly all of its
+        # travel, and only full travel frees it. Defensible, but it is the
+        # behaviour the README has to describe, so pin it.
+        mix = LoopMix()
+        for raw in range(0, CC_MAX - PICKUP_TOLERANCE_CC):
+            self.assertEqual(mix.messages_for(0, raw), [], f"wrote early at {raw}")
+        self.assertTrue(mix.messages_for(0, CC_MAX))
 
     def test_suppressed_movement_does_not_change_stored_gain(self):
         mix = LoopMix()

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -2,19 +2,17 @@ import unittest
 
 import loop_mix
 from apc_faders import CC_MAX, MASTER
-from loop_mix import PICKUP_TOLERANCE_CC, CoalescingSender, LoopMix, fader_taper
+from loop_mix import CoalescingSender, LoopMix, fader_taper
 
 
 def _picked_up(mix, fader):
-    """Move a fader onto its stored value so pickup stops suppressing it."""
-    mix.messages_for(fader, mix.user_gain[fader])
+    """Anchor relative pickup so subsequent moves apply delta."""
+    mix.messages_for(fader, mix._pickup_ref.get(fader, CC_MAX))
     return mix
 
 
 class Taper(unittest.TestCase):
     def test_bottom_of_travel_is_actual_silence(self):
-        # A log law cannot reach zero; without the snap the fader bottoms out
-        # audible, which reads as a bug rather than as a taper.
         self.assertEqual(fader_taper(0, floor_db=-40.0, ceil_db=0.0), 0.0)
 
     def test_top_of_travel_is_unity(self):
@@ -57,14 +55,10 @@ class ColumnMapping(unittest.TestCase):
 
 class Master(unittest.TestCase):
     def test_master_scales_every_loop_over_per_loop_wet(self):
-        # Not an engine-global /set: nothing in this system has ever written a
-        # level at engine scope, and an OSC message to a control the engine
-        # does not have vanishes silently. Per-loop wet is proven.
         msgs = LoopMix(num_loops=16).messages_for(MASTER, 100)
         self.assertEqual([p for p, _ in msgs], [f"/sl/{n}/set" for n in range(16)])
 
     def test_master_at_full_is_identity(self):
-        # Guards the new factor silently attenuating everything at rest.
         mix = LoopMix()
         mix.messages_for(MASTER, CC_MAX)
         self.assertAlmostEqual(mix.wet_for(0), 1.0)
@@ -78,53 +72,44 @@ class Master(unittest.TestCase):
         self.assertAlmostEqual(mix.wet_for(0), expected)
 
     def test_master_is_not_gated_by_column_pickup(self):
-        # No column owns it, and a fresh mix has picked up nothing.
         self.assertTrue(LoopMix().messages_for(MASTER, 40))
 
     def test_master_is_exempt_from_pickup(self):
-        # There is no per-loop truth to seed it from, so suppressing it would
-        # leave the master permanently inert.
         self.assertTrue(LoopMix().messages_for(MASTER, 5))
 
 
 class Pickup(unittest.TestCase):
-    def test_fader_is_ignored_until_it_crosses_the_stored_value(self):
-        mix = LoopMix()  # every loop seeded at CC_MAX
-        self.assertEqual(mix.messages_for(0, 10), [])
-        self.assertEqual(mix.messages_for(0, 60), [])
-
-    def test_fader_writes_once_it_has_crossed(self):
+    def test_first_touch_anchors_without_changing_level(self):
         mix = LoopMix()
-        self.assertEqual(mix.messages_for(0, 10), [])
-        self.assertTrue(mix.messages_for(0, CC_MAX))
-        self.assertTrue(mix.messages_for(0, 10))  # now live
+        self.assertEqual(mix.messages_for(0, 40), [])
+        self.assertEqual(mix.user_gain[0], CC_MAX)
 
-    def test_a_fader_resting_at_the_bottom_escapes_by_sweeping_to_the_top(self):
-        # The actual state after every bench restart: gains seeded at CC_MAX
-        # while the physical fader is wherever it was left. With a tolerance of
-        # a couple of CC steps that fader is inert across nearly all of its
-        # travel, and only full travel frees it. Defensible, but it is the
-        # behaviour the README has to describe, so pin it.
+    def test_relative_movement_after_anchor_applies_delta(self):
         mix = LoopMix()
-        for raw in range(0, CC_MAX - PICKUP_TOLERANCE_CC):
-            self.assertEqual(mix.messages_for(0, raw), [], f"wrote early at {raw}")
-        self.assertTrue(mix.messages_for(0, CC_MAX))
+        mix.messages_for(0, 40)  # anchor at 40, ref 127
+        msgs = mix.messages_for(0, 30)  # delta -10 → effective 117
+        self.assertTrue(msgs)
+        self.assertEqual(mix.user_gain[0], 117)
 
-    def test_suppressed_movement_does_not_change_stored_gain(self):
+    def test_misaligned_fader_does_not_jump_on_grab(self):
+        mix = LoopMix()
+        mix.messages_for(0, 10)
+        self.assertEqual(mix.user_gain[0], CC_MAX)
+        mix.messages_for(0, 5)
+        self.assertEqual(mix.user_gain[0], 122)
+
+    def test_suppressed_anchor_does_not_change_stored_gain(self):
         mix = LoopMix()
         mix.messages_for(0, 10)
         self.assertEqual(mix.user_gain[0], CC_MAX)
 
     def test_engine_seed_rearms_pickup_for_that_column(self):
         mix = _picked_up(LoopMix(), 0)
-        self.assertTrue(mix.messages_for(0, 100))
-        mix.seed_from_engine(8, 0.25)  # loop 8 is column 0
+        mix.messages_for(0, 100)
+        mix.seed_from_engine(8, 0.25)
         self.assertEqual(mix.messages_for(0, 100), [])
 
     def test_engine_echoing_our_own_value_does_not_rearm_pickup(self):
-        # `wet` streams continuously, so most updates are the engine repeating
-        # what we just set. Re-arming on those would leave every fader inert
-        # forever: it can never cross a target that keeps moving to meet it.
         mix = _picked_up(LoopMix(), 0)
         mix.messages_for(0, 100)
         for _ in range(20):
@@ -133,8 +118,6 @@ class Pickup(unittest.TestCase):
         self.assertTrue(mix.messages_for(0, 90))
 
     def test_master_echo_does_not_corrupt_column_fader_gain(self):
-        # Composed wet echoes must not be inverted into user_gain — that would
-        # treat the master factor as if it were the column fader position.
         mix = _picked_up(LoopMix(), 0)
         mix.messages_for(0, 100)
         before = mix.user_gain[0]
@@ -161,7 +144,6 @@ class Composition(unittest.TestCase):
         mix.active_loops = 4
         with _law_enabled():
             self.assertAlmostEqual(mix.wet_for(0), 0.25)
-            # Recomputed from user_gain each time, so it does not compound.
             self.assertAlmostEqual(mix.wet_for(0), 0.25)
 
     def test_loop_count_change_reemits_every_loop(self):
@@ -196,25 +178,25 @@ class Coalescing(unittest.TestCase):
     def setUp(self):
         self.sent = []
         self.sender = CoalescingSender(
-            lambda path, args: self.sent.append((path, args)), interval_s=1.0
+            lambda path, args: self.sent.append((path, args)),
+            interval_s=1.0,
+            smooth_tau_s=0.0,
         )
 
     def test_bursts_are_collapsed_to_one_send_per_path(self):
-        for i, value in enumerate([10, 20, 30, 40]):
+        for i, value in enumerate([0.1, 0.2, 0.3, 0.4]):
             self.sender.submit([("/sl/0/set", ["wet", value])], now=i * 0.01)
         self.assertEqual(len(self.sent), 1)
 
     def test_the_endpoint_value_always_survives(self):
-        # Dropping the last value leaves the fader physically lying about the
-        # level, which is worse than the flood the throttle prevents.
-        for i, value in enumerate([10, 20, 30, 99]):
+        for i, value in enumerate([0.1, 0.2, 0.3, 0.99]):
             self.sender.submit([("/sl/0/set", ["wet", value])], now=i * 0.01)
         self.sender.flush(now=99.0)
-        self.assertEqual(self.sent[-1], ("/sl/0/set", ["wet", 99]))
+        self.assertEqual(self.sent[-1], ("/sl/0/set", ["wet", 0.99]))
 
     def test_distinct_paths_are_not_collapsed_into_each_other(self):
         self.sender.submit(
-            [("/sl/0/set", ["wet", 1]), ("/sl/8/set", ["wet", 1])], now=0.0
+            [("/sl/0/set", ["wet", 1.0]), ("/sl/8/set", ["wet", 1.0])], now=0.0
         )
         self.sender.flush(now=5.0)
         self.assertEqual({p for p, _ in self.sent}, {"/sl/0/set", "/sl/8/set"})
@@ -222,6 +204,36 @@ class Coalescing(unittest.TestCase):
     def test_flush_with_nothing_pending_is_silent(self):
         self.sender.flush(now=1.0)
         self.assertEqual(self.sent, [])
+
+
+class Smoothing(unittest.TestCase):
+    def test_ramps_toward_target_over_ticks(self):
+        sent = []
+        sender = CoalescingSender(
+            lambda path, args: sent.append(args[1]),
+            interval_s=0.0,
+            smooth_tau_s=0.05,
+            smooth_snap=0.001,
+        )
+        sender.submit([("/sl/0/set", ["wet", 0.0])], now=0.0)
+        sent.clear()
+        sender.submit([("/sl/0/set", ["wet", 1.0])], now=0.0)
+        sender.tick(now=0.01)
+        sender.tick(now=0.02)
+        self.assertTrue(sent)
+        self.assertLess(sent[-1], 1.0)
+        sender.flush(now=0.2)
+        self.assertAlmostEqual(sent[-1], 1.0)
+
+    def test_snap_when_disabled(self):
+        sent = []
+        sender = CoalescingSender(
+            lambda path, args: sent.append(args[1]),
+            interval_s=0.0,
+            smooth_tau_s=0.0,
+        )
+        sender.submit([("/sl/0/set", ["wet", 0.75])], now=0.0)
+        self.assertEqual(sent[-1], 0.75)
 
 
 if __name__ == "__main__":

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -93,6 +93,17 @@ class Pickup(unittest.TestCase):
         mix.seed_from_engine(8, 0.25)  # loop 8 is column 0
         self.assertEqual(mix.messages_for(0, 100), [])
 
+    def test_engine_echoing_our_own_value_does_not_rearm_pickup(self):
+        # `wet` streams continuously, so most updates are the engine repeating
+        # what we just set. Re-arming on those would leave every fader inert
+        # forever: it can never cross a target that keeps moving to meet it.
+        mix = _picked_up(LoopMix(), 0)
+        mix.messages_for(0, 100)
+        for _ in range(20):
+            mix.seed_from_engine(0, mix.wet_for(0))
+            mix.seed_from_engine(8, mix.wet_for(8))
+        self.assertTrue(mix.messages_for(0, 90))
+
     def test_engine_seed_round_trips_through_the_taper(self):
         mix = LoopMix()
         mix.seed_from_engine(0, 0.5)

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -106,17 +106,8 @@ class Pickup(unittest.TestCase):
     def test_engine_seed_rearms_pickup_for_that_column(self):
         mix = _picked_up(LoopMix(), 0)
         mix.messages_for(0, 100)
-        mix._pickup_anchor.pop(0, None)  # idle — no hand on fader
         mix.seed_from_engine(8, 0.25)
         self.assertEqual(mix.messages_for(0, 100), [])
-
-    def test_engine_seed_ignored_while_column_fader_is_in_hand(self):
-        mix = _picked_up(LoopMix(), 0)
-        mix.messages_for(0, 100)
-        before = mix.user_gain[0]
-        mix.seed_from_engine(8, 0.25)  # lagging echo must not re-arm pickup
-        self.assertEqual(mix.user_gain[0], before)
-        self.assertTrue(mix.messages_for(0, 90))
 
     def test_engine_echoing_our_own_value_does_not_rearm_pickup(self):
         mix = _picked_up(LoopMix(), 0)
@@ -244,7 +235,7 @@ class Smoothing(unittest.TestCase):
         sender.submit([("/sl/0/set", ["wet", 0.75])], now=0.0)
         self.assertEqual(sent[-1], 0.75)
 
-    def test_first_send_ramps_from_seeded_engine_level(self):
+    def test_seed_current_avoids_assuming_target_on_first_send(self):
         sent = []
         sender = CoalescingSender(
             lambda path, args: sent.append(args[1]),
@@ -256,8 +247,7 @@ class Smoothing(unittest.TestCase):
         sender.submit([("/sl/0/set", ["wet", 0.5])], now=0.0)
         sender.tick(now=0.01)
         self.assertTrue(sent)
-        self.assertGreater(sent[-1], 0.5)
-        self.assertLess(sent[-1], 1.0)
+        self.assertGreater(sent[0], 0.5)
 
 
 if __name__ == "__main__":

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -56,13 +56,30 @@ class ColumnMapping(unittest.TestCase):
 
 
 class Master(unittest.TestCase):
-    def test_master_writes_the_engine_global_not_a_loop(self):
-        msgs = LoopMix().messages_for(MASTER, CC_MAX)
-        self.assertEqual(len(msgs), 1)
-        path, args = msgs[0]
-        self.assertEqual(path, "/set")
-        self.assertEqual(args[0], loop_mix.SL_MASTER_CONTROL)
-        self.assertAlmostEqual(args[1], 1.0)
+    def test_master_scales_every_loop_over_per_loop_wet(self):
+        # Not an engine-global /set: nothing in this system has ever written a
+        # level at engine scope, and an OSC message to a control the engine
+        # does not have vanishes silently. Per-loop wet is proven.
+        msgs = LoopMix(num_loops=16).messages_for(MASTER, 100)
+        self.assertEqual([p for p, _ in msgs], [f"/sl/{n}/set" for n in range(16)])
+
+    def test_master_at_full_is_identity(self):
+        # Guards the new factor silently attenuating everything at rest.
+        mix = LoopMix()
+        mix.messages_for(MASTER, CC_MAX)
+        self.assertAlmostEqual(mix.wet_for(0), 1.0)
+
+    def test_master_composes_multiplicatively_with_user_gain(self):
+        mix = _picked_up(LoopMix(), 0)
+        mix.messages_for(0, 100)
+        alone = mix.wet_for(0)
+        mix.messages_for(MASTER, 100)
+        expected = alone * fader_taper(100, floor_db=-40.0, ceil_db=0.0)
+        self.assertAlmostEqual(mix.wet_for(0), expected)
+
+    def test_master_is_not_gated_by_column_pickup(self):
+        # No column owns it, and a fresh mix has picked up nothing.
+        self.assertTrue(LoopMix().messages_for(MASTER, 40))
 
     def test_master_is_exempt_from_pickup(self):
         # There is no per-loop truth to seed it from, so suppressing it would

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -1,0 +1,177 @@
+import unittest
+
+import loop_mix
+from apc_faders import CC_MAX, MASTER
+from loop_mix import CoalescingSender, LoopMix, fader_taper
+
+
+def _picked_up(mix, fader):
+    """Move a fader onto its stored value so pickup stops suppressing it."""
+    mix.messages_for(fader, mix.user_gain[fader])
+    return mix
+
+
+class Taper(unittest.TestCase):
+    def test_bottom_of_travel_is_actual_silence(self):
+        # A log law cannot reach zero; without the snap the fader bottoms out
+        # audible, which reads as a bug rather than as a taper.
+        self.assertEqual(fader_taper(0, floor_db=-40.0, ceil_db=0.0), 0.0)
+
+    def test_top_of_travel_is_unity(self):
+        self.assertAlmostEqual(fader_taper(CC_MAX, floor_db=-40.0, ceil_db=0.0), 1.0)
+
+    def test_monotonic_across_travel(self):
+        values = [fader_taper(r, floor_db=-40.0, ceil_db=0.0) for r in range(128)]
+        self.assertEqual(values, sorted(values))
+
+    def test_even_db_per_step_in_the_middle(self):
+        def db(raw):
+            import math
+
+            return 20.0 * math.log10(fader_taper(raw, floor_db=-40.0, ceil_db=0.0))
+
+        first = db(64) - db(32)
+        second = db(96) - db(64)
+        self.assertAlmostEqual(first, second, places=6)
+
+
+class ColumnMapping(unittest.TestCase):
+    def test_fader_writes_both_loops_in_its_column(self):
+        mix = _picked_up(LoopMix(), 3)
+        paths = [p for p, _ in mix.messages_for(3, 100)]
+        self.assertEqual(paths, ["/sl/3/set", "/sl/11/set"])
+
+    def test_fader_zero_writes_loops_zero_and_eight(self):
+        mix = _picked_up(LoopMix(), 0)
+        paths = [p for p, _ in mix.messages_for(0, 100)]
+        self.assertEqual(paths, ["/sl/0/set", "/sl/8/set"])
+
+    def test_loops_beyond_num_loops_are_not_addressed(self):
+        mix = _picked_up(LoopMix(num_loops=8), 2)
+        paths = [p for p, _ in mix.messages_for(2, 100)]
+        self.assertEqual(paths, ["/sl/2/set"])
+
+    def test_out_of_range_fader_emits_nothing(self):
+        self.assertEqual(LoopMix().messages_for(9, 100), [])
+
+
+class Master(unittest.TestCase):
+    def test_master_writes_the_engine_global_not_a_loop(self):
+        msgs = LoopMix().messages_for(MASTER, CC_MAX)
+        self.assertEqual(len(msgs), 1)
+        path, args = msgs[0]
+        self.assertEqual(path, "/set")
+        self.assertEqual(args[0], loop_mix.SL_MASTER_CONTROL)
+        self.assertAlmostEqual(args[1], 1.0)
+
+    def test_master_is_exempt_from_pickup(self):
+        # There is no per-loop truth to seed it from, so suppressing it would
+        # leave the master permanently inert.
+        self.assertTrue(LoopMix().messages_for(MASTER, 5))
+
+
+class Pickup(unittest.TestCase):
+    def test_fader_is_ignored_until_it_crosses_the_stored_value(self):
+        mix = LoopMix()  # every loop seeded at CC_MAX
+        self.assertEqual(mix.messages_for(0, 10), [])
+        self.assertEqual(mix.messages_for(0, 60), [])
+
+    def test_fader_writes_once_it_has_crossed(self):
+        mix = LoopMix()
+        self.assertEqual(mix.messages_for(0, 10), [])
+        self.assertTrue(mix.messages_for(0, CC_MAX))
+        self.assertTrue(mix.messages_for(0, 10))  # now live
+
+    def test_suppressed_movement_does_not_change_stored_gain(self):
+        mix = LoopMix()
+        mix.messages_for(0, 10)
+        self.assertEqual(mix.user_gain[0], CC_MAX)
+
+    def test_engine_seed_rearms_pickup_for_that_column(self):
+        mix = _picked_up(LoopMix(), 0)
+        self.assertTrue(mix.messages_for(0, 100))
+        mix.seed_from_engine(8, 0.25)  # loop 8 is column 0
+        self.assertEqual(mix.messages_for(0, 100), [])
+
+    def test_engine_seed_round_trips_through_the_taper(self):
+        mix = LoopMix()
+        mix.seed_from_engine(0, 0.5)
+        self.assertAlmostEqual(mix.wet_for(0), 0.5, places=2)
+
+
+class Composition(unittest.TestCase):
+    def test_wet_is_user_gain_when_the_law_is_off(self):
+        mix = _picked_up(LoopMix(), 0)
+        mix.messages_for(0, CC_MAX)
+        self.assertAlmostEqual(mix.wet_for(0), 1.0)
+
+    def test_law_scales_every_loop_and_never_reads_back(self):
+        mix = LoopMix()
+        mix.active_loops = 4
+        with _law_enabled():
+            self.assertAlmostEqual(mix.wet_for(0), 0.25)
+            # Recomputed from user_gain each time, so it does not compound.
+            self.assertAlmostEqual(mix.wet_for(0), 0.25)
+
+    def test_loop_count_change_reemits_every_loop(self):
+        mix = LoopMix(num_loops=16)
+        msgs = mix.note_active_loops(3)
+        self.assertEqual(len(msgs), 16)
+
+    def test_unchanged_loop_count_emits_nothing(self):
+        mix = LoopMix()
+        mix.note_active_loops(3)
+        self.assertEqual(mix.note_active_loops(3), [])
+
+    def test_wet_stays_in_range(self):
+        mix = LoopMix()
+        mix.active_loops = 1
+        with _law_enabled():
+            self.assertLessEqual(mix.wet_for(0), 1.0)
+            self.assertGreaterEqual(mix.wet_for(0), 0.0)
+
+
+class _law_enabled:
+    def __enter__(self):
+        self._prev = loop_mix.AUTO_LAW_ENABLED
+        loop_mix.AUTO_LAW_ENABLED = True
+
+    def __exit__(self, *exc):
+        loop_mix.AUTO_LAW_ENABLED = self._prev
+        return False
+
+
+class Coalescing(unittest.TestCase):
+    def setUp(self):
+        self.sent = []
+        self.sender = CoalescingSender(
+            lambda path, args: self.sent.append((path, args)), interval_s=1.0
+        )
+
+    def test_bursts_are_collapsed_to_one_send_per_path(self):
+        for i, value in enumerate([10, 20, 30, 40]):
+            self.sender.submit([("/sl/0/set", ["wet", value])], now=i * 0.01)
+        self.assertEqual(len(self.sent), 1)
+
+    def test_the_endpoint_value_always_survives(self):
+        # Dropping the last value leaves the fader physically lying about the
+        # level, which is worse than the flood the throttle prevents.
+        for i, value in enumerate([10, 20, 30, 99]):
+            self.sender.submit([("/sl/0/set", ["wet", value])], now=i * 0.01)
+        self.sender.flush(now=99.0)
+        self.assertEqual(self.sent[-1], ("/sl/0/set", ["wet", 99]))
+
+    def test_distinct_paths_are_not_collapsed_into_each_other(self):
+        self.sender.submit(
+            [("/sl/0/set", ["wet", 1]), ("/sl/8/set", ["wet", 1])], now=0.0
+        )
+        self.sender.flush(now=5.0)
+        self.assertEqual({p for p, _ in self.sent}, {"/sl/0/set", "/sl/8/set"})
+
+    def test_flush_with_nothing_pending_is_silent(self):
+        self.sender.flush(now=1.0)
+        self.assertEqual(self.sent, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -235,6 +235,21 @@ class Smoothing(unittest.TestCase):
         sender.submit([("/sl/0/set", ["wet", 0.75])], now=0.0)
         self.assertEqual(sent[-1], 0.75)
 
+    def test_first_send_ramps_from_seeded_engine_level(self):
+        sent = []
+        sender = CoalescingSender(
+            lambda path, args: sent.append(args[1]),
+            interval_s=0.0,
+            smooth_tau_s=0.05,
+            smooth_snap=0.001,
+        )
+        sender.seed_current("/sl/0/set", 1.0)
+        sender.submit([("/sl/0/set", ["wet", 0.5])], now=0.0)
+        sender.tick(now=0.01)
+        self.assertTrue(sent)
+        self.assertGreater(sent[-1], 0.5)
+        self.assertLess(sent[-1], 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -132,6 +132,18 @@ class Pickup(unittest.TestCase):
             mix.seed_from_engine(8, mix.wet_for(8))
         self.assertTrue(mix.messages_for(0, 90))
 
+    def test_master_echo_does_not_corrupt_column_fader_gain(self):
+        # Composed wet echoes must not be inverted into user_gain — that would
+        # treat the master factor as if it were the column fader position.
+        mix = _picked_up(LoopMix(), 0)
+        mix.messages_for(0, 100)
+        before = mix.user_gain[0]
+        mix.messages_for(MASTER, 64)
+        for loop in range(mix.num_loops):
+            mix.seed_from_engine(loop, mix.wet_for(loop))
+        self.assertEqual(mix.user_gain[0], before)
+        self.assertTrue(mix.messages_for(0, 90))
+
     def test_engine_seed_round_trips_through_the_taper(self):
         mix = LoopMix()
         mix.seed_from_engine(0, 0.5)

--- a/tests/test_loop_mix.py
+++ b/tests/test_loop_mix.py
@@ -106,8 +106,17 @@ class Pickup(unittest.TestCase):
     def test_engine_seed_rearms_pickup_for_that_column(self):
         mix = _picked_up(LoopMix(), 0)
         mix.messages_for(0, 100)
+        mix._pickup_anchor.pop(0, None)  # idle — no hand on fader
         mix.seed_from_engine(8, 0.25)
         self.assertEqual(mix.messages_for(0, 100), [])
+
+    def test_engine_seed_ignored_while_column_fader_is_in_hand(self):
+        mix = _picked_up(LoopMix(), 0)
+        mix.messages_for(0, 100)
+        before = mix.user_gain[0]
+        mix.seed_from_engine(8, 0.25)  # lagging echo must not re-arm pickup
+        self.assertEqual(mix.user_gain[0], before)
+        self.assertTrue(mix.messages_for(0, 90))
 
     def test_engine_echoing_our_own_value_does_not_rearm_pickup(self):
         mix = _picked_up(LoopMix(), 0)


### PR DESCRIPTION
Wires the APC mini's 9 physical faders to loop level. The bench handled note
on/off only — CC fell through the dispatch loop untouched.

**v1 semantic:** fader N drives both clips in grid column N (loops N and N+8).
Eight faders cover all 16 loops with no bank button. Explicitly a starting
point, not the final mapping.

## Design

The ask was architecture, not a POC, so two known futures shaped it:

**Faders will get other jobs** (LFO filter, pan). So state lives per
`(loop, parameter)`, never on the fader — a fader is a write-only *view* onto a
set of loops. `FaderMode` + a `PARAMETERS` dict is the seam where a new
parameter lands: a descriptor and a dict entry, not a refactor. Deliberately two
new modules rather than a binding registry; nine faders don't justify one yet.

**`wet` was already spoken for.** DECISIONS.md:468 plans a `loop_gain/N` backstop
"applied by our driver over OSC". That law and a user fader both want to write
the same control, and if they're written from two places they'll fight — the bug
would read as "the faders drift" rather than as a design error. So there is
exactly one composition point:

```
wet_for(loop) = taper(user_gain[loop]) × taper(master_gain) × auto_law(active_loops)
```

Always recomputed in full from state we own; never read-modify-write on the
engine's value. The backstop law is off by default (`MPE_SL_LOOP_GAIN_LAW=1`),
but the seam exists from the first commit — that's the whole point of it.

**The master is arithmetic, not a bus control.** This started as an engine-global
`/set wet` and was changed after review. Nothing in this system has ever written
a *level* at engine scope — every global we send is a setting (`tempo`,
`sync_source`, `fade_samples`) — so that control was assumed, not known, and OSC
drops a message to a control the engine lacks in silence. The failure mode was a
master fader that does nothing, with no error and no log line, pending hardware
we can't reach from here. Per-loop `wet` is proven live (eval 2026-08-14:
`oscsend … /sl/0/set sf dry 0.0`), so the master is now a factor in `wet_for()`
and moves all 16 loops. Equivalent, not merely similar: loops sum into
`common_out` through plain `jack_connect` with no gain or limiter stage, so
scaling all 16 by one factor is exactly scaling the bus. Cost is 16 OSC messages
per master move, capped by the existing coalescer.

Other decisions worth the review time:

- **Pickup.** Faders have no motors, so at startup their physical positions mean
  nothing and the first touch mid-jam would be a loud jump. Levels seed from the
  engine's reported `wet`; a fader stays inert until it crosses its stored value.
  The master is exempt — there's no engine truth to seed it from, so gating it
  would leave it permanently inert. The tradeoff, noted at the call site: its
  first move jumps all 16 loops at once, downward from unity. Safe direction, and
  the alternative is a dead fader.
- **`wet` echoes must not re-arm pickup.** `wet` streams continuously, so most
  updates are the engine repeating what we just set. Re-arming on those would
  leave every fader permanently inert — it can never cross a target that moves to
  meet it. Suppressed by tolerance, and registered at 500 ms, not the 100 ms used
  for `state`.
- **Hard zero at the bottom.** A log taper can't reach zero; without the snap the
  fader bottoms out audible, which reads as a bug.
- **The coalescer never drops the endpoint.** A dropped final value leaves the
  fader physically lying about the level — worse than the flood the throttle
  prevents. Flushed from the idle branch, the only code that runs after the last
  CC of a drag.
- **Layout is single-sourced.** `loops_for_column()` derives from
  `all_loop_pads()`, so faders follow the pads by construction.

**Master is loops only, by design** — it does not touch the live synth. The live
path `Surge → system:playback` must fail open (DECISIONS.md 440–500, the same
reasoning that killed `limiter_live`). Live level stays on the per-patch Vol
fader on the touch screen.

## One unverified hardware fact — please read before merging

**Fader CC numbers (48–55, master 56) are unconfirmed.** Routed through a
variant-aware resolver mirroring `apc_transport.py` — which exists precisely
because Shift/Stop-All notes *do* differ between mk1 and mk2 — rather than module
constants, even though the two variants are believed to agree here. The green
suite does not prove this.

## Verification

- ✅ `python3 -m unittest discover -s tests -q` — 704 tests, OK (5 skipped).
- ⬜ **Hardware not run — no Pi in this session.** Still needed: confirm fader CCs
  with `--dump-midi` (now decodes `0xB0`, which it didn't before — that tool
  couldn't read faders at all); ear-pass the taper after recording loops on a
  column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENyWTVMivwA2QyePKchyMk
