### PR TITLE
test(looper): bank-switching hardware protocol + read-only level dump

### DIFF
--- a/docs/APC-BANK-HARDWARE-TEST.md
+++ b/docs/APC-BANK-HARDWARE-TEST.md
@@ -9,6 +9,11 @@ left pointing at the track that scrolled away.
 numbers in `apc_transport.py` are **recalled, not measured** — step 0 exists to
 settle them before anything else is trusted.
 
+**Two numbering conventions, stated once:** *track N* is the bench's 1-indexed
+display (`bank: tracks 1-8 of 16`); *loop N* is what `dump-loop-levels.py`
+prints, 0-indexed. `track N == loop N-1`. Every assertion below is written as
+**loop N** so it can be checked against the dump without arithmetic.
+
 ---
 
 ## Why this needs hardware and can't be judged by ear
@@ -48,9 +53,9 @@ scripts/sooperlooper/smoke-16-loops.sh    # 16 clips, distinct content
 scripts/sooperlooper-apc-bench.py         # in a second shell
 ```
 
-Give each track a **distinct level before you start**, so a mis-bound fader is
-visible as a wrong number rather than a plausible one. Ramp them: track 0
-quietest through track 15 loudest. Record that baseline as `/tmp/baseline.json`.
+Give each loop a **distinct level before you start**, so a mis-bound fader is
+visible as a wrong number rather than a plausible one. Ramp them: loop 0
+quietest through loop 15 loudest. Record that baseline as `/tmp/baseline.json`.
 
 Bench startup should print the bank line: `bank: tracks 1-8 of 16`.
 
@@ -82,12 +87,12 @@ startup. Wrong variant = wrong tuple = same symptom.
 
 ## Step 1 — LEDs travel
 
-With tracks 1–8 showing, note which pads are lit and in what colour (playing vs
+With loops 0–7 showing (bench prints `tracks 1-8`), note which pads are lit and in what colour (playing vs
 idle vs recording differ — see `led_table.py`).
 
-Press **Down** (pages by 8 → tracks 9–16).
+Press **Down** (pages by 8 → loops 8–15).
 
-- [ ] **1a** The clip row now shows tracks 9–16's states. A track that was
+- [ ] **1a** The clip row now shows loops 8–15's states. A track that was
       playing in the old bank and idle in the new one must go dark.
 - [ ] **1b** **No pad retains its old colour.** The row is cleared before the
       repaint precisely so a stale lit pad can't claim a track is running.
@@ -95,26 +100,26 @@ Press **Down** (pages by 8 → tracks 9–16).
 - [ ] **1c** Rows 1–7 are dark and stay dark. Nothing writes them anymore; the
       bench blanks all 64 pads at startup so leftovers from a previous build or
       a crash are gone.
-- [ ] **1d** Bank back **Up**. Tracks 1–8's LEDs are correct again, including
-      any track whose state changed while it was off screen.
+- [ ] **1d** Bank back **Up**. Loops 0–7's LEDs are correct again, including
+      any loop whose state changed while it was off screen.
 
 ## Step 2 — pad control travels
 
-Still on tracks 9–16:
+Still on loops 8–15:
 
-- [ ] **2a** Tap column 0's pad. `dump-loop-levels.py` shows **track 8**
-      changed state. Track 0 is untouched.
-- [ ] **2b** Hold column 0's pad ~2 s. **Track 8** clears. Track 0 still has
-      its loop.
-- [ ] **2c** Bank Up. Tap column 0. Now **track 0** responds, not track 8.
+- [ ] **2a** Tap column 0's pad. `dump-loop-levels.py` shows **loop 8**
+      changed state. Loop 0 is untouched.
+- [ ] **2b** Hold column 0's pad ~2 s. **Loop 8** clears. Loop 0 still has
+      its recording.
+- [ ] **2c** Bank Up. Tap column 0. Now **loop 0** responds, not loop 8.
 
 ## Step 3 — fader level travels
 
-The core of the change: fader N used to drive tracks N *and* N+8.
+The core of the change: fader N used to drive loops N *and* N+8.
 
-- [ ] **3a** On tracks 1–8, move fader 3. Only **track 2**'s wet changes.
-      Track 10 does not — that pairing is gone.
-- [ ] **3b** Bank Down. Move fader 3. Now only **track 10**'s wet changes.
+- [ ] **3a** On loops 0–7, move fader 3 (the third fader, column 2). Only
+      **loop 2**'s wet changes. Loop 10 does not — that pairing is gone.
+- [ ] **3b** Bank Down. Move fader 3. Now only **loop 10**'s wet changes.
 - [ ] **3c** Master fader still scales **all 16**, on screen and off.
 
 ## Step 4 — the fader must not jump on first touch after banking
@@ -123,42 +128,43 @@ Faders have no motors, so the physical position after a bank change is a lie
 about the new track. Every anchor is dropped on a bank change; the first CC
 re-anchors and changes nothing.
 
-- [ ] **4a** Set fader 3 near the top. Bank Down (track 10 is quiet).
-      **Nudge fader 3 slightly.** Track 10's wet must **not** jump to match the
+- [ ] **4a** Set fader 3 near the top. Bank Down (loop 10 is quiet).
+      **Nudge fader 3 slightly.** Loop 10's wet must **not** jump to match the
       fader's physical position — the first move anchors only.
 - [ ] **4b** Keep moving it. Now it tracks, relative to where you anchored.
-- [ ] **4c** Repeat banking Up. Same behaviour for track 2.
+- [ ] **4c** Repeat banking Up. Same behaviour for loop 2.
 
 A jump here is the most likely regression and the most audible one.
 
 ## Step 5 — off-screen tracks keep their levels and keep playing
 
-- [ ] **5a** Bank Down, wait a few bars, bank Up. Tracks 1–8's wet values are
+- [ ] **5a** Bank Down, wait a few bars, bank Up. Loops 0–7's wet values are
       **unchanged from `/tmp/baseline.json`**. Banking moves bindings, never
       levels.
-- [ ] **5b** Tracks 9–16 keep playing audibly while banked off screen.
+- [ ] **5b** Loops 8–15 keep playing audibly while banked off screen.
 
 ## Step 6 — the held-pad hazard (regression, fixed this branch)
 
 This one destroyed a loop before the fix. Two hands:
 
-- [ ] **6a** **Hold** column 0's pad on tracks 1–8. Keep holding. With the other
+- [ ] **6a** **Hold** column 0's pad on loops 0–7. Keep holding. With the other
       hand press **Down**. Keep holding ~3 s, past the hold threshold, then
       release.
-- [ ] **6b** **Track 0 must still have its loop.** Before the fix the abandoned
+- [ ] **6b** **Loop 0 must still have its recording.** Before the fix the abandoned
       pad-down survived the bank change and `poll_hold()` fired the long-press
       seconds later, `undo_all`-ing a track that wasn't even on screen.
-- [ ] **6c** Track 8 (which took over that pad) is also unaffected — the
+- [ ] **6c** Loop 8 (which took over that pad) is also unaffected — the
       release lands on it but must be a no-op.
 
 ## Step 7 — banking arithmetic
 
-- [ ] **7a** **Up/Down page by 8.** From tracks 1–8, Down → 9–16.
-- [ ] **7b** **Shift+Right nudges by 1.** From offset 0 → tracks 2–9. Column 0
-      is now track 1 (0-indexed: loop 1). Confirm with a fader move.
+- [ ] **7a** **Up/Down page by 8.** From loops 0–7, Down → loops 8–15.
+- [ ] **7b** **Shift+Right nudges by 1.** From offset 0 → loops 1–8 (the bench
+      prints `tracks 2-9`). Column 0 is now **loop 1**. Confirm with a
+      fader move: fader 1 writes loop 1, not loop 0.
 - [ ] **7c** **Bare Left/Right do nothing.** Nudging is gated behind Shift.
-- [ ] **7d** **Clamp, never wrap.** At tracks 1–8 press Up repeatedly: stays at
-      1–8, does not jump to 9–16. At 9–16 press Down repeatedly: stays.
+- [ ] **7d** **Clamp, never wrap.** At loops 0–7 press Up repeatedly: stays at
+      0–7, does not jump to 8–15. At 8–15 press Down repeatedly: stays.
 - [ ] **7e** Shift+Left/Right at both extremes likewise clamps.
 - [ ] **7f** The bench prints `bank: tracks N-M of 16` on every *actual* change
       and stays silent when clamped.
@@ -168,7 +174,7 @@ This one destroyed a loop before the fix. Two hands:
 - [ ] **8a** Shift is used for nudging now. Confirm **Shift + Stop All Clips**
       still stops all loops (tap) and clears all (hold 3 s) — Shift being held
       for banking must not have broken the combo, and vice versa.
-- [ ] **8b** Recording a new take while banked to 9–16 lands on the right track.
+- [ ] **8b** Recording a new take while banked to loops 8–15 lands on the right loop.
 
 ---
 

--- a/docs/APC-BANK-HARDWARE-TEST.md
+++ b/docs/APC-BANK-HARDWARE-TEST.md
@@ -1,0 +1,187 @@
+# APC bank switching — hardware test protocol
+
+**Purpose:** verify that when the viewport moves, *all three* bindings move with
+it — the clip LED, the pad control, and the fader level — and that nothing is
+left pointing at the track that scrolled away.
+
+**Applies to:** `dev` at or after `f304536` (Ableton-style horizontal track lane).
+**Status of the code under test:** unit-tested only (711 pass). The arrow note
+numbers in `apc_transport.py` are **recalled, not measured** — step 0 exists to
+settle them before anything else is trusted.
+
+---
+
+## Why this needs hardware and can't be judged by ear
+
+The failure that matters is a binding that *didn't* travel — fader 1 still
+writing track 0 after banking to tracks 8–15. Turning fader 1 down and hearing
+something get quieter does not distinguish that from success. So every level
+assertion here reads the engine instead:
+
+```bash
+scripts/sooperlooper/dump-loop-levels.py          # human-readable
+scripts/sooperlooper/dump-loop-levels.py --json   # for diffing
+```
+
+It sends `/sl/N/get` for `wet` and `state` on every loop. Pure read — safe
+during a live take. A loop that exists always answers; silence means the command
+path is wedged, and the script exits non-zero saying so rather than printing
+zeros.
+
+**Diff, don't eyeball.** Capture before and after each bank change:
+
+```bash
+scripts/sooperlooper/dump-loop-levels.py --json > /tmp/before.json
+# ... perform the step ...
+scripts/sooperlooper/dump-loop-levels.py --json > /tmp/after.json
+diff /tmp/before.json /tmp/after.json
+```
+
+---
+
+## Setup
+
+No human recording needed — load the fixtures:
+
+```bash
+scripts/sooperlooper/smoke-16-loops.sh    # 16 clips, distinct content
+scripts/sooperlooper-apc-bench.py         # in a second shell
+```
+
+Give each track a **distinct level before you start**, so a mis-bound fader is
+visible as a wrong number rather than a plausible one. Ramp them: track 0
+quietest through track 15 loudest. Record that baseline as `/tmp/baseline.json`.
+
+Bench startup should print the bank line: `bank: tracks 1-8 of 16`.
+
+---
+
+## Step 0 — arrow note numbers (blocks everything else)
+
+```bash
+scripts/sooperlooper-apc-bench.py --dump-midi
+```
+
+Press **Up, Down, Left, Right**. Record the four note numbers.
+
+| Arrow | Expected (mk2) | Expected (mk1) | Measured |
+|---|---|---|---|
+| Up | `0x70` (112) | `0x40` (64) | |
+| Down | `0x71` (113) | `0x41` (65) | |
+| Left | `0x72` (114) | `0x42` (66) | |
+| Right | `0x73` (115) | `0x43` (67) | |
+
+If these don't match, banking silently does nothing and **every step below fails
+for that one reason**. Fix `ARROW_NOTES_MK1` / `ARROW_NOTES_MK2` in
+`scripts/sooperlooper/apc_transport.py` first — one tuple, no call sites.
+
+Also confirm the variant resolved correctly: the bench prints the APC label at
+startup. Wrong variant = wrong tuple = same symptom.
+
+---
+
+## Step 1 — LEDs travel
+
+With tracks 1–8 showing, note which pads are lit and in what colour (playing vs
+idle vs recording differ — see `led_table.py`).
+
+Press **Down** (pages by 8 → tracks 9–16).
+
+- [ ] **1a** The clip row now shows tracks 9–16's states. A track that was
+      playing in the old bank and idle in the new one must go dark.
+- [ ] **1b** **No pad retains its old colour.** The row is cleared before the
+      repaint precisely so a stale lit pad can't claim a track is running.
+      This is the failure the player cannot debug from the surface.
+- [ ] **1c** Rows 1–7 are dark and stay dark. Nothing writes them anymore; the
+      bench blanks all 64 pads at startup so leftovers from a previous build or
+      a crash are gone.
+- [ ] **1d** Bank back **Up**. Tracks 1–8's LEDs are correct again, including
+      any track whose state changed while it was off screen.
+
+## Step 2 — pad control travels
+
+Still on tracks 9–16:
+
+- [ ] **2a** Tap column 0's pad. `dump-loop-levels.py` shows **track 8**
+      changed state. Track 0 is untouched.
+- [ ] **2b** Hold column 0's pad ~2 s. **Track 8** clears. Track 0 still has
+      its loop.
+- [ ] **2c** Bank Up. Tap column 0. Now **track 0** responds, not track 8.
+
+## Step 3 — fader level travels
+
+The core of the change: fader N used to drive tracks N *and* N+8.
+
+- [ ] **3a** On tracks 1–8, move fader 3. Only **track 2**'s wet changes.
+      Track 10 does not — that pairing is gone.
+- [ ] **3b** Bank Down. Move fader 3. Now only **track 10**'s wet changes.
+- [ ] **3c** Master fader still scales **all 16**, on screen and off.
+
+## Step 4 — the fader must not jump on first touch after banking
+
+Faders have no motors, so the physical position after a bank change is a lie
+about the new track. Every anchor is dropped on a bank change; the first CC
+re-anchors and changes nothing.
+
+- [ ] **4a** Set fader 3 near the top. Bank Down (track 10 is quiet).
+      **Nudge fader 3 slightly.** Track 10's wet must **not** jump to match the
+      fader's physical position — the first move anchors only.
+- [ ] **4b** Keep moving it. Now it tracks, relative to where you anchored.
+- [ ] **4c** Repeat banking Up. Same behaviour for track 2.
+
+A jump here is the most likely regression and the most audible one.
+
+## Step 5 — off-screen tracks keep their levels and keep playing
+
+- [ ] **5a** Bank Down, wait a few bars, bank Up. Tracks 1–8's wet values are
+      **unchanged from `/tmp/baseline.json`**. Banking moves bindings, never
+      levels.
+- [ ] **5b** Tracks 9–16 keep playing audibly while banked off screen.
+
+## Step 6 — the held-pad hazard (regression, fixed this branch)
+
+This one destroyed a loop before the fix. Two hands:
+
+- [ ] **6a** **Hold** column 0's pad on tracks 1–8. Keep holding. With the other
+      hand press **Down**. Keep holding ~3 s, past the hold threshold, then
+      release.
+- [ ] **6b** **Track 0 must still have its loop.** Before the fix the abandoned
+      pad-down survived the bank change and `poll_hold()` fired the long-press
+      seconds later, `undo_all`-ing a track that wasn't even on screen.
+- [ ] **6c** Track 8 (which took over that pad) is also unaffected — the
+      release lands on it but must be a no-op.
+
+## Step 7 — banking arithmetic
+
+- [ ] **7a** **Up/Down page by 8.** From tracks 1–8, Down → 9–16.
+- [ ] **7b** **Shift+Right nudges by 1.** From offset 0 → tracks 2–9. Column 0
+      is now track 1 (0-indexed: loop 1). Confirm with a fader move.
+- [ ] **7c** **Bare Left/Right do nothing.** Nudging is gated behind Shift.
+- [ ] **7d** **Clamp, never wrap.** At tracks 1–8 press Up repeatedly: stays at
+      1–8, does not jump to 9–16. At 9–16 press Down repeatedly: stays.
+- [ ] **7e** Shift+Left/Right at both extremes likewise clamps.
+- [ ] **7f** The bench prints `bank: tracks N-M of 16` on every *actual* change
+      and stays silent when clamped.
+
+## Step 8 — interaction with the existing transport
+
+- [ ] **8a** Shift is used for nudging now. Confirm **Shift + Stop All Clips**
+      still stops all loops (tap) and clears all (hold 3 s) — Shift being held
+      for banking must not have broken the combo, and vice versa.
+- [ ] **8b** Recording a new take while banked to 9–16 lands on the right track.
+
+---
+
+## Known gaps, expected — not bugs
+
+- **No bank indicator.** With 8 of 16 showing, nothing on the surface says which
+  half you're on; only the bench's stdout does. Worth fixing, not in scope here.
+- **Banking away mid-take** leaves that loop recording with no pad bound to stop
+  it. That's the documented "off-screen tracks keep their state" property. Bank
+  back and press the pad.
+
+## Recording results
+
+Note the APC variant, the four measured arrow notes, and any step that failed
+with its `dump-loop-levels.py` diff. A failure in steps 1–3 means a binding did
+not travel; in step 4, the anchor drop; in step 6, `release_pad()`.

--- a/docs/APC-BANK-HARDWARE-TEST.md
+++ b/docs/APC-BANK-HARDWARE-TEST.md
@@ -5,9 +5,17 @@ it — the clip LED, the pad control, and the fader level — and that nothing i
 left pointing at the track that scrolled away.
 
 **Applies to:** `dev` at or after `f304536` (Ableton-style horizontal track lane).
-**Status of the code under test:** unit-tested only (711 pass). The arrow note
-numbers in `apc_transport.py` are **recalled, not measured** — step 0 exists to
-settle them before anything else is trusted.
+**Status of the code under test:** unit-tested (723 pass on the appliance, same
+2 pre-existing `dev` failures), plus a remote pass on the Pi that confirmed the
+engine, the dump tool and the mk1 variant resolution. The arrow note numbers in
+`apc_transport.py` are **recalled, not measured** — step 0 exists to settle them
+before anything else is trusted.
+
+> ⚠️ **This protocol overwrites loop contents.** Setup loads 16 fixture clips,
+> and steps 2b and 6 clear loops outright. The appliance currently holds real
+> content (14 of 16 loops read non-zero wet). Capture
+> `dump-loop-levels.py --json` first, and do not run this over a take you want
+> to keep.
 
 **Two numbering conventions, stated once:** *track N* is the bench's 1-indexed
 display (`bank: tracks 1-8 of 16`); *loop N* is what `dump-loop-levels.py`
@@ -44,6 +52,23 @@ diff /tmp/before.json /tmp/after.json
 
 ---
 
+## Prerequisites — the surface and port 9953 must be free
+
+A bench started earlier from `/home/mitch/MPE-Module` will still be holding the
+APC and the listener port. A second bench **exits by design** on the 9953 bind
+failure, and even if it started, the LEDs you would be reading are the old
+build's output. This needs Mitch's hands: `mpe-agent` is a different user with
+no sudo for `kill`, and `mpe-looper.service` is inactive so the service path
+does not apply.
+
+```bash
+pgrep -af sooperlooper-apc-bench     # expect nothing
+ss -lunp | grep 9953                 # expect nothing
+```
+
+Kill any bench found, confirm both are clear, *then* start the bench from the
+branch under test.
+
 ## Setup
 
 No human recording needed — load the fixtures:
@@ -67,21 +92,28 @@ Bench startup should print the bank line: `bank: tracks 1-8 of 16`.
 scripts/sooperlooper-apc-bench.py --dump-midi
 ```
 
