### PR TITLE
Live peak dBFS meter (fail-open JACK tap)

### DIFF
--- a/patch_browser/peak_meter_math.py
+++ b/patch_browser/peak_meter_math.py
@@ -1,0 +1,39 @@
+"""Peak dBFS helpers for the live output meter."""
+
+from __future__ import annotations
+
+import math
+
+# Bar maps this floor to empty and 0 dBFS to full.
+PEAK_METER_FLOOR_DBFS = -48.0
+PEAK_METER_CEIL_DBFS = 0.0
+
+
+def linear_peak_to_dbfs(peak: float) -> float | None:
+    """Convert linear peak (0..1+) to dBFS. Returns None when silent."""
+    if peak <= 0.0 or not math.isfinite(peak):
+        return None
+    return 20.0 * math.log10(peak)
+
+
+def dbfs_to_meter_ratio(dbfs: float | None) -> float | None:
+    """Map dBFS to 0..1 bar fill. None when offline/silent."""
+    if dbfs is None or not math.isfinite(dbfs):
+        return None
+    if dbfs <= PEAK_METER_FLOOR_DBFS:
+        return 0.0
+    if dbfs >= PEAK_METER_CEIL_DBFS:
+        return 1.0
+    span = PEAK_METER_CEIL_DBFS - PEAK_METER_FLOOR_DBFS
+    return (dbfs - PEAK_METER_FLOOR_DBFS) / span
+
+
+def peak_meter_color_dbfs(dbfs: float | None) -> str:
+    """Semantic bucket for theming: ok | warn | hot."""
+    if dbfs is None:
+        return "muted"
+    if dbfs < -18.0:
+        return "ok"
+    if dbfs < -6.0:
+        return "warn"
+    return "hot"

--- a/patch_browser/surge_peak_monitor.py
+++ b/patch_browser/surge_peak_monitor.py
@@ -85,13 +85,23 @@ class SurgePeakMonitor:
 
     def snapshot(self) -> dict:
         with self._lock:
+            if not self._online:
+                return {
+                    "online": False,
+                    "peak_linear": None,
+                    "dbfs": None,
+                    "ratio": None,
+                    "source": self._source,
+                }
             dbfs = linear_peak_to_dbfs(self._peak_linear)
             ratio = dbfs_to_meter_ratio(dbfs)
+            if ratio is None:
+                ratio = 0.0
             return {
-                "online": self._online,
-                "peak_linear": self._peak_linear if self._online else None,
-                "dbfs": dbfs if self._online else None,
-                "ratio": ratio if self._online else None,
+                "online": True,
+                "peak_linear": self._peak_linear,
+                "dbfs": dbfs,
+                "ratio": ratio,
                 "source": self._source,
             }
 
@@ -172,10 +182,24 @@ class SurgePeakMonitor:
         peak = 0.0
         for port in self._inports:
             try:
-                buf = port.get_buffer()
+                arr = port.get_array()
             except Exception:
+                try:
+                    buf = port.get_buffer()
+                except Exception:
+                    continue
+                peak = max(peak, _buffer_peak(buf, frames))
                 continue
-            peak = max(peak, _buffer_peak(buf, frames))
+            if arr is None or len(arr) == 0:
+                continue
+            count = min(frames, len(arr))
+            for idx in range(count):
+                sample = float(arr[idx])
+                if sample != sample:
+                    continue
+                a = -sample if sample < 0.0 else sample
+                if a > peak:
+                    peak = a
         if peak > self._period_peak:
             self._period_peak = peak
 
@@ -184,20 +208,30 @@ class SurgePeakMonitor:
         if client is None:
             self._wired = False
             return
-        wired = True
-        for ch in (1, 2):
+        for ch, port in enumerate(self._inports, start=1):
             src = f"{self.surge_client}:out_{ch}"
-            dst = f"{client.name}:in_{ch}"
             try:
-                client.connect(src, dst)
-            except Exception as exc:
-                if "already connected" in str(exc).lower():
+                if port.is_connected_to(src):
                     continue
-                wired = False
-        self._wired = wired
+                client.connect(src, port)
+            except Exception as exc:
+                msg = str(exc).lower()
+                if "already connected" in msg or "already exists" in msg:
+                    continue
+                self._wired = False
+                return
+        self._wired = self._surge_outputs_connected()
 
     def _surge_outputs_connected(self) -> bool:
-        return self._wired
+        if not self._inports or len(self._inports) < 2:
+            return False
+        try:
+            return all(
+                port.is_connected_to(f"{self.surge_client}:out_{ch}")
+                for ch, port in enumerate(self._inports, start=1)
+            )
+        except Exception:
+            return self._wired
 
     def _shutdown_jack(self) -> None:
         client = self._client

--- a/patch_browser/surge_peak_monitor.py
+++ b/patch_browser/surge_peak_monitor.py
@@ -1,0 +1,212 @@
+"""Passive JACK peak meter for Surge output (fail-open parallel tap)."""
+
+from __future__ import annotations
+
+import struct
+import threading
+import time
+
+from patch_browser.peak_meter_math import dbfs_to_meter_ratio, linear_peak_to_dbfs
+
+POLL_INTERVAL_S = 0.2  # 5 Hz — UI reads snapshot only
+PEAK_DECAY = 0.86  # per poll tick between peaks
+SURGE_JACK_CLIENT = "Surge XT"
+METER_JACK_CLIENT = "mpe-peak-meter"
+RECONNECT_INTERVAL_S = 2.0
+
+
+def _buffer_peak(buf, nframes: int) -> float:
+    """Max abs sample from a JACK float32 port buffer (no numpy)."""
+    if nframes <= 0:
+        return 0.0
+    peak = 0.0
+    mv = memoryview(buf)[: nframes * 4]
+    for offset in range(0, len(mv), 4):
+        sample = struct.unpack_from("<f", mv, offset)[0]
+        if not (sample == sample):  # NaN
+            continue
+        a = -sample if sample < 0.0 else sample
+        if a > peak:
+            peak = a
+    return peak
+
+
+class SurgePeakMonitor:
+    """Parallel JACK input-only client — never sits in Surge's playback path.
+
+    Topology (fail-open):
+      Surge XT:out_{1,2} → system:playback_{1,2}   (unchanged)
+      Surge XT:out_{1,2} → mpe-peak-meter:in_{1,2} (optional fan-out)
+
+    No output ports on this client, so it cannot insert downstream of Surge.
+    If JACK is down, Surge is offline, or wiring fails, the touch UI shows —.
+    """
+
+    def __init__(
+        self,
+        surge_monitor,
+        *,
+        poll_interval: float = POLL_INTERVAL_S,
+        surge_client: str = SURGE_JACK_CLIENT,
+    ) -> None:
+        self.surge_monitor = surge_monitor
+        self.poll_interval = poll_interval
+        self.surge_client = surge_client
+        self._lock = threading.Lock()
+        self._peak_linear = 0.0
+        self._period_peak = 0.0
+        self._online = False
+        self._source = "none"
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._jack = None
+        self._client = None
+        self._inports: list = []
+        self._jack_available: bool | None = None
+        self._last_connect_attempt = 0.0
+        self._wired = False
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._worker,
+            daemon=True,
+            name="SurgePeakMonitor",
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=1.5)
+        self._shutdown_jack()
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            dbfs = linear_peak_to_dbfs(self._peak_linear)
+            ratio = dbfs_to_meter_ratio(dbfs)
+            return {
+                "online": self._online,
+                "peak_linear": self._peak_linear if self._online else None,
+                "dbfs": dbfs if self._online else None,
+                "ratio": ratio if self._online else None,
+                "source": self._source,
+            }
+
+    def _worker(self) -> None:
+        while not self._stop.wait(self.poll_interval):
+            try:
+                self._poll_once()
+            except Exception as exc:
+                print(f"Surge peak monitor poll error: {exc}")
+
+    def _poll_once(self) -> None:
+        healthy, _ = self.surge_monitor.check_health()
+        if not healthy:
+            self._reset_display(online=False)
+            return
+
+        if not self._ensure_jack_client():
+            self._reset_display(online=False)
+            return
+
+        now = time.monotonic()
+        if now - self._last_connect_attempt >= RECONNECT_INTERVAL_S:
+            self._last_connect_attempt = now
+            self._try_connect_surge_outputs()
+
+        wired = self._surge_outputs_connected()
+        with self._lock:
+            window_peak = self._period_peak
+            self._period_peak = 0.0
+            if window_peak > self._peak_linear:
+                self._peak_linear = window_peak
+            elif wired:
+                self._peak_linear *= PEAK_DECAY
+            else:
+                self._peak_linear = 0.0
+            self._online = wired
+            self._source = "jack" if wired else "none"
+
+    def _reset_display(self, *, online: bool) -> None:
+        self._wired = False
+        with self._lock:
+            self._online = online
+            self._peak_linear = 0.0
+            self._period_peak = 0.0
+            self._source = "none"
+
+    def _ensure_jack_client(self) -> bool:
+        if self._client is not None:
+            return True
+        if self._jack_available is False:
+            return False
+        try:
+            import jack
+        except ImportError:
+            self._jack_available = False
+            return False
+
+        self._jack = jack
+        try:
+            client = jack.Client(METER_JACK_CLIENT, no_start_server=True)
+            inports = [
+                client.inports.register("in_1"),
+                client.inports.register("in_2"),
+            ]
+            client.set_process_callback(self._process)
+            client.activate()
+        except Exception:
+            self._jack_available = False
+            self._shutdown_jack()
+            return False
+
+        self._client = client
+        self._inports = inports
+        self._jack_available = True
+        return True
+
+    def _process(self, frames: int) -> None:
+        peak = 0.0
+        for port in self._inports:
+            try:
+                buf = port.get_buffer()
+            except Exception:
+                continue
+            peak = max(peak, _buffer_peak(buf, frames))
+        if peak > self._period_peak:
+            self._period_peak = peak
+
+    def _try_connect_surge_outputs(self) -> None:
+        client = self._client
+        if client is None:
+            self._wired = False
+            return
+        wired = True
+        for ch in (1, 2):
+            src = f"{self.surge_client}:out_{ch}"
+            dst = f"{client.name}:in_{ch}"
+            try:
+                client.connect(src, dst)
+            except Exception as exc:
+                if "already connected" in str(exc).lower():
+                    continue
+                wired = False
+        self._wired = wired
+
+    def _surge_outputs_connected(self) -> bool:
+        return self._wired
+
+    def _shutdown_jack(self) -> None:
+        client = self._client
+        self._client = None
+        self._inports = []
+        if client is None:
+            return
+        try:
+            client.deactivate()
+            client.close()
+        except Exception:
+            pass

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -28,6 +28,7 @@ from patch_browser.scroll_widgets import ContentScrollArea, ScrollList
 from patch_browser.looper_clock_monitor import LooperClockMonitor
 from patch_browser.screen_recorder import DEFAULT_ENV_FILE, ScreenRecorder
 from patch_browser.surge_cpu_monitor import SurgeCpuMonitor
+from patch_browser.surge_peak_monitor import SurgePeakMonitor
 from patch_browser.surge_monitor import SurgeMonitor
 from patch_browser.touch_evdev import TouchEvdevBridge, evdev_bridge_enabled
 from patch_browser.touch_browser_browse import TouchBrowserBrowseMixin
@@ -143,6 +144,8 @@ class TouchPatchBrowser(
         self.surge_monitor = SurgeMonitor()
         self.cpu_monitor = SurgeCpuMonitor(self.surge_monitor)
         self.cpu_monitor.start()
+        self.peak_monitor = SurgePeakMonitor(self.surge_monitor)
+        self.peak_monitor.start()
         self.looper_monitor = LooperClockMonitor()
         self.looper_monitor.start()
         from patch_browser.engine_state_monitor import EngineStateMonitor
@@ -175,6 +178,7 @@ class TouchPatchBrowser(
 
         self.volume_level = self._load_volume_level()
         self.show_cpu_meter = self._load_ui_preference("show_cpu_meter", default=True)
+        self.show_peak_meter = self._load_ui_preference("show_peak_meter", default=True)
         self.show_looper_hud = self._load_ui_preference("show_looper_hud", default=True)
         self.poly_governor_enabled = self._load_ui_preference("poly_governor_enabled", default=True)
         self.brightness_percent = self.backlight.get_percent()
@@ -425,6 +429,7 @@ class TouchPatchBrowser(
         if self._screen_recorder is not None:
             self._screen_recorder.close()
         self.cpu_monitor.stop()
+        self.peak_monitor.stop()
         pygame.quit()
 
 

--- a/patch_browser/touch_browser_draw.py
+++ b/patch_browser/touch_browser_draw.py
@@ -386,7 +386,7 @@ class TouchBrowserDrawMixin:
 
     def _draw_peak_meter(self, rect: Rect) -> None:
         snap = self.peak_monitor.snapshot()
-        label = self.font_sm.render("PK", True, self.theme.muted)
+        label = self.font_sm.render("OUT", True, self.theme.muted)
         label_x = rect.x
         label_y = rect.y + (rect.h - label.get_height()) // 2
         self.screen.blit(label, (label_x, label_y))
@@ -397,14 +397,16 @@ class TouchBrowserDrawMixin:
         bar_rect = pygame.Rect(bar_x, bar_y, CPU_METER_BAR_W, bar_h)
         pygame.draw.rect(self.screen, self.theme.surface_alt, bar_rect, border_radius=3)
 
-        if not snap["online"] or snap["ratio"] is None:
+        if not snap["online"]:
             dash = self.font_sm.render("—", True, self.theme.muted)
             dash_x = bar_rect.x + (bar_rect.w - dash.get_width()) // 2
             dash_y = bar_rect.y + (bar_rect.h - dash.get_height()) // 2
             self.screen.blit(dash, (dash_x, dash_y))
             return
 
-        ratio = max(0.0, min(1.0, float(snap["ratio"])))
+        ratio = max(0.0, min(1.0, float(snap["ratio"] or 0.0)))
+        if ratio <= 0.0:
+            return
         fill_h = max(1, int(bar_rect.h * ratio))
         fill_rect = pygame.Rect(bar_rect.x, bar_rect.bottom - fill_h, bar_rect.w, fill_h)
         pygame.draw.rect(

--- a/patch_browser/touch_browser_draw.py
+++ b/patch_browser/touch_browser_draw.py
@@ -14,6 +14,7 @@ from patch_browser.draw_primitives import (
     draw_filter_icon,
     draw_sidebar_panel_icon,
 )
+from patch_browser.peak_meter_math import peak_meter_color_dbfs
 from patch_browser.geometry import Rect
 from patch_browser.mixer import MixerChannel
 from patch_browser.patch_identity import (
@@ -373,6 +374,46 @@ class TouchBrowserDrawMixin:
             pygame.draw.rect(self.screen, self.theme.accent, fill_rect, border_radius=10)
         text = self.font_sm.render(label, True, self.theme.muted)
         self.screen.blit(text, (rect.x, rect.y - 22))
+    def _peak_meter_color(self, dbfs: float | None):
+        bucket = peak_meter_color_dbfs(dbfs)
+        if bucket == "ok":
+            return self.theme.ok
+        if bucket == "warn":
+            return self.theme.playing
+        if bucket == "hot":
+            return self.theme.danger
+        return self.theme.muted
+
+    def _draw_peak_meter(self, rect: Rect) -> None:
+        snap = self.peak_monitor.snapshot()
+        label = self.font_sm.render("PK", True, self.theme.muted)
+        label_x = rect.x
+        label_y = rect.y + (rect.h - label.get_height()) // 2
+        self.screen.blit(label, (label_x, label_y))
+
+        bar_h = label.get_height()
+        bar_x = rect.x + label.get_width() + CPU_METER_LABEL_GAP
+        bar_y = label_y
+        bar_rect = pygame.Rect(bar_x, bar_y, CPU_METER_BAR_W, bar_h)
+        pygame.draw.rect(self.screen, self.theme.surface_alt, bar_rect, border_radius=3)
+
+        if not snap["online"] or snap["ratio"] is None:
+            dash = self.font_sm.render("—", True, self.theme.muted)
+            dash_x = bar_rect.x + (bar_rect.w - dash.get_width()) // 2
+            dash_y = bar_rect.y + (bar_rect.h - dash.get_height()) // 2
+            self.screen.blit(dash, (dash_x, dash_y))
+            return
+
+        ratio = max(0.0, min(1.0, float(snap["ratio"])))
+        fill_h = max(1, int(bar_rect.h * ratio))
+        fill_rect = pygame.Rect(bar_rect.x, bar_rect.bottom - fill_h, bar_rect.w, fill_h)
+        pygame.draw.rect(
+            self.screen,
+            self._peak_meter_color(snap["dbfs"]),
+            fill_rect,
+            border_radius=3,
+        )
+
     def _cpu_meter_color(self, percent: float) -> tuple[int, int, int]:
         if percent < 40.0:
             return self.theme.ok
@@ -571,6 +612,8 @@ class TouchBrowserDrawMixin:
         if getattr(self, "show_looper_hud", True):
             self._draw_looper_hud(self.looper_hud_rect)
         self._draw_audio_profile_badge(self.audio_profile_badge_rect)
+        if self.show_peak_meter:
+            self._draw_peak_meter(self.peak_meter_rect)
         if self.show_cpu_meter:
             self._draw_cpu_meter(self.cpu_meter_rect)
         self._draw_button(

--- a/patch_browser/touch_browser_input.py
+++ b/patch_browser/touch_browser_input.py
@@ -258,6 +258,8 @@ class TouchBrowserInputMixin:
             return "advanced_toggle"
         if self._settings_rect_hit(self.cpu_meter_toggle_rect, local_pos):
             return "cpu_meter"
+        if self._settings_rect_hit(self.peak_meter_toggle_rect, local_pos):
+            return "peak_meter"
         if self._settings_rect_hit(self.looper_sync_row_rect, local_pos):
             return "looper_sync"
         if self._settings_rect_hit(self.looper_hud_toggle_rect, local_pos):
@@ -294,6 +296,8 @@ class TouchBrowserInputMixin:
             self._toggle_global_normalization()
         elif hit == "cpu_meter":
             self._toggle_cpu_meter_visibility()
+        elif hit == "peak_meter":
+            self._toggle_peak_meter_visibility()
         elif hit == "looper_hud":
             self._toggle_looper_hud_visibility()
         elif hit == "looper_sync":

--- a/patch_browser/touch_browser_layout.py
+++ b/patch_browser/touch_browser_layout.py
@@ -83,6 +83,17 @@ class TouchBrowserLayoutMixin:
         _label_w, label_h = self._cpu_meter_text_size()
         return label_h
 
+    def _peak_meter_text_size(self) -> tuple[int, int]:
+        return self.font_sm.size("PK")
+
+    def _peak_meter_width(self) -> int:
+        label_w, _label_h = self._peak_meter_text_size()
+        return label_w + CPU_METER_LABEL_GAP + CPU_METER_BAR_W
+
+    def _peak_meter_height(self) -> int:
+        _label_w, label_h = self._peak_meter_text_size()
+        return label_h
+
     def _audio_badge_width(self) -> int:
         label_w = self.font_sm.size(header_badge_label())[0]
         return label_w + AUDIO_BADGE_PAD_X * 2
@@ -134,6 +145,19 @@ class TouchBrowserLayoutMixin:
             right_cursor -= STATUS_BAR_ITEM_GAP
         else:
             self.cpu_meter_rect = Rect(right_cursor, self.status_rect.y + 6, 0, 0)
+        if self.show_peak_meter:
+            meter_w = self._peak_meter_width()
+            right_cursor -= meter_w
+            meter_h = self._peak_meter_height()
+            self.peak_meter_rect = Rect(
+                right_cursor,
+                self.status_rect.y + (status_h - meter_h) // 2,
+                meter_w,
+                meter_h,
+            )
+            right_cursor -= STATUS_BAR_ITEM_GAP
+        else:
+            self.peak_meter_rect = Rect(right_cursor, self.status_rect.y + 6, 0, 0)
         audio_badge_w = self._audio_badge_width()
         right_cursor -= audio_badge_w
         self.audio_profile_badge_rect = Rect(

--- a/patch_browser/touch_browser_layout.py
+++ b/patch_browser/touch_browser_layout.py
@@ -84,7 +84,7 @@ class TouchBrowserLayoutMixin:
         return label_h
 
     def _peak_meter_text_size(self) -> tuple[int, int]:
-        return self.font_sm.size("PK")
+        return self.font_sm.size("OUT")
 
     def _peak_meter_width(self) -> int:
         label_w, _label_h = self._peak_meter_text_size()

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -269,9 +269,9 @@ class TouchBrowserPrefsMixin:
         self._save_ui_preference("show_peak_meter", self.show_peak_meter)
         self._layout()
         if self.show_peak_meter:
-            self._toast("Peak meter on", 1.2)
+            self._toast("Output meter on", 1.2)
         else:
-            self._toast("Peak meter off", 1.2)
+            self._toast("Output meter off", 1.2)
 
     def _toggle_looper_hud_visibility(self) -> None:
         self.show_looper_hud = not self.show_looper_hud

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -264,6 +264,15 @@ class TouchBrowserPrefsMixin:
         else:
             self._toast("CPU meter off", 1.2)
 
+    def _toggle_peak_meter_visibility(self) -> None:
+        self.show_peak_meter = not self.show_peak_meter
+        self._save_ui_preference("show_peak_meter", self.show_peak_meter)
+        self._layout()
+        if self.show_peak_meter:
+            self._toast("Peak meter on", 1.2)
+        else:
+            self._toast("Peak meter off", 1.2)
+
     def _toggle_looper_hud_visibility(self) -> None:
         self.show_looper_hud = not self.show_looper_hud
         self._save_ui_preference("show_looper_hud", self.show_looper_hud)

--- a/patch_browser/touch_browser_settings.py
+++ b/patch_browser/touch_browser_settings.py
@@ -118,6 +118,7 @@ class TouchBrowserSettingsMixin:
         y += SETTINGS_ROW_H + SETTINGS_ROW_GAP
 
         self.cpu_meter_toggle_rect = Rect(pad, y, 0, 0)
+        self.peak_meter_toggle_rect = Rect(pad, y, 0, 0)
         self.norm_global_toggle_rect = Rect(pad, y, 0, 0)
         self._surge_restart_btn = None
         self._calibrate_missing_btn = Rect(pad, y, 0, 0)
@@ -127,6 +128,10 @@ class TouchBrowserSettingsMixin:
             cpu_h = self._settings_row_height("CPU meter", inner_w, toggle=True)
             self.cpu_meter_toggle_rect = Rect(pad, y, inner_w, cpu_h)
             y += cpu_h + SETTINGS_ROW_GAP
+
+            peak_h = self._settings_row_height("Peak meter", inner_w, toggle=True)
+            self.peak_meter_toggle_rect = Rect(pad, y, inner_w, peak_h)
+            y += peak_h + SETTINGS_ROW_GAP
 
             status = self.surge_monitor.get_status_summary()
             if status.get("can_restart"):
@@ -149,6 +154,7 @@ class TouchBrowserSettingsMixin:
         self.theme_btn_rect = Rect(pad, y, 0, 0)
         self.wifi_row_rect = Rect(pad, y, 0, 0)
         self.cpu_meter_toggle_rect = Rect(pad, y, 0, 0)
+        self.peak_meter_toggle_rect = Rect(pad, y, 0, 0)
         self._surge_restart_btn = None
 
         from patch_browser.audio_profile import profile_settings_label
@@ -512,6 +518,15 @@ class TouchBrowserSettingsMixin:
                         self.show_cpu_meter,
                         has_gain=True,
                         label="CPU meter",
+                    )
+
+                peak_toggle = self._panel_local_to_screen(self.peak_meter_toggle_rect, scrolled=True)
+                if peak_toggle.h > 0:
+                    self._draw_normalize_toggle(
+                        peak_toggle,
+                        self.show_peak_meter,
+                        has_gain=True,
+                        label="Peak meter",
                     )
 
                 if self._surge_restart_btn and self._surge_restart_btn.h > 0:

--- a/patch_browser/touch_browser_settings.py
+++ b/patch_browser/touch_browser_settings.py
@@ -129,7 +129,7 @@ class TouchBrowserSettingsMixin:
             self.cpu_meter_toggle_rect = Rect(pad, y, inner_w, cpu_h)
             y += cpu_h + SETTINGS_ROW_GAP
 
-            peak_h = self._settings_row_height("Peak meter", inner_w, toggle=True)
+            peak_h = self._settings_row_height("Output meter", inner_w, toggle=True)
             self.peak_meter_toggle_rect = Rect(pad, y, inner_w, peak_h)
             y += peak_h + SETTINGS_ROW_GAP
 
@@ -526,7 +526,7 @@ class TouchBrowserSettingsMixin:
                         peak_toggle,
                         self.show_peak_meter,
                         has_gain=True,
-                        label="Peak meter",
+                        label="Output meter",
                     )
 
                 if self._surge_restart_btn and self._surge_restart_btn.h > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ python-osc>=1.9.0
 
 # Touch patch browser (5" DSI — optional on encoder-only builds)
 pygame>=2.5.0
+
+# Live peak meter (optional — parallel JACK tap; on Pi: sudo apt install python3-jack-client)
+# JACK-Client>=0.5.3

--- a/tests/test_surge_peak_monitor.py
+++ b/tests/test_surge_peak_monitor.py
@@ -1,0 +1,68 @@
+"""Tests for live peak meter math and offline monitor behavior."""
+
+from __future__ import annotations
+
+import math
+import unittest
+from unittest.mock import MagicMock
+
+from patch_browser.peak_meter_math import (
+    PEAK_METER_FLOOR_DBFS,
+    dbfs_to_meter_ratio,
+    linear_peak_to_dbfs,
+    peak_meter_color_dbfs,
+)
+from patch_browser.surge_peak_monitor import SurgePeakMonitor, _buffer_peak
+
+
+class PeakMeterMathTests(unittest.TestCase):
+    def test_silence_returns_none(self) -> None:
+        self.assertIsNone(linear_peak_to_dbfs(0.0))
+
+    def test_unity_peak_is_zero_dbfs(self) -> None:
+        db = linear_peak_to_dbfs(1.0)
+        assert db is not None
+        self.assertAlmostEqual(db, 0.0, places=6)
+
+    def test_half_peak_is_minus_six_db(self) -> None:
+        db = linear_peak_to_dbfs(0.5)
+        assert db is not None
+        self.assertAlmostEqual(db, -6.0206, places=3)
+
+    def test_floor_maps_to_zero_ratio(self) -> None:
+        self.assertEqual(dbfs_to_meter_ratio(PEAK_METER_FLOOR_DBFS), 0.0)
+
+    def test_zero_dbfs_maps_to_full_bar(self) -> None:
+        self.assertEqual(dbfs_to_meter_ratio(0.0), 1.0)
+
+    def test_color_buckets(self) -> None:
+        self.assertEqual(peak_meter_color_dbfs(-24.0), "ok")
+        self.assertEqual(peak_meter_color_dbfs(-12.0), "warn")
+        self.assertEqual(peak_meter_color_dbfs(-3.0), "hot")
+
+
+class BufferPeakTests(unittest.TestCase):
+    def test_empty_buffer(self) -> None:
+        self.assertEqual(_buffer_peak(b"", 0), 0.0)
+
+    def test_finds_max_abs_sample(self) -> None:
+        import struct
+
+        samples = struct.pack("<fff", 0.1, -0.8, 0.3)
+        self.assertAlmostEqual(_buffer_peak(samples, 3), 0.8)
+
+
+class SurgePeakMonitorOfflineTests(unittest.TestCase):
+    def test_offline_when_surge_unhealthy(self) -> None:
+        surge = MagicMock()
+        surge.check_health.return_value = (False, "down")
+        monitor = SurgePeakMonitor(surge)
+        monitor._poll_once()
+        snap = monitor.snapshot()
+        self.assertFalse(snap["online"])
+        self.assertIsNone(snap["dbfs"])
+        self.assertEqual(snap["source"], "none")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a **PK** peak dBFS bar in the touch header (left of CPU meter)
- **Passive JACK tap:** input-only `mpe-peak-meter` client fans out from `Surge XT:out_{1,2}` in parallel with `system:playback` — never downstream of the live path
- **Fail-open:** if JACK/`python3-jack-client` is missing or wiring fails, the UI shows **—** and audio is unaffected
- Settings → Advanced → **Peak meter** toggle (`show_peak_meter`, default on)

Closes #30 (scoped to peak dBFS v1; LUFS deferred).

## Test plan

- [x] `mpe test local all`
- [ ] Pi: `sudo apt install python3-jack-client` if not present
- [ ] Pi: checkout branch, restart touch browser, play — PK bar moves with output
- [ ] Confirm Surge → playback still works if peak monitor disabled or JACK client fails
- [ ] Heavy MPE soak: no new xruns vs baseline