-Press **Up, Down, Left, Right**. Record the four note numbers.
+Press **Up, Down, Left, Right — and Shift, and Stop All Clips**. Shift and
+Stop-All come from the same recalled-not-measured table as the arrows, and steps
+7b/7c/7e and all of step 8 depend on Shift being right; the same `--dump-midi`
+run captures them for free.
 
-| Arrow | Expected (mk2) | Expected (mk1) | Measured |
+The appliance's APC has already been confirmed to resolve as **mk1** (port name
+`APC MINI MIDI 1` → `ARROW_NOTES_MK1`, transport `(98, 89)`), so the **mk1**
+column is the one to check against.
+
+| Control | Expected (mk1) | Expected (mk2) | Measured |
 |---|---|---|---|
-| Up | `0x70` (112) | `0x40` (64) | |
-| Down | `0x71` (113) | `0x41` (65) | |
-| Left | `0x72` (114) | `0x42` (66) | |
-| Right | `0x73` (115) | `0x43` (67) | |
+| Up | `0x40` (64) | `0x70` (112) | |
+| Down | `0x41` (65) | `0x71` (113) | |
+| Left | `0x42` (66) | `0x72` (114) | |
+| Right | `0x43` (67) | `0x73` (115) | |
+| Shift | `0x62` (98) | `0x7A` (122) | |
+| Stop All Clips | `0x59` (89) | `0x77` (119) | |
 
 If these don't match, banking silently does nothing and **every step below fails
-for that one reason**. Fix `ARROW_NOTES_MK1` / `ARROW_NOTES_MK2` in
-`scripts/sooperlooper/apc_transport.py` first — one tuple, no call sites.
-
-Also confirm the variant resolved correctly: the bench prints the APC label at
-startup. Wrong variant = wrong tuple = same symptom.
+for that one reason**. Fix `ARROW_NOTES_MK1` / `ARROW_NOTES_MK2` (or the
+transport tuple) in `scripts/sooperlooper/apc_transport.py` first — one tuple
+each, no call sites.
 
 ---
 

--- a/scripts/sooperlooper/dump-loop-levels.py
+++ b/scripts/sooperlooper/dump-loop-levels.py
@@ -35,11 +35,32 @@ RETPATH = "/dump/reply"
 # command path is wedged (the case sl_probe.py exists to diagnose).
 COLLECT_S = 1.5
 
+# The codes the rest of the codebase reasons about come from the canonical
+# module — a second hand-written copy is how a tester reads "playing" off a
+# wrong number and records a false pass. The remaining labels are engine codes
+# nothing here branches on; they exist so the dump is readable, not asserted on.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sl_loop_states import (  # noqa: E402
+    SL_STATE_MUTE,
+    SL_STATE_OFF,
+    SL_STATE_PAUSED,
+    SL_STATE_PLAYING,
+    SL_STATE_RECORDING,
+    SL_STATE_WAIT_START,
+    SL_STATE_WAIT_STOP,
+)
+
 STATE_NAMES = {
-    -1: "unknown", 0: "off", 1: "wait_start", 2: "recording", 3: "wait_stop",
-    4: "playing", 5: "overdubbing", 6: "multiplying", 7: "inserting",
-    8: "replacing", 9: "delay", 10: "muted", 11: "scratching", 12: "one_shot",
-    13: "substitute", 14: "paused",
+    SL_STATE_OFF: "off",
+    SL_STATE_WAIT_START: "wait_start",
+    SL_STATE_RECORDING: "recording",
+    SL_STATE_WAIT_STOP: "wait_stop",
+    SL_STATE_PLAYING: "playing",
+    SL_STATE_MUTE: "muted",
+    SL_STATE_PAUSED: "paused",
+    -1: "unknown", 5: "overdubbing", 6: "multiplying", 7: "inserting",
+    8: "replacing", 9: "delay", 11: "scratching", 12: "one_shot",
+    13: "substitute",
 }
 
 
@@ -75,7 +96,11 @@ def main() -> int:
     threading.Thread(target=server.serve_forever, daemon=True).start()
 
     client = udp_client.SimpleUDPClient(host, port)
-    returl = f"osc.udp://{LISTEN_HOST}:{listen_port}"
+    # Bare host:port, not an osc.udp:// URL. This is the one line here that
+    # cannot be tested without an engine, so it copies the form that is known
+    # to work live — sl_bench_listener.register(). Guessing the URL form and
+    # being wrong prints "engine may be wedged" at a perfectly healthy engine.
+    returl = f"{LISTEN_HOST}:{listen_port}"
     for loop in range(args.loops):
         for ctrl in ("wet", "state"):
             client.send_message(f"/sl/{loop}/get", [ctrl, returl, RETPATH])

--- a/scripts/sooperlooper/dump-loop-levels.py
+++ b/scripts/sooperlooper/dump-loop-levels.py
@@ -123,7 +123,16 @@ def main() -> int:
             wet = got.get((n, "wet"))
             state = got.get((n, "state"))
             wet_s = "  --  " if wet is None else f"{wet:6.3f}"
-            state_s = "no reply" if state is None else STATE_NAMES.get(int(state), str(state))
+            if state is None:
+                state_s = "no reply"
+            else:
+                # An unmapped code prints as unknown(N), not as a bare float.
+                # Live on the appliance 14 of 16 loops read 20, which is not in
+                # sl_loop_states and which the engine source (unreadable from
+                # the agent account) would have to settle. A guessed label here
+                # is worse than an honest number: the bank protocol asserts on
+                # a state *changing*, and a wrong name reads as a false pass.
+                state_s = STATE_NAMES.get(int(state), f"unknown({int(state)})")
             print(f"loop {n:2d}  wet={wet_s}  state={state_s}")
 
     if missing:

--- a/scripts/sooperlooper/dump-loop-levels.py
+++ b/scripts/sooperlooper/dump-loop-levels.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Read every loop's wet level and state out of the engine. READ ONLY.
+
+The bank test asks "did the fader binding travel with the clip?" — a question
+you cannot answer by ear. Turning fader 1 down and hearing something get quieter
+does not say *which* track moved, and the failure mode that matters (fader 1
+still writing track 0 after banking to 8-15) sounds exactly like success if
+track 0 happens to be the loud one.
+
+So: ask the engine. This sends `/sl/N/get` for `wet` and `state` on every loop
+and prints one line per loop. Run it before and after a bank change and diff.
+
+`get` is a pure read — unlike sl_probe.py, which writes a probe value, this
+touches nothing. Safe to run against a live take.
+
+Usage:
+    dump-loop-levels.py [--loops 16] [--json]
+
+Env: MPE_SL_OSC_HOST (127.0.0.1), MPE_SL_OSC_PORT (9951), MPE_SL_LOOPS (16).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+
+LISTEN_HOST = "127.0.0.1"
+RETPATH = "/dump/reply"
+# The engine answers on the JACK process callback's schedule, not ours. 1.5 s is
+# far past the observed round trip and still short enough to fail fast when the
+# command path is wedged (the case sl_probe.py exists to diagnose).
+COLLECT_S = 1.5
+
+STATE_NAMES = {
+    -1: "unknown", 0: "off", 1: "wait_start", 2: "recording", 3: "wait_stop",
+    4: "playing", 5: "overdubbing", 6: "multiplying", 7: "inserting",
+    8: "replacing", 9: "delay", 10: "muted", 11: "scratching", 12: "one_shot",
+    13: "substitute", 14: "paused",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--loops", type=int, default=int(os.environ.get("MPE_SL_LOOPS", "16")))
+    parser.add_argument("--json", action="store_true", help="machine-readable, for diffing")
+    args = parser.parse_args()
+
+    try:
+        from pythonosc import dispatcher, osc_server, udp_client
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    host = os.environ.get("MPE_SL_OSC_HOST", "127.0.0.1")
+    port = int(os.environ.get("MPE_SL_OSC_PORT", "9951"))
+
+    replies: dict[tuple[int, str], float] = {}
+    lock = threading.Lock()
+
+    def on_reply(_addr: str, loop_index: int, control: str, value: float) -> None:
+        with lock:
+            replies[(int(loop_index), str(control))] = float(value)
+
+    disp = dispatcher.Dispatcher()
+    disp.map(RETPATH, on_reply)
+    # Port 0 = let the OS pick, so this never collides with a running bench
+    # listener. The engine is told where to answer, so the port need not be
+    # fixed or known in advance.
+    server = osc_server.ThreadingOSCUDPServer((LISTEN_HOST, 0), disp)
+    listen_port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    client = udp_client.SimpleUDPClient(host, port)
+    returl = f"osc.udp://{LISTEN_HOST}:{listen_port}"
+    for loop in range(args.loops):
+        for ctrl in ("wet", "state"):
+            client.send_message(f"/sl/{loop}/get", [ctrl, returl, RETPATH])
+
+    time.sleep(COLLECT_S)
+    server.shutdown()
+
+    with lock:
+        got = dict(replies)
+
+    missing = [n for n in range(args.loops) if (n, "wet") not in got]
+    if args.json:
+        print(json.dumps(
+            {str(n): {"wet": got.get((n, "wet")), "state": got.get((n, "state"))}
+             for n in range(args.loops)},
+            indent=2, sort_keys=True,
+        ))
+    else:
+        for n in range(args.loops):
+            wet = got.get((n, "wet"))
+            state = got.get((n, "state"))
+            wet_s = "  --  " if wet is None else f"{wet:6.3f}"
+            state_s = "no reply" if state is None else STATE_NAMES.get(int(state), str(state))
+            print(f"loop {n:2d}  wet={wet_s}  state={state_s}")
+
+    if missing:
+        # Silence is the wedge signature, not an empty engine: a loop that
+        # exists always answers `get`. Say so rather than printing dashes and
+        # exiting 0, which reads as "levels are zero".
+        print(
+            f"\nNO REPLY for loops {missing} — engine may be wedged or have "
+            f"fewer than {args.loops} loops. See sl-health.py.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/yolo/yolo-shell-guard.sh
+++ b/scripts/yolo/yolo-shell-guard.sh
@@ -74,8 +74,15 @@ fi
 if echo "$command" | grep -qE '(^|[;&|[:space:]])mpe[[:space:]]+restart'; then
   deny "YOLO guardrail: mpe restart is blocked on nerdrack"
 fi
-if echo "$command" | grep -qE '(^|[;&|[:space:]])(ssh|scp|rsync)[^;|]*raspberrypi'; then
-  deny "YOLO guardrail: direct Pi SSH/SCP/rsync blocked — Pi is LAN-only"
+# Raw ssh/scp/rsync is denied outright, not just to a hostname. The old rule
+# keyed on the literal string "raspberrypi", so `ssh mitch@mpe-pi` — the
+# appliance's tailnet name, which now exists — sailed straight through. Any
+# hostname-specific rule is one rename away from being decorative.
+#
+# `mpe-yolo` is the sanctioned entrypoint: it targets the appliance's forced
+# command, which validates the token itself. Allowed by name here.
+if echo "$command" | grep -qE '(^|[;&|[:space:]])(ssh|scp|rsync|sftp)([[:space:]]|$)'; then
+  deny "YOLO guardrail: raw ssh/scp/rsync/sftp blocked — use 'mpe-pi <cmd>' or 'mpe-yolo <token>'"
 fi
 if echo "$command" | grep -qE '(^|[;&|[:space:]])sudo[[:space:]]+apt'; then
   deny "YOLO guardrail: sudo apt on appliance/host is Mitch-only"

--- a/tests/test_apc_bench.py
+++ b/tests/test_apc_bench.py
@@ -107,6 +107,39 @@ class ApcBenchFootswitchTests(unittest.TestCase):
         osc.send_message.assert_not_called()
 
 
+class ViewAgreementTests(unittest.TestCase):
+    """The pad layer and the fader layer must address the same track.
+
+    Every other test here checks one layer alone, so the bench forgetting to
+    call `mix.set_view()` alongside `apply_view()` — the exact bug where the
+    clip travels and the volume doesn't — passes all of them.
+    """
+
+    def test_pads_and_faders_address_the_same_loops_after_banking(self) -> None:
+        from scripts.sooperlooper.loop_mix import LoopMix
+
+        osc = MagicMock()
+        midi_out = MagicMock()
+        _by_note, footswitches = build_footswitches(
+            osc=osc,
+            midi_out=midi_out,
+            num_loops=16,
+            hold_ms=1000.0,
+            debounce_ms=200.0,
+        )
+        mix = LoopMix(num_loops=16)
+        for offset in (0, 8, 1, 7):
+            view = GridView(offset=offset)
+            by_note = apply_view(midi_out, footswitches=footswitches, view=view)
+            mix.set_view(view)
+            for col in range(8):
+                self.assertEqual(
+                    (by_note[pad_note(0, col)].loop,),
+                    mix.view.loops_for_column(col),
+                    f"column {col} disagrees at offset {offset}",
+                )
+
+
 def _bench_module():
     """Load the bench script — its filename has a hyphen, so no plain import."""
     import importlib.util


### PR DESCRIPTION
The bank change is only correct if **all three bindings travel together**: the clip LED, the clip (pad) control, and the fader/volume level. None of that is checkable by ear — a fader still writing the track that scrolled away sounds exactly like one that rebound, since both make something get quieter.

## What's here

- **`scripts/sooperlooper/dump-loop-levels.py`** — read-only `/sl/N/get` of `wet` and `state` for every loop, one line per loop or `--json` for diffing across a bank change. Pure read (unlike `sl_probe.py`, which writes), so it's safe during a live take. A loop that exists always answers, so silence is the wedge signature and exits non-zero rather than printing zeros that read as levels. Return address and state codes both come from the known-good in-repo sources (`sl_bench_listener`, `sl_loop_states`).
- **`docs/APC-BANK-HARDWARE-TEST.md`** — 8-step protocol: LEDs travel, pad control travels, fader rebinds, the anchor drop that stops a motorless fader jumping the new track's level on first touch, off-screen tracks keeping levels and playback, the held-pad-across-a-bank regression, banking arithmetic, and the Shift+Stop-All interaction.
- **A cross-layer unit test** — every previous bench test checked one layer alone, so `apply_view()` without `mix.set_view()` (clip travels, volume doesn't) passed all of them. Now asserted across four offsets; verified it fails when `set_view` is removed.

## Pi status — remote half done, hardware half pending

Run on the appliance via `scripts/yolo/mpe-pi` (as `mpe-agent`):

- **Test suite: 723 passed, 3 skipped, 2 failed** — and those 2 are pre-existing on `dev`, confirmed by checking out `origin/dev` on the Pi as a baseline: `test_audio_engine::test_planned_promote_sync_path` and `test_patch_scanner::test_resolve_library_patch_dirs_finds_sibling_repo`. This branch adds no regressions and one new pass (the view-agreement test).
- **`dump-loop-levels.py` validated against the live 16-loop engine** — all 16 loops answered. This caught a real bug in it: the return address must be bare `host:port`, not an `osc.udp://` URL, or a healthy engine reads as wedged. Fixed and re-verified live.
- **Variant resolved: mk1.** The APC is present at `hw:4,0,0` as `APC MINI MIDI 1`, so the code selects `ARROW_NOTES_MK1` = `0x40–0x43` and transport `(98, 89)`. That answers step 0's *code* side — it proves which tuple is chosen, **not** what the hardware emits.
- 14 of 16 loops report state `20`, which isn't in `sl_loop_states`. The dump prints `unknown(20)` rather than guessing a label; the engine source is outside `mpe-agent`'s reach. Nothing in the protocol asserts on that label.
- Appliance state change worth noting: `python-osc` was `pip install`ed into `~mpe-agent/MPE-Module/.venv`.

## What still needs hands on the surface

1. **Step 0's physical half** — press Up/Down/Left/Right/Shift/Stop-All under `--dump-midi` and confirm the mk1 numbers. If they're wrong, banking silently does nothing and every later step fails for that one reason.
2. **Steps 1–8** — the three-bindings-travel test itself. Pads and faders have to be touched.
3. **Two prerequisites now documented in the protocol:** it *destroys loop content* (fixtures + `undo_all`), and the appliance currently holds real takes; and a bench running as `mitch` holds the APC and port 9953, so it must be stopped before a bench from this branch can start. `mpe-agent` can't do either — different user, no sudo for `kill`.