### PR TITLE
feat: session control plane Phases 0–2 (calibration, snapshot, events)

### DIFF
--- a/Documents/specs/session-control-plane-spec.md
+++ b/Documents/specs/session-control-plane-spec.md
@@ -1,6 +1,6 @@
 # Session control plane — one owner per fact, reconciliation over sequences
 
-**Status:** Draft — 2026-08-17
+**Status:** Implemented — 2026-08-17 (Phases 0–2)
 **Author:** written after the 2026-08-17 stability session; every claim in Evidence is measured on `raspberrypi2`, not reasoned.
 
 ---

--- a/Documents/specs/session-control-plane-spec.md
+++ b/Documents/specs/session-control-plane-spec.md
@@ -1,6 +1,6 @@
 # Session control plane — one owner per fact, reconciliation over sequences
 
-**Status:** Implemented — 2026-08-17 (Phases 0–2)
+**Status:** Draft — Phases 0–2 (Pi verification pending)
 **Author:** written after the 2026-08-17 stability session; every claim in Evidence is measured on `raspberrypi2`, not reasoned.
 
 ---

--- a/patch_browser/calibration_teardown.py
+++ b/patch_browser/calibration_teardown.py
@@ -12,10 +12,12 @@ See ``patch_browser.calibration_constants`` for the env var name and helper.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
 import sys
 import time
+from collections.abc import Iterator
 
 from patch_browser.calibration_constants import (
     MPE_CALIB_FROM_BROWSER,
@@ -23,6 +25,7 @@ from patch_browser.calibration_constants import (
     calibration_from_browser,
 )
 from patch_browser.session_events import emit_event
+from patch_browser.session_snapshot import maintenance_flag_path
 
 # Looper eval stack — Restart=always units (spec Phase 0 / Appendix A).
 # Stop in reverse dependency order; start after Surge is back.
@@ -42,6 +45,35 @@ LOOPER_UNITS_START_ORDER = (
 
 def _systemctl(unit: str, verb: str) -> None:
     subprocess.run(["sudo", "systemctl", verb, f"{unit}.service"], check=False)
+
+
+def _safe_emit_event(name: str, **kwargs: object) -> None:
+    try:
+        emit_event(name, **kwargs)  # type: ignore[arg-type]
+    except (OSError, ValueError):
+        pass
+
+
+def _unit_is_active(unit: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", f"{unit}.service"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return (result.stdout or "").strip() == "active"
+
+
+def ensure_looper_units_running() -> None:
+    """Start looper units left stopped by an aborted calibration (no maintenance flag)."""
+    if maintenance_flag_path().exists():
+        return
+    for unit in LOOPER_UNITS_START_ORDER:
+        if not _unit_is_active(unit):
+            _systemctl(unit, "start")
 
 
 def unload_snd_aloop_if_idle() -> None:
@@ -67,13 +99,13 @@ def stop_mpe_audio_services() -> None:
     units.extend(LOOPER_UNITS_STOP_ORDER)
     for unit in units:
         _systemctl(unit, "stop")
-    emit_event(
+    _safe_emit_event(
         "looper.units.stopped",
         detail="calibration",
         source="calibration_teardown.py",
         fields={"units": ",".join(LOOPER_UNITS_STOP_ORDER)},
     )
-    emit_event("mode.changed", detail="calibration-stop", source="calibration_teardown.py")
+    _safe_emit_event("mode.changed", detail="calibration-stop", source="calibration_teardown.py")
     time.sleep(1)
     subprocess.run(["sudo", "pkill", "-f", "surge-xt-cli"], check=False)
     time.sleep(0.5)
@@ -101,12 +133,22 @@ def restore_mpe_audio_services(*, restart_browser: bool = True) -> None:
     time.sleep(1)
     for unit in LOOPER_UNITS_START_ORDER:
         _systemctl(unit, "start")
-    emit_event(
+    _safe_emit_event(
         "looper.units.started",
         detail="calibration-restore",
         source="calibration_teardown.py",
         fields={"units": ",".join(LOOPER_UNITS_START_ORDER)},
     )
-    emit_event("mode.changed", detail="calibration-restore", source="calibration_teardown.py")
+    _safe_emit_event("mode.changed", detail="calibration-restore", source="calibration_teardown.py")
     if restart_browser and not calibration_from_browser():
         _systemctl("touch-patch-browser", "start")
+
+
+@contextlib.contextmanager
+def calibration_audio_scope(*, restart_browser: bool = True) -> Iterator[None]:
+    """Stop production stack for calibration; always restore on any exit path."""
+    stop_mpe_audio_services()
+    try:
+        yield
+    finally:
+        restore_mpe_audio_services(restart_browser=restart_browser)

--- a/patch_browser/calibration_teardown.py
+++ b/patch_browser/calibration_teardown.py
@@ -22,6 +22,26 @@ from patch_browser.calibration_constants import (
     TOUCH_PATCH_BROWSER_SCRIPT,
     calibration_from_browser,
 )
+from patch_browser.session_events import emit_event
+
+# Looper eval stack — Restart=always units (spec Phase 0 / Appendix A).
+# Stop in reverse dependency order; start after Surge is back.
+LOOPER_UNITS_STOP_ORDER = (
+    "mpe-apc-bench",
+    "sl-hud-monitor",
+    "sl-watchdog",
+    "mpe-sooperlooper",
+)
+LOOPER_UNITS_START_ORDER = (
+    "mpe-sooperlooper",
+    "mpe-apc-bench",
+    "sl-hud-monitor",
+    "sl-watchdog",
+)
+
+
+def _systemctl(unit: str, verb: str) -> None:
+    subprocess.run(["sudo", "systemctl", verb, f"{unit}.service"], check=False)
 
 
 def unload_snd_aloop_if_idle() -> None:
@@ -39,13 +59,21 @@ def unload_snd_aloop_if_idle() -> None:
 
 
 def stop_mpe_audio_services() -> None:
-    """Stop production Surge, pressure remapper, and patch browser (unless browser handoff)."""
+    """Stop production Surge, pressure remapper, patch browser, and looper stack."""
     units: list[str] = []
     if not calibration_from_browser():
         units.append("touch-patch-browser")
     units.extend(["mpe-pressure-remap", "surge-poly-governor", "surge-xt-cli"])
+    units.extend(LOOPER_UNITS_STOP_ORDER)
     for unit in units:
-        subprocess.run(["sudo", "systemctl", "stop", f"{unit}.service"], check=False)
+        _systemctl(unit, "stop")
+    emit_event(
+        "looper.units.stopped",
+        detail="calibration",
+        source="calibration_teardown.py",
+        fields={"units": ",".join(LOOPER_UNITS_STOP_ORDER)},
+    )
+    emit_event("mode.changed", detail="calibration-stop", source="calibration_teardown.py")
     time.sleep(1)
     subprocess.run(["sudo", "pkill", "-f", "surge-xt-cli"], check=False)
     time.sleep(0.5)
@@ -67,8 +95,18 @@ def restore_mpe_audio_services(*, restart_browser: bool = True) -> None:
     subprocess.run(["sudo", "pkill", "-f", "surge-xt-cli"], check=False)
     time.sleep(0.5)
     unload_snd_aloop_if_idle()
-    subprocess.run(["sudo", "systemctl", "start", "mpe-pressure-remap.service"], check=False)
-    subprocess.run(["sudo", "systemctl", "start", "surge-poly-governor.service"], check=False)
-    subprocess.run(["sudo", "systemctl", "start", "surge-xt-cli.service"], check=False)
+    _systemctl("mpe-pressure-remap", "start")
+    _systemctl("surge-poly-governor", "start")
+    _systemctl("surge-xt-cli", "start")
+    time.sleep(1)
+    for unit in LOOPER_UNITS_START_ORDER:
+        _systemctl(unit, "start")
+    emit_event(
+        "looper.units.started",
+        detail="calibration-restore",
+        source="calibration_teardown.py",
+        fields={"units": ",".join(LOOPER_UNITS_START_ORDER)},
+    )
+    emit_event("mode.changed", detail="calibration-restore", source="calibration_teardown.py")
     if restart_browser and not calibration_from_browser():
-        subprocess.run(["sudo", "systemctl", "start", "touch-patch-browser"], check=False)
+        _systemctl("touch-patch-browser", "start")

--- a/patch_browser/calibration_teardown.py
+++ b/patch_browser/calibration_teardown.py
@@ -25,7 +25,12 @@ from patch_browser.calibration_constants import (
     calibration_from_browser,
 )
 from patch_browser.session_events import emit_event
-from patch_browser.session_snapshot import maintenance_flag_path
+from patch_browser.session_snapshot import (
+    clear_maintenance_flag,
+    maintenance_mode_active,
+    set_maintenance_flag,
+    systemd_unit_active,
+)
 
 # Looper eval stack — Restart=always units (spec Phase 0 / Appendix A).
 # Stop in reverse dependency order; start after Surge is back.
@@ -54,25 +59,12 @@ def _safe_emit_event(name: str, **kwargs: object) -> None:
         pass
 
 
-def _unit_is_active(unit: str) -> bool:
-    try:
-        result = subprocess.run(
-            ["systemctl", "is-active", f"{unit}.service"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except OSError:
-        return False
-    return (result.stdout or "").strip() == "active"
-
-
 def ensure_looper_units_running() -> None:
     """Start looper units left stopped by an aborted calibration (no maintenance flag)."""
-    if maintenance_flag_path().exists():
+    if maintenance_mode_active():
         return
     for unit in LOOPER_UNITS_START_ORDER:
-        if not _unit_is_active(unit):
+        if systemd_unit_active(unit) is False:
             _systemctl(unit, "start")
 
 
@@ -92,6 +84,7 @@ def unload_snd_aloop_if_idle() -> None:
 
 def stop_mpe_audio_services() -> None:
     """Stop production Surge, pressure remapper, patch browser, and looper stack."""
+    set_maintenance_flag(source="calibration")
     units: list[str] = []
     if not calibration_from_browser():
         units.append("touch-patch-browser")
@@ -142,13 +135,17 @@ def restore_mpe_audio_services(*, restart_browser: bool = True) -> None:
     _safe_emit_event("mode.changed", detail="calibration-restore", source="calibration_teardown.py")
     if restart_browser and not calibration_from_browser():
         _systemctl("touch-patch-browser", "start")
+    clear_maintenance_flag()
 
 
 @contextlib.contextmanager
-def calibration_audio_scope(*, restart_browser: bool = True) -> Iterator[None]:
-    """Stop production stack for calibration; always restore on any exit path."""
+def calibration_audio_scope(*, restart_browser: bool = True, restore: bool = True) -> Iterator[None]:
+    """Stop production stack for calibration; always restore or clear maintenance on exit."""
     stop_mpe_audio_services()
     try:
         yield
     finally:
-        restore_mpe_audio_services(restart_browser=restart_browser)
+        if restore:
+            restore_mpe_audio_services(restart_browser=restart_browser)
+        else:
+            clear_maintenance_flag()

--- a/patch_browser/mpe_run_dir.py
+++ b/patch_browser/mpe_run_dir.py
@@ -1,0 +1,21 @@
+"""Resolve MPE runtime state directory — mirrors ``mpe_run_dir()`` in audio-engine.sh."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def run_dir() -> Path:
+    """Return writable runtime dir; fall back to ``${TMPDIR}/mpe`` like bash."""
+    configured = Path(os.environ.get("MPE_RUN_DIR", "/run/mpe"))
+    if not configured.is_dir():
+        try:
+            configured.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+    if configured.is_dir() and os.access(configured, os.W_OK):
+        return configured
+    fallback = Path(os.environ.get("TMPDIR", "/tmp")) / "mpe"
+    fallback.mkdir(parents=True, exist_ok=True)
+    return fallback

--- a/patch_browser/session_events.py
+++ b/patch_browser/session_events.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
+
+from patch_browser.mpe_run_dir import run_dir
 
 EVENT_NAMES = frozenset(
     {
@@ -28,10 +31,6 @@ EVENT_NAMES = frozenset(
 
 EVENTS_FILENAME = "events.jsonl"
 MAX_EVENTS = 2000
-
-
-def run_dir() -> Path:
-    return Path(os.environ.get("MPE_RUN_DIR", "/run/mpe"))
 
 
 def events_path(*, run: Path | None = None) -> Path:
@@ -83,6 +82,27 @@ def trim_ring_buffer(lines: list[str], *, max_events: int = MAX_EVENTS) -> list[
     return lines[-max_events:]
 
 
+def _maybe_rotate_events(path: Path, *, max_events: int) -> None:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    if len(lines) <= max_events:
+        return
+    trimmed = trim_ring_buffer(lines, max_events=max_events)
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, prefix=f"{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(trimmed) + ("\n" if trimmed else ""))
+        os.chmod(tmp_path, 0o644)
+        os.replace(tmp_path, path)
+    except OSError:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
 def emit_event(
     name: str,
     *,
@@ -98,20 +118,14 @@ def emit_event(
     path = events_path(run=run)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    existing: list[str] = []
-    if path.exists():
-        try:
-            existing = path.read_text(encoding="utf-8").splitlines()
-        except OSError:
-            existing = []
+    line = event_line(event) + "\n"
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.write(fd, line.encode("utf-8"))
+    finally:
+        os.close(fd)
 
-    existing.append(event_line(event))
-    existing = trim_ring_buffer(existing, max_events=max_events)
-
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text("\n".join(existing) + ("\n" if existing else ""), encoding="utf-8")
-    os.chmod(tmp, 0o644)
-    tmp.replace(path)
+    _maybe_rotate_events(path, max_events=max_events)
     return event
 
 
@@ -135,6 +149,8 @@ def read_events(
         if name is not None and parsed.get("event") != name:
             continue
         out.append(parsed)
-    if limit is not None and limit >= 0:
+    if limit is not None:
+        if limit <= 0:
+            return []
         out = out[-limit:]
     return out

--- a/patch_browser/session_events.py
+++ b/patch_browser/session_events.py
@@ -1,0 +1,140 @@
+"""Session control plane event stream — Phase 2 (spec criterion 9).
+
+Append-only JSONL ring buffer under ``/run/mpe/events.jsonl``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+EVENT_NAMES = frozenset(
+    {
+        "engine.started",
+        "engine.exited",
+        "grid.established",
+        "grid.dropped",
+        "buffer.changed",
+        "client.registered",
+        "client.leaked",
+        "mode.changed",
+        "looper.units.stopped",
+        "looper.units.started",
+    }
+)
+
+EVENTS_FILENAME = "events.jsonl"
+MAX_EVENTS = 2000
+
+
+def run_dir() -> Path:
+    return Path(os.environ.get("MPE_RUN_DIR", "/run/mpe"))
+
+
+def events_path(*, run: Path | None = None) -> Path:
+    return (run or run_dir()) / EVENTS_FILENAME
+
+
+def format_event(
+    name: str,
+    *,
+    detail: str = "",
+    source: str = "",
+    fields: dict[str, Any] | None = None,
+    ts: float | None = None,
+) -> dict[str, Any]:
+    if name not in EVENT_NAMES:
+        raise ValueError(f"unknown event name: {name}")
+    payload: dict[str, Any] = {
+        "ts": time.time() if ts is None else ts,
+        "event": name,
+        "source": source or "unknown",
+    }
+    if detail:
+        payload["detail"] = detail
+    if fields:
+        payload.update(fields)
+    return payload
+
+
+def event_line(event: dict[str, Any]) -> str:
+    return json.dumps(event, sort_keys=True, separators=(",", ":"))
+
+
+def parse_event_line(line: str) -> dict[str, Any] | None:
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        raw = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict) or "event" not in raw:
+        return None
+    return raw
+
+
+def trim_ring_buffer(lines: list[str], *, max_events: int = MAX_EVENTS) -> list[str]:
+    if len(lines) <= max_events:
+        return lines
+    return lines[-max_events:]
+
+
+def emit_event(
+    name: str,
+    *,
+    detail: str = "",
+    source: str = "",
+    fields: dict[str, Any] | None = None,
+    ts: float | None = None,
+    run: Path | None = None,
+    max_events: int = MAX_EVENTS,
+) -> dict[str, Any]:
+    """Append one structured event; rotate file when over ``max_events``."""
+    event = format_event(name, detail=detail, source=source, fields=fields, ts=ts)
+    path = events_path(run=run)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: list[str] = []
+    if path.exists():
+        try:
+            existing = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            existing = []
+
+    existing.append(event_line(event))
+    existing = trim_ring_buffer(existing, max_events=max_events)
+
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text("\n".join(existing) + ("\n" if existing else ""), encoding="utf-8")
+    os.chmod(tmp, 0o644)
+    tmp.replace(path)
+    return event
+
+
+def read_events(
+    path: Path | None = None,
+    *,
+    run: Path | None = None,
+    limit: int | None = None,
+    name: str | None = None,
+) -> list[dict[str, Any]]:
+    target = path or events_path(run=run)
+    try:
+        lines = target.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    out: list[dict[str, Any]] = []
+    for line in lines:
+        parsed = parse_event_line(line)
+        if parsed is None:
+            continue
+        if name is not None and parsed.get("event") != name:
+            continue
+        out.append(parsed)
+    if limit is not None and limit >= 0:
+        out = out[-limit:]
+    return out

--- a/patch_browser/session_snapshot.py
+++ b/patch_browser/session_snapshot.py
@@ -1,0 +1,294 @@
+"""Session control plane snapshot — schema v1 (spec D6, Phase 1).
+
+Aggregates existing runtime truth under ``/run/mpe/session.snapshot.json``.
+Does not own engine state; readers treat stale sub-sources as unknown (never
+last-known-good).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from patch_browser.audio_engine import read_engine_state
+from patch_browser.sl_hud_state import read_sl_hud_state
+
+SCHEMA_VERSION = 1
+STALE_THRESHOLD_S = 1.5
+PUBLISH_INTERVAL_S = 0.5
+SEQ_STALE_FACTOR = 2
+
+SNAPSHOT_FILENAME = "session.snapshot.json"
+SEQ_FILENAME = "session.snapshot.seq"
+
+VALID_LOOPER_POLICIES = frozenset({"eval", "adopt", "disabled"})
+VALID_MODES = frozenset({"ok", "recovering", "failed", "maintenance"})
+
+
+def run_dir() -> Path:
+    return Path(os.environ.get("MPE_RUN_DIR", "/run/mpe"))
+
+
+def snapshot_path(*, run: Path | None = None) -> Path:
+    base = run or run_dir()
+    return base / SNAPSHOT_FILENAME
+
+
+def seq_path(*, run: Path | None = None) -> Path:
+    base = run or run_dir()
+    return base / SEQ_FILENAME
+
+
+def maintenance_flag_path(*, run: Path | None = None) -> Path:
+    base = run or run_dir()
+    return base / "maintenance"
+
+
+def _parse_epoch(value: str | None) -> float:
+    if not value:
+        return 0.0
+    try:
+        parsed = float(str(value).strip())
+    except ValueError:
+        return 0.0
+    return parsed if parsed > 0 else 0.0
+
+
+def field_age_stale(updated: float, *, now: float, threshold: float = STALE_THRESHOLD_S) -> bool:
+    if updated <= 0:
+        return True
+    return (now - updated) >= threshold
+
+
+def looper_policy(*, looper_policy_env: str | None = None) -> str:
+    """D15 placeholder — ``eval`` until adopt/kill verdict lands."""
+    raw = (looper_policy_env if looper_policy_env is not None else os.environ.get("MPE_LOOPER_POLICY", "")).strip()
+    if raw in VALID_LOOPER_POLICIES:
+        return raw
+    return "eval"
+
+
+def looper_guard_label(*, looper_enabled: str | None = None) -> str:
+    """D16 reflection — inverted ``MPE_LOOPER_ENABLED`` semantics."""
+    enabled = looper_enabled if looper_enabled is not None else os.environ.get("MPE_LOOPER_ENABLED", "0")
+    return "guarded" if str(enabled).strip() == "1" else "off"
+
+
+def _wrap_field(
+    value: Any,
+    *,
+    source: str,
+    updated: float,
+    now: float,
+    threshold: float = STALE_THRESHOLD_S,
+) -> dict[str, Any]:
+    stale = field_age_stale(updated, now=now, threshold=threshold)
+    payload: dict[str, Any] = {
+        "source": source,
+        "updated": updated,
+        "stale": stale,
+    }
+    if stale:
+        payload["value"] = None
+    else:
+        payload["value"] = value
+    return payload
+
+
+def _read_kv_file(path: Path) -> dict[str, str]:
+    return read_engine_state(path)
+
+
+def derive_mode(
+    engine: dict[str, str],
+    *,
+    maintenance: bool = False,
+) -> str:
+    if maintenance:
+        return "maintenance"
+    state = (engine.get("state") or "").strip()
+    if state in VALID_MODES:
+        return state
+    if state:
+        return state
+    return "ok"
+
+
+def build_snapshot(
+    *,
+    now: float | None = None,
+    run: Path | None = None,
+    hud_path: Path | None = None,
+    looper_policy_env: str | None = None,
+    looper_enabled: str | None = None,
+    seq: int | None = None,
+) -> dict[str, Any]:
+    """Aggregate existing truth into schema v1 document."""
+    base = run or run_dir()
+    now_ts = time.time() if now is None else now
+
+    engine_path = base / "engine.state"
+    jack_path = base / "jack.state"
+    surge_path = base / "surge.state"
+    reconcile_path = base / "engine-reconcile.state"
+
+    engine_raw = _read_kv_file(engine_path)
+    jack_raw = _read_kv_file(jack_path)
+    surge_raw = _read_kv_file(surge_path)
+    reconcile_raw = _read_kv_file(reconcile_path)
+
+    engine_updated = _parse_epoch(engine_raw.get("updated"))
+    jack_updated = _parse_epoch(jack_raw.get("started"))
+    surge_updated = _parse_epoch(surge_raw.get("started"))
+
+    maintenance = maintenance_flag_path(run=base).exists()
+    mode = derive_mode(engine_raw, maintenance=maintenance)
+
+    hud = read_sl_hud_state(now=now_ts) if hud_path is None else _read_hud_at(hud_path, now=now_ts)
+
+    if seq is None:
+        seq = read_seq(run=base) + 1
+
+    policy = looper_policy(looper_policy_env=looper_policy_env)
+    guard = looper_guard_label(looper_enabled=looper_enabled)
+
+    return {
+        "schema": SCHEMA_VERSION,
+        "seq": seq,
+        "published_at": now_ts,
+        "mode": mode,
+        "engine": _wrap_field(
+            engine_raw or None,
+            source=str(engine_path),
+            updated=engine_updated,
+            now=now_ts,
+        ),
+        "jack": _wrap_field(
+            jack_raw or None,
+            source=str(jack_path),
+            updated=jack_updated,
+            now=now_ts,
+        ),
+        "surge": _wrap_field(
+            surge_raw or None,
+            source=str(surge_path),
+            updated=surge_updated,
+            now=now_ts,
+        ),
+        "reconcile": _wrap_field(
+            reconcile_raw or None,
+            source=str(reconcile_path),
+            updated=_parse_epoch(reconcile_raw.get("last_restart")),
+            now=now_ts,
+            threshold=STALE_THRESHOLD_S * 4,
+        ),
+        "looper": {
+            "policy": {"value": policy, "source": "env:MPE_LOOPER_POLICY|default:eval", "stale": False},
+            "guard": {
+                "value": guard,
+                "source": "env:MPE_LOOPER_ENABLED",
+                "stale": False,
+            },
+            "hud": _wrap_field(
+                hud or None,
+                source=str(hud_path or os.environ.get("MPE_SL_HUD_STATE_FILE", Path.home() / ".mpe_sl_hud_state.json")),
+                updated=float(hud.get("updated_at") or 0.0) if hud else 0.0,
+                now=now_ts,
+            ),
+        },
+    }
+
+
+def _read_hud_at(path: Path, *, now: float) -> dict:
+    prev = os.environ.get("MPE_SL_HUD_STATE_FILE")
+    os.environ["MPE_SL_HUD_STATE_FILE"] = str(path)
+    try:
+        return read_sl_hud_state(now=now)
+    finally:
+        if prev is None:
+            os.environ.pop("MPE_SL_HUD_STATE_FILE", None)
+        else:
+            os.environ["MPE_SL_HUD_STATE_FILE"] = prev
+
+
+def read_seq(*, run: Path | None = None) -> int:
+    path = seq_path(run=run)
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+        return max(0, int(raw))
+    except (OSError, ValueError):
+        return 0
+
+
+def write_seq(value: int, *, run: Path | None = None) -> None:
+    path = seq_path(run=run)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(f"{value}\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def write_snapshot(snapshot: dict[str, Any], *, run: Path | None = None) -> Path:
+    """Atomically publish snapshot JSON and bump seq counter."""
+    base = run or run_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    target = snapshot_path(run=base)
+    tmp = target.with_suffix(".tmp")
+    seq = int(snapshot.get("seq") or 0)
+    tmp.write_text(json.dumps(snapshot, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+    os.chmod(tmp, 0o644)
+    tmp.replace(target)
+    if seq > 0:
+        write_seq(seq, run=base)
+    return target
+
+
+def read_snapshot(
+    path: Path | None = None,
+    *,
+    now: float | None = None,
+    max_schema: int | None = SCHEMA_VERSION,
+) -> dict[str, Any]:
+    """Load snapshot; raise ``ValueError`` on unknown schema major."""
+    target = path or snapshot_path()
+    now_ts = time.time() if now is None else now
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"snapshot unreadable: {target}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(f"snapshot not an object: {target}")
+    schema = int(raw.get("schema") or 0)
+    if max_schema is not None and schema > max_schema:
+        raise ValueError(f"unsupported snapshot schema {schema} (max {max_schema})")
+    published = float(raw.get("published_at") or 0.0)
+    seq = int(raw.get("seq") or 0)
+    seq_stale = published > 0 and (now_ts - published) > (PUBLISH_INTERVAL_S * SEQ_STALE_FACTOR)
+    raw["_meta"] = {
+        "snapshot_stale": seq_stale,
+        "age_s": (now_ts - published) if published > 0 else None,
+    }
+    return raw
+
+
+def publish_snapshot(**kwargs: Any) -> Path:
+    snap = build_snapshot(**kwargs)
+    return write_snapshot(snap, run=kwargs.get("run"))
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Publish session.snapshot.json (Phase 1)")
+    parser.add_argument("--run-dir", default=os.environ.get("MPE_RUN_DIR", "/run/mpe"))
+    args = parser.parse_args()
+    path = publish_snapshot(run=Path(args.run_dir))
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/patch_browser/session_snapshot.py
+++ b/patch_browser/session_snapshot.py
@@ -7,17 +7,22 @@ last-known-good).
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
+import subprocess
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from patch_browser.audio_engine import read_engine_state
+from patch_browser.mpe_run_dir import run_dir
 from patch_browser.sl_hud_state import read_sl_hud_state
 
 SCHEMA_VERSION = 1
 STALE_THRESHOLD_S = 1.5
+ENGINE_FALLBACK_STALE_S = 86400.0
 PUBLISH_INTERVAL_S = 0.5
 SEQ_STALE_FACTOR = 2
 
@@ -27,9 +32,8 @@ SEQ_FILENAME = "session.snapshot.seq"
 VALID_LOOPER_POLICIES = frozenset({"eval", "adopt", "disabled"})
 VALID_MODES = frozenset({"ok", "recovering", "failed", "maintenance"})
 
-
-def run_dir() -> Path:
-    return Path(os.environ.get("MPE_RUN_DIR", "/run/mpe"))
+JACK_UNIT = "mpe-jackd"
+SURGE_UNIT = "surge-xt-cli"
 
 
 def snapshot_path(*, run: Path | None = None) -> Path:
@@ -63,6 +67,70 @@ def field_age_stale(updated: float, *, now: float, threshold: float = STALE_THRE
     return (now - updated) >= threshold
 
 
+def systemd_unit_active(unit: str) -> bool | None:
+    """Return True/False when systemctl answers; None when unavailable."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", f"{unit}.service"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    state = (result.stdout or "").strip()
+    if state == "active":
+        return True
+    if state in {"inactive", "failed", "deactivating"}:
+        return False
+    return None
+
+
+def process_field_stale(
+    raw: dict[str, str] | None,
+    *,
+    unit: str,
+    started_key: str,
+    unit_active: Callable[[str], bool | None],
+) -> bool:
+    """Liveness-based staleness for transition-only state (jack/surge ``started``)."""
+    if not raw:
+        return True
+    if _parse_epoch(raw.get(started_key)) <= 0:
+        return True
+    active = unit_active(unit)
+    if active is False:
+        return True
+    return False
+
+
+def engine_field_stale(
+    raw: dict[str, str] | None,
+    *,
+    now: float,
+    unit_active: Callable[[str], bool | None],
+) -> bool:
+    """Engine state is transition-written; trust it while Surge is live."""
+    if not raw:
+        return True
+    updated = _parse_epoch(raw.get("updated"))
+    if updated <= 0:
+        return True
+    engine_active = (raw.get("active") or "").strip()
+    surge_live = unit_active(SURGE_UNIT)
+    if engine_active == "jack" and surge_live is False:
+        return True
+    if surge_live is True:
+        return False
+    return (now - updated) >= ENGINE_FALLBACK_STALE_S
+
+
+def reconcile_field_stale(raw: dict[str, str] | None) -> bool:
+    """``last_restart=0`` means never restarted — valid, not stale."""
+    return not raw
+
+
 def looper_policy(*, looper_policy_env: str | None = None) -> str:
     """D15 placeholder — ``eval`` until adopt/kill verdict lands."""
     raw = (looper_policy_env if looper_policy_env is not None else os.environ.get("MPE_LOOPER_POLICY", "")).strip()
@@ -82,19 +150,14 @@ def _wrap_field(
     *,
     source: str,
     updated: float,
-    now: float,
-    threshold: float = STALE_THRESHOLD_S,
+    stale: bool,
 ) -> dict[str, Any]:
-    stale = field_age_stale(updated, now=now, threshold=threshold)
     payload: dict[str, Any] = {
         "source": source,
         "updated": updated,
         "stale": stale,
     }
-    if stale:
-        payload["value"] = None
-    else:
-        payload["value"] = value
+    payload["value"] = None if stale else value
     return payload
 
 
@@ -113,7 +176,7 @@ def derive_mode(
     if state in VALID_MODES:
         return state
     if state:
-        return state
+        return "failed"
     return "ok"
 
 
@@ -125,10 +188,12 @@ def build_snapshot(
     looper_policy_env: str | None = None,
     looper_enabled: str | None = None,
     seq: int | None = None,
+    unit_active: Callable[[str], bool | None] | None = None,
 ) -> dict[str, Any]:
     """Aggregate existing truth into schema v1 document."""
     base = run or run_dir()
     now_ts = time.time() if now is None else now
+    check_unit = unit_active or systemd_unit_active
 
     engine_path = base / "engine.state"
     jack_path = base / "jack.state"
@@ -147,13 +212,20 @@ def build_snapshot(
     maintenance = maintenance_flag_path(run=base).exists()
     mode = derive_mode(engine_raw, maintenance=maintenance)
 
-    hud = read_sl_hud_state(now=now_ts) if hud_path is None else _read_hud_at(hud_path, now=now_ts)
+    default_hud = Path(os.environ.get("MPE_SL_HUD_STATE_FILE", str(Path.home() / ".mpe_sl_hud_state.json")))
+    hud_file = hud_path or default_hud
+    hud = read_sl_hud_state(path=hud_file, now=now_ts)
 
     if seq is None:
-        seq = read_seq(run=base) + 1
+        seq = next_seq(run=base)
 
     policy = looper_policy(looper_policy_env=looper_policy_env)
     guard = looper_guard_label(looper_enabled=looper_enabled)
+
+    engine_stale = engine_field_stale(engine_raw, now=now_ts, unit_active=check_unit)
+    jack_stale = process_field_stale(jack_raw, unit=JACK_UNIT, started_key="started", unit_active=check_unit)
+    surge_stale = process_field_stale(surge_raw, unit=SURGE_UNIT, started_key="started", unit_active=check_unit)
+    reconcile_stale = reconcile_field_stale(reconcile_raw)
 
     return {
         "schema": SCHEMA_VERSION,
@@ -164,26 +236,25 @@ def build_snapshot(
             engine_raw or None,
             source=str(engine_path),
             updated=engine_updated,
-            now=now_ts,
+            stale=engine_stale,
         ),
         "jack": _wrap_field(
             jack_raw or None,
             source=str(jack_path),
             updated=jack_updated,
-            now=now_ts,
+            stale=jack_stale,
         ),
         "surge": _wrap_field(
             surge_raw or None,
             source=str(surge_path),
             updated=surge_updated,
-            now=now_ts,
+            stale=surge_stale,
         ),
         "reconcile": _wrap_field(
             reconcile_raw or None,
             source=str(reconcile_path),
             updated=_parse_epoch(reconcile_raw.get("last_restart")),
-            now=now_ts,
-            threshold=STALE_THRESHOLD_S * 4,
+            stale=reconcile_stale,
         ),
         "looper": {
             "policy": {"value": policy, "source": "env:MPE_LOOPER_POLICY|default:eval", "stale": False},
@@ -194,24 +265,12 @@ def build_snapshot(
             },
             "hud": _wrap_field(
                 hud or None,
-                source=str(hud_path or os.environ.get("MPE_SL_HUD_STATE_FILE", Path.home() / ".mpe_sl_hud_state.json")),
+                source=str(hud_file),
                 updated=float(hud.get("updated_at") or 0.0) if hud else 0.0,
-                now=now_ts,
+                stale=field_age_stale(float(hud.get("updated_at") or 0.0), now=now_ts) if hud else True,
             ),
         },
     }
-
-
-def _read_hud_at(path: Path, *, now: float) -> dict:
-    prev = os.environ.get("MPE_SL_HUD_STATE_FILE")
-    os.environ["MPE_SL_HUD_STATE_FILE"] = str(path)
-    try:
-        return read_sl_hud_state(now=now)
-    finally:
-        if prev is None:
-            os.environ.pop("MPE_SL_HUD_STATE_FILE", None)
-        else:
-            os.environ["MPE_SL_HUD_STATE_FILE"] = prev
 
 
 def read_seq(*, run: Path | None = None) -> int:
@@ -223,10 +282,29 @@ def read_seq(*, run: Path | None = None) -> int:
         return 0
 
 
+def next_seq(*, run: Path | None = None) -> int:
+    """Atomically increment and return the next snapshot sequence number."""
+    path = seq_path(run=run)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.touch(mode=0o644, exist_ok=True)
+    with path.open("r+", encoding="utf-8") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        raw = handle.read().strip()
+        current = max(0, int(raw)) if raw else 0
+        value = current + 1
+        handle.seek(0)
+        handle.truncate()
+        handle.write(f"{value}\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        return value
+
+
 def write_seq(value: int, *, run: Path | None = None) -> None:
     path = seq_path(run=run)
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
     tmp.write_text(f"{value}\n", encoding="utf-8")
     tmp.replace(path)
 
@@ -236,7 +314,7 @@ def write_snapshot(snapshot: dict[str, Any], *, run: Path | None = None) -> Path
     base = run or run_dir()
     base.mkdir(parents=True, exist_ok=True)
     target = snapshot_path(run=base)
-    tmp = target.with_suffix(".tmp")
+    tmp = target.with_name(f"{target.name}.tmp.{os.getpid()}")
     seq = int(snapshot.get("seq") or 0)
     tmp.write_text(json.dumps(snapshot, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
     os.chmod(tmp, 0o644)
@@ -265,7 +343,6 @@ def read_snapshot(
     if max_schema is not None and schema > max_schema:
         raise ValueError(f"unsupported snapshot schema {schema} (max {max_schema})")
     published = float(raw.get("published_at") or 0.0)
-    seq = int(raw.get("seq") or 0)
     seq_stale = published > 0 and (now_ts - published) > (PUBLISH_INTERVAL_S * SEQ_STALE_FACTOR)
     raw["_meta"] = {
         "snapshot_stale": seq_stale,
@@ -283,9 +360,10 @@ def main() -> int:
     import argparse
 
     parser = argparse.ArgumentParser(description="Publish session.snapshot.json (Phase 1)")
-    parser.add_argument("--run-dir", default=os.environ.get("MPE_RUN_DIR", "/run/mpe"))
+    parser.add_argument("--run-dir", default=None, help="Override MPE_RUN_DIR (default: resolved run dir)")
     args = parser.parse_args()
-    path = publish_snapshot(run=Path(args.run_dir))
+    run = Path(args.run_dir) if args.run_dir else None
+    path = publish_snapshot(run=run)
     print(path)
     return 0
 

--- a/patch_browser/session_snapshot.py
+++ b/patch_browser/session_snapshot.py
@@ -34,6 +34,7 @@ VALID_MODES = frozenset({"ok", "recovering", "failed", "maintenance"})
 
 JACK_UNIT = "mpe-jackd"
 SURGE_UNIT = "surge-xt-cli"
+ENGINE_STATE_WRITER_UNIT = "surge-watchdog"
 
 
 def snapshot_path(*, run: Path | None = None) -> Path:
@@ -110,7 +111,10 @@ def clear_maintenance_flag(*, run: Path | None = None) -> None:
 
 
 def maintenance_mode_active(*, run: Path | None = None, now: float | None = None) -> bool:
-    """True while maintenance flag exists, unexpired, and setter PID is alive."""
+    """True while maintenance flag exists, unexpired, and setter PID is alive.
+
+    Side effect: expired or dead-PID flags are unlinked (self-clearing D11).
+    """
     raw = read_maintenance_flag(run=run)
     if not raw:
         return False
@@ -185,12 +189,16 @@ def engine_field_stale(
     *,
     unit_active: Callable[[str], bool | None],
 ) -> bool:
-    """Engine state is transition-written; trust it only while Surge is confirmed live."""
+    """Engine state freshness follows the writer (surge-watchdog), not Surge itself.
+
+    During recovery Surge is down but watchdog has just published state=recovering;
+    gating on surge-xt-cli would null the field exactly when it carries the reason.
+    """
     if not raw:
         return True
     if _parse_epoch(raw.get("updated")) <= 0:
         return True
-    return unit_active(SURGE_UNIT) is not True
+    return unit_active(ENGINE_STATE_WRITER_UNIT) is not True
 
 
 def reconcile_field_stale(raw: dict[str, str] | None) -> bool:

--- a/patch_browser/session_snapshot.py
+++ b/patch_browser/session_snapshot.py
@@ -22,9 +22,9 @@ from patch_browser.sl_hud_state import read_sl_hud_state
 
 SCHEMA_VERSION = 1
 STALE_THRESHOLD_S = 1.5
-ENGINE_FALLBACK_STALE_S = 86400.0
 PUBLISH_INTERVAL_S = 0.5
 SEQ_STALE_FACTOR = 2
+MAINTENANCE_DEFAULT_DEADLINE_S = float(os.environ.get("MPE_MAINTENANCE_DEADLINE_S", "1800"))
 
 SNAPSHOT_FILENAME = "session.snapshot.json"
 SEQ_FILENAME = "session.snapshot.seq"
@@ -61,6 +61,71 @@ def _parse_epoch(value: str | None) -> float:
     return parsed if parsed > 0 else 0.0
 
 
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def read_maintenance_flag(*, run: Path | None = None) -> dict[str, str]:
+    path = maintenance_flag_path(run=run)
+    return read_engine_state(path)
+
+
+def set_maintenance_flag(
+    *,
+    run: Path | None = None,
+    source: str = "calibration",
+    deadline_s: float | None = None,
+    pid: int | None = None,
+) -> Path:
+    """Write maintenance flag (D11 minimum slice) before suppressing reconciler action."""
+    base = run or run_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    path = maintenance_flag_path(run=base)
+    owner = os.getpid() if pid is None else pid
+    deadline = time.time() + (MAINTENANCE_DEFAULT_DEADLINE_S if deadline_s is None else deadline_s)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp.write_text(
+        f"pid={owner}\n"
+        f"deadline={deadline:.3f}\n"
+        f"source={source}\n",
+        encoding="utf-8",
+    )
+    os.chmod(tmp, 0o644)
+    tmp.replace(path)
+    return path
+
+
+def clear_maintenance_flag(*, run: Path | None = None) -> None:
+    path = maintenance_flag_path(run=run)
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+def maintenance_mode_active(*, run: Path | None = None, now: float | None = None) -> bool:
+    """True while maintenance flag exists, unexpired, and setter PID is alive."""
+    raw = read_maintenance_flag(run=run)
+    if not raw:
+        return False
+    now_ts = time.time() if now is None else now
+    deadline = _parse_epoch(raw.get("deadline"))
+    if deadline <= 0 or now_ts >= deadline:
+        clear_maintenance_flag(run=run)
+        return False
+    owner = int(_parse_epoch(raw.get("pid")))
+    if owner > 0 and not _pid_alive(owner):
+        clear_maintenance_flag(run=run)
+        return False
+    return True
+
+
 def field_age_stale(updated: float, *, now: float, threshold: float = STALE_THRESHOLD_S) -> bool:
     if updated <= 0:
         return True
@@ -68,7 +133,7 @@ def field_age_stale(updated: float, *, now: float, threshold: float = STALE_THRE
 
 
 def systemd_unit_active(unit: str) -> bool | None:
-    """Return True/False when systemctl answers; None when unavailable."""
+    """Return True/False when systemctl answers; None when unavailable or transitional."""
     try:
         result = subprocess.run(
             ["systemctl", "is-active", f"{unit}.service"],
@@ -87,6 +152,19 @@ def systemd_unit_active(unit: str) -> bool | None:
     return None
 
 
+def _memoized_unit_active(
+    base: Callable[[str], bool | None],
+) -> Callable[[str], bool | None]:
+    cache: dict[str, bool | None] = {}
+
+    def check(unit: str) -> bool | None:
+        if unit not in cache:
+            cache[unit] = base(unit)
+        return cache[unit]
+
+    return check
+
+
 def process_field_stale(
     raw: dict[str, str] | None,
     *,
@@ -99,31 +177,20 @@ def process_field_stale(
         return True
     if _parse_epoch(raw.get(started_key)) <= 0:
         return True
-    active = unit_active(unit)
-    if active is False:
-        return True
-    return False
+    return unit_active(unit) is not True
 
 
 def engine_field_stale(
     raw: dict[str, str] | None,
     *,
-    now: float,
     unit_active: Callable[[str], bool | None],
 ) -> bool:
-    """Engine state is transition-written; trust it while Surge is live."""
+    """Engine state is transition-written; trust it only while Surge is confirmed live."""
     if not raw:
         return True
-    updated = _parse_epoch(raw.get("updated"))
-    if updated <= 0:
+    if _parse_epoch(raw.get("updated")) <= 0:
         return True
-    engine_active = (raw.get("active") or "").strip()
-    surge_live = unit_active(SURGE_UNIT)
-    if engine_active == "jack" and surge_live is False:
-        return True
-    if surge_live is True:
-        return False
-    return (now - updated) >= ENGINE_FALLBACK_STALE_S
+    return unit_active(SURGE_UNIT) is not True
 
 
 def reconcile_field_stale(raw: dict[str, str] | None) -> bool:
@@ -193,7 +260,7 @@ def build_snapshot(
     """Aggregate existing truth into schema v1 document."""
     base = run or run_dir()
     now_ts = time.time() if now is None else now
-    check_unit = unit_active or systemd_unit_active
+    check_unit = _memoized_unit_active(unit_active or systemd_unit_active)
 
     engine_path = base / "engine.state"
     jack_path = base / "jack.state"
@@ -209,7 +276,7 @@ def build_snapshot(
     jack_updated = _parse_epoch(jack_raw.get("started"))
     surge_updated = _parse_epoch(surge_raw.get("started"))
 
-    maintenance = maintenance_flag_path(run=base).exists()
+    maintenance = maintenance_mode_active(run=base, now=now_ts)
     mode = derive_mode(engine_raw, maintenance=maintenance)
 
     default_hud = Path(os.environ.get("MPE_SL_HUD_STATE_FILE", str(Path.home() / ".mpe_sl_hud_state.json")))
@@ -222,7 +289,7 @@ def build_snapshot(
     policy = looper_policy(looper_policy_env=looper_policy_env)
     guard = looper_guard_label(looper_enabled=looper_enabled)
 
-    engine_stale = engine_field_stale(engine_raw, now=now_ts, unit_active=check_unit)
+    engine_stale = engine_field_stale(engine_raw, unit_active=check_unit)
     jack_stale = process_field_stale(jack_raw, unit=JACK_UNIT, started_key="started", unit_active=check_unit)
     surge_stale = process_field_stale(surge_raw, unit=SURGE_UNIT, started_key="started", unit_active=check_unit)
     reconcile_stale = reconcile_field_stale(reconcile_raw)
@@ -301,26 +368,15 @@ def next_seq(*, run: Path | None = None) -> int:
         return value
 
 
-def write_seq(value: int, *, run: Path | None = None) -> None:
-    path = seq_path(run=run)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
-    tmp.write_text(f"{value}\n", encoding="utf-8")
-    tmp.replace(path)
-
-
 def write_snapshot(snapshot: dict[str, Any], *, run: Path | None = None) -> Path:
-    """Atomically publish snapshot JSON and bump seq counter."""
+    """Atomically publish snapshot JSON (seq is allocated by ``next_seq`` in ``build_snapshot``)."""
     base = run or run_dir()
     base.mkdir(parents=True, exist_ok=True)
     target = snapshot_path(run=base)
     tmp = target.with_name(f"{target.name}.tmp.{os.getpid()}")
-    seq = int(snapshot.get("seq") or 0)
     tmp.write_text(json.dumps(snapshot, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
     os.chmod(tmp, 0o644)
     tmp.replace(target)
-    if seq > 0:
-        write_seq(seq, run=base)
     return target
 
 

--- a/patch_browser/sl_hud_state.py
+++ b/patch_browser/sl_hud_state.py
@@ -14,11 +14,12 @@ STALE_AFTER_S = float(os.environ.get("MPE_SL_HUD_STALE_S", "2.0"))
 TRANSPORT_STALE_AFTER_S = float(os.environ.get("MPE_SL_HUD_TRANSPORT_STALE_S", "5.0"))
 
 
-def read_sl_hud_state(*, now: float | None = None) -> dict:
+def read_sl_hud_state(*, path: Path | None = None, now: float | None = None) -> dict:
     """Return normalized SL HUD snapshot (empty dict if missing/stale)."""
     now = time.time() if now is None else now
+    hud_file = path if path is not None else SL_HUD_STATE_FILE
     try:
-        raw = json.loads(SL_HUD_STATE_FILE.read_text(encoding="utf-8"))
+        raw = json.loads(hud_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
 

--- a/scripts/calibrate-patch-normalization.py
+++ b/scripts/calibrate-patch-normalization.py
@@ -13,6 +13,7 @@ Surge/ffmpeg.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import math
 import os
@@ -69,8 +70,7 @@ from patch_browser.calibration_constants import (  # noqa: E402
     estimate_calibration_duration_seconds,
 )
 from patch_browser.calibration_teardown import (  # noqa: E402
-    restore_mpe_audio_services,
-    stop_mpe_audio_services,
+    calibration_audio_scope,
     unload_snd_aloop_if_idle,
 )
 from patch_browser.patch_normalization import (  # noqa: E402
@@ -1080,159 +1080,151 @@ def main() -> int:
         return 1
 
     cal_surge_started = False
-    services_stopped_for_cal = False
-    if use_loopback and args.mock_lufs is None:
-        try:
-            emit_progress(
-                args,
-                {"type": "setup", "message": "Stopping patch browser and Surge…"},
-            )
-            stop_mpe_audio_services()
-            services_stopped_for_cal = True
-            audio_device = detect_capture_device(args.audio_device, use_loopback=True)
-            print(f"Capture device: {audio_device}", file=sys.stderr)
-            emit_progress(args, {"type": "setup", "message": "Starting Surge for measurement…"})
-            loopback_interface = start_surge_loopback()
-            cal_surge_started = True
-            print(f"Surge loopback interface: {loopback_interface}", file=sys.stderr)
-            loader = PatchLoader(osc_host=args.osc_host, osc_port=args.osc_port)
-            if not loader.osc_enabled:
-                raise RuntimeError("OSC unavailable after loopback Surge start")
-        except Exception as exc:
-            print(f"Error: loopback calibration setup failed: {exc}", file=sys.stderr)
-            emit_progress(args, {"type": "error", "message": str(exc)})
-            if services_stopped_for_cal:
-                restore_mpe_audio_services()
-            emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
-            return 1
-    elif standalone_restart:
-        try:
-            emit_progress(
-                args,
-                {"type": "setup", "message": "Stopping production Surge for measurement…"},
-            )
-            stop_mpe_audio_services()
-            services_stopped_for_cal = True
-            emit_progress(args, {"type": "setup", "message": "Starting Surge on Sound Blaster…"})
-            standalone_interface = start_surge_standalone()
-            cal_surge_started = True
-            audio_device = detect_capture_device(args.audio_device, use_loopback=False)
-            print(f"Capture device: {audio_device}", file=sys.stderr)
-            print(f"Surge standalone interface: {standalone_interface}", file=sys.stderr)
-            loader = PatchLoader(osc_host=args.osc_host, osc_port=args.osc_port)
-            if not loader.osc_enabled:
-                raise RuntimeError("OSC unavailable after standalone Surge start")
-        except Exception as exc:
-            print(f"Error: standalone calibration setup failed: {exc}", file=sys.stderr)
-            emit_progress(args, {"type": "error", "message": str(exc)})
-            if services_stopped_for_cal:
-                restore_mpe_audio_services()
-            emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
-            return 1
-
-    signal.signal(signal.SIGTERM, _handle_interrupt)
-    signal.signal(signal.SIGINT, _handle_interrupt)
-
-    midi_port = wait_for_surge_midi_port() if args.mock_lufs is None else None
-    if midi_port is None and args.mock_lufs is None:
-        msg = "Surge MIDI port not found — is Surge running with MIDI inputs?"
-        print(f"Error: {msg}", file=sys.stderr)
-        emit_progress(args, {"type": "error", "message": msg})
-        if cal_surge_started or services_stopped_for_cal:
-            restore_mpe_audio_services()
-        emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
-        return 1
-
     updated = 0
     exit_code = 0
-    midi_out: object | None = None
     last_patch_index = 0
     last_patch_name = ""
-    light_measurements: list[tuple[str, float, float, float]] = []
-    try:
-        if args.mock_lufs is None:
-            midi_out = open_midi_out(midi_port)
-        for index, path in enumerate(targets, start=1):
-            if _interrupted:
-                print("Calibration interrupted — keeping partial progress.", file=sys.stderr)
-                break
-            name = path.stem
-            last_patch_index = index
-            last_patch_name = name
-            print(f"[{index}/{len(targets)}] {name}", file=sys.stderr if args.progress_json else sys.stdout)
-            emit_progress(
-                args,
-                {"type": "patch", "index": index, "total": len(targets), "name": name},
-            )
+    needs_service_handoff = (use_loopback and args.mock_lufs is None) or standalone_restart
+    audio_scope = (
+        calibration_audio_scope(restore=not args.no_restore_services)
+        if needs_service_handoff
+        else contextlib.nullcontext()
+    )
+
+    with audio_scope:
+        if needs_service_handoff:
             try:
-                result = calibrate_patch(
-                    path,
-                    loader,
-                    store,
-                    audio_device=audio_device,
-                    mock_lufs=args.mock_lufs,
-                    dry_run=False,
-                    midi_out=midi_out,
-                    touch_cal=touch_cal,
-                )
-            except Exception as exc:
-                msg = f"{name}: {exc}"
-                print(f"  [fail] {msg}", file=sys.stderr)
-                write_failure_report(
-                    patch_index=index,
-                    patch_name=name,
-                    total=len(targets),
-                    reason=str(exc),
-                    exit_code=1,
-                )
-                emit_progress(args, {"type": "error", "message": msg})
-                exit_code = 1
-                break
-            emit_progress(
-                args,
-                {
-                    "type": "patch_done",
-                    "index": index,
-                    "total": len(targets),
-                    "name": name,
-                    "ok": result.ok,
-                },
-            )
-            if result.ok:
-                updated += 1
-                if (
-                    result.lufs_light is not None
-                    and result.lufs_strike is not None
-                    and result.lufs_sustain is not None
-                ):
-                    light_measurements.append(
-                        (name, result.lufs_light, result.lufs_strike, result.lufs_sustain)
+                if use_loopback and args.mock_lufs is None:
+                    emit_progress(
+                        args,
+                        {"type": "setup", "message": "Stopping patch browser and Surge…"},
                     )
-        if light_measurements and touch_cal and not _interrupted:
-            target_lufs = resolve_light_touch_target([v for _, v, _, _ in light_measurements])
-            pressure_store = PatchPressureStore(pressure_path)
-            touch_updated = 0
-            for name, lufs_light, lufs_strike, lufs_sustain in light_measurements:
-                floor = compute_touch_calibration_floor(
-                    lufs_light, target_lufs, lufs_strike, lufs_sustain
+                    audio_device = detect_capture_device(args.audio_device, use_loopback=True)
+                    print(f"Capture device: {audio_device}", file=sys.stderr)
+                    emit_progress(args, {"type": "setup", "message": "Starting Surge for measurement…"})
+                    loopback_interface = start_surge_loopback()
+                    cal_surge_started = True
+                    print(f"Surge loopback interface: {loopback_interface}", file=sys.stderr)
+                    loader = PatchLoader(osc_host=args.osc_host, osc_port=args.osc_port)
+                    if not loader.osc_enabled:
+                        raise RuntimeError("OSC unavailable after loopback Surge start")
+                elif standalone_restart:
+                    emit_progress(
+                        args,
+                        {"type": "setup", "message": "Stopping production Surge for measurement…"},
+                    )
+                    emit_progress(args, {"type": "setup", "message": "Starting Surge on Sound Blaster…"})
+                    standalone_interface = start_surge_standalone()
+                    cal_surge_started = True
+                    audio_device = detect_capture_device(args.audio_device, use_loopback=False)
+                    print(f"Capture device: {audio_device}", file=sys.stderr)
+                    print(f"Surge standalone interface: {standalone_interface}", file=sys.stderr)
+                    loader = PatchLoader(osc_host=args.osc_host, osc_port=args.osc_port)
+                    if not loader.osc_enabled:
+                        raise RuntimeError("OSC unavailable after standalone Surge start")
+            except Exception as exc:
+                label = "loopback" if use_loopback and args.mock_lufs is None else "standalone"
+                print(f"Error: {label} calibration setup failed: {exc}", file=sys.stderr)
+                emit_progress(args, {"type": "error", "message": str(exc)})
+                emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
+                return 1
+
+        signal.signal(signal.SIGTERM, _handle_interrupt)
+        signal.signal(signal.SIGINT, _handle_interrupt)
+
+        midi_port = wait_for_surge_midi_port() if args.mock_lufs is None else None
+        if midi_port is None and args.mock_lufs is None:
+            msg = "Surge MIDI port not found — is Surge running with MIDI inputs?"
+            print(f"Error: {msg}", file=sys.stderr)
+            emit_progress(args, {"type": "error", "message": msg})
+            emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
+            return 1
+
+        midi_out: object | None = None
+        light_measurements: list[tuple[str, float, float, float]] = []
+        try:
+            if args.mock_lufs is None:
+                midi_out = open_midi_out(midi_port)
+            for index, path in enumerate(targets, start=1):
+                if _interrupted:
+                    print("Calibration interrupted — keeping partial progress.", file=sys.stderr)
+                    break
+                name = path.stem
+                last_patch_index = index
+                last_patch_name = name
+                print(f"[{index}/{len(targets)}] {name}", file=sys.stderr if args.progress_json else sys.stdout)
+                emit_progress(
+                    args,
+                    {"type": "patch", "index": index, "total": len(targets), "name": name},
                 )
-                pressure_store.set_calibration(name, floor, lufs_light)
-                touch_updated += 1
-            pressure_store.save()
-            print(
-                f"Wrote {touch_updated} touch calibration entries to {pressure_path} "
-                f"(light target {target_lufs:.1f} LUFS)",
-                file=sys.stderr if args.progress_json else sys.stdout,
-            )
-    finally:
-        close_midi_out(midi_out)
-        if (cal_surge_started or services_stopped_for_cal) and not args.no_restore_services:
-            emit_progress(
-                args,
-                {"type": "setup", "message": "Restarting patch browser and Surge…"},
-            )
-            print("Restoring surge-xt-cli and touch-patch-browser services...", file=sys.stderr)
-            restore_mpe_audio_services()
+                try:
+                    result = calibrate_patch(
+                        path,
+                        loader,
+                        store,
+                        audio_device=audio_device,
+                        mock_lufs=args.mock_lufs,
+                        dry_run=False,
+                        midi_out=midi_out,
+                        touch_cal=touch_cal,
+                    )
+                except Exception as exc:
+                    msg = f"{name}: {exc}"
+                    print(f"  [fail] {msg}", file=sys.stderr)
+                    write_failure_report(
+                        patch_index=index,
+                        patch_name=name,
+                        total=len(targets),
+                        reason=str(exc),
+                        exit_code=1,
+                    )
+                    emit_progress(args, {"type": "error", "message": msg})
+                    exit_code = 1
+                    break
+                emit_progress(
+                    args,
+                    {
+                        "type": "patch_done",
+                        "index": index,
+                        "total": len(targets),
+                        "name": name,
+                        "ok": result.ok,
+                    },
+                )
+                if result.ok:
+                    updated += 1
+                    if (
+                        result.lufs_light is not None
+                        and result.lufs_strike is not None
+                        and result.lufs_sustain is not None
+                    ):
+                        light_measurements.append(
+                            (name, result.lufs_light, result.lufs_strike, result.lufs_sustain)
+                        )
+            if light_measurements and touch_cal and not _interrupted:
+                target_lufs = resolve_light_touch_target([v for _, v, _, _ in light_measurements])
+                pressure_store = PatchPressureStore(pressure_path)
+                touch_updated = 0
+                for name, lufs_light, lufs_strike, lufs_sustain in light_measurements:
+                    floor = compute_touch_calibration_floor(
+                        lufs_light, target_lufs, lufs_strike, lufs_sustain
+                    )
+                    pressure_store.set_calibration(name, floor, lufs_light)
+                    touch_updated += 1
+                pressure_store.save()
+                print(
+                    f"Wrote {touch_updated} touch calibration entries to {pressure_path} "
+                    f"(light target {target_lufs:.1f} LUFS)",
+                    file=sys.stderr if args.progress_json else sys.stdout,
+                )
+        finally:
+            close_midi_out(midi_out)
+            if needs_service_handoff and cal_surge_started and not args.no_restore_services:
+                emit_progress(
+                    args,
+                    {"type": "setup", "message": "Restarting patch browser and Surge…"},
+                )
+                print("Restoring surge-xt-cli and touch-patch-browser services...", file=sys.stderr)
 
     if updated:
         print(f"Wrote {updated} calibration entries to {output_path}")

--- a/scripts/calibrate-patch-normalization.py
+++ b/scripts/calibrate-patch-normalization.py
@@ -1080,6 +1080,7 @@ def main() -> int:
         return 1
 
     cal_surge_started = False
+    services_stopped_for_cal = False
     if use_loopback and args.mock_lufs is None:
         try:
             emit_progress(
@@ -1087,6 +1088,7 @@ def main() -> int:
                 {"type": "setup", "message": "Stopping patch browser and Surge…"},
             )
             stop_mpe_audio_services()
+            services_stopped_for_cal = True
             audio_device = detect_capture_device(args.audio_device, use_loopback=True)
             print(f"Capture device: {audio_device}", file=sys.stderr)
             emit_progress(args, {"type": "setup", "message": "Starting Surge for measurement…"})
@@ -1099,7 +1101,7 @@ def main() -> int:
         except Exception as exc:
             print(f"Error: loopback calibration setup failed: {exc}", file=sys.stderr)
             emit_progress(args, {"type": "error", "message": str(exc)})
-            if cal_surge_started:
+            if services_stopped_for_cal:
                 restore_mpe_audio_services()
             emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
             return 1
@@ -1110,6 +1112,7 @@ def main() -> int:
                 {"type": "setup", "message": "Stopping production Surge for measurement…"},
             )
             stop_mpe_audio_services()
+            services_stopped_for_cal = True
             emit_progress(args, {"type": "setup", "message": "Starting Surge on Sound Blaster…"})
             standalone_interface = start_surge_standalone()
             cal_surge_started = True
@@ -1122,7 +1125,7 @@ def main() -> int:
         except Exception as exc:
             print(f"Error: standalone calibration setup failed: {exc}", file=sys.stderr)
             emit_progress(args, {"type": "error", "message": str(exc)})
-            if cal_surge_started:
+            if services_stopped_for_cal:
                 restore_mpe_audio_services()
             emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
             return 1
@@ -1135,7 +1138,7 @@ def main() -> int:
         msg = "Surge MIDI port not found — is Surge running with MIDI inputs?"
         print(f"Error: {msg}", file=sys.stderr)
         emit_progress(args, {"type": "error", "message": msg})
-        if cal_surge_started:
+        if cal_surge_started or services_stopped_for_cal:
             restore_mpe_audio_services()
         emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
         return 1
@@ -1223,7 +1226,7 @@ def main() -> int:
             )
     finally:
         close_midi_out(midi_out)
-        if cal_surge_started and not args.no_restore_services:
+        if (cal_surge_started or services_stopped_for_cal) and not args.no_restore_services:
             emit_progress(
                 args,
                 {"type": "setup", "message": "Restarting patch browser and Surge…"},

--- a/scripts/ensure-looper-units-running.py
+++ b/scripts/ensure-looper-units-running.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Start stopped looper units unless maintenance mode is active (calibration recovery)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from patch_browser.calibration_teardown import ensure_looper_units_running
+
+
+def main() -> int:
+    ensure_looper_units_running()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -199,8 +199,9 @@ mpe_engine_state_write() {
     local state="${3:?state required}"
     local reason="${4:-}"
     local looper="${5:-off}"
-    local file
+    local file prev_state
     file="$(mpe_engine_state_file)"
+    prev_state="$(mpe_engine_state_get state)"
     mpe_state_write_atomic "$file" \
         "engine=$engine" \
         "active=$active" \
@@ -208,6 +209,7 @@ mpe_engine_state_write() {
         "reason=$reason" \
         "looper=$looper" \
         "updated=$(date +%s)" || true
+    mpe_session_events_on_engine_transition "$prev_state" "$state" "$active" "$reason"
 }
 
 mpe_engine_state_get() {
@@ -312,14 +314,18 @@ mpe_jack_state_write() {
     local period="${2:-}"
     local periods="${3:-}"
     local rate="${4:-}"
-    local file
+    local file prev_period
     file="$(mpe_jack_state_file)"
+    prev_period="$(mpe_state_get "$file" period)"
     mpe_state_write_atomic "$file" \
         "started=$(date +%s)" \
         "device=$device" \
         "period=$period" \
         "periods=$periods" \
         "rate=$rate" || true
+    if [ -n "$period" ] && [ -n "$prev_period" ] && [ "$period" != "$prev_period" ]; then
+        mpe_session_event_emit buffer.changed "period=$period" "from=$prev_period"
+    fi
 }
 
 # Epoch seconds when jackd last started, or 0 when unknown. Written by
@@ -389,6 +395,7 @@ mpe_publish_jack_engine_failure() {
 mpe_restart_audio_graph() {
     local unit
     unit="$(mpe_audio_graph_unit)"
+    mpe_session_event_emit engine.exited "graph-restart"
     # A unit sitting in start-limit failure refuses `restart` ("start request
     # repeated too quickly") until it is reset. That is exactly the state a DAC
     # unplug leaves jackd in, and the replug is the event that must recover it.
@@ -649,4 +656,38 @@ mpe_surge_on_jack_graph() {
 # Back-compat alias used by udev helper and profile scripts.
 restart_audio_graph() {
     mpe_restart_audio_graph
+}
+
+# ---------------------------------------------------------------------------
+# Session control plane — Phase 2 event emit (lazy-loaded)
+# ---------------------------------------------------------------------------
+
+_mpe_session_events_loaded=0
+
+mpe_session_events_ensure() {
+    if [ "$_mpe_session_events_loaded" = 1 ]; then
+        return 0
+    fi
+    # shellcheck source=session-events.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/session-events.sh"
+    _mpe_session_events_loaded=1
+}
+
+mpe_session_event_emit() {
+    mpe_session_events_ensure
+    mpe_session_event_append "$@"
+}
+
+mpe_session_events_on_engine_transition() {
+    local prev_state="${1:-}" new_state="${2:-}" active="${3:-}" reason="${4:-}"
+    mpe_session_events_ensure
+    if [ "$new_state" = ok ] && [ "$prev_state" != ok ]; then
+        mpe_session_event_emit engine.started "$active" "reason=$reason"
+    fi
+    if [ "$new_state" = failed ] && [ "$prev_state" != failed ]; then
+        mpe_session_event_emit engine.exited "$reason"
+    fi
+    if [ "$new_state" = recovering ] && [ "$prev_state" != recovering ]; then
+        mpe_session_event_emit mode.changed "recovering" "reason=$reason"
+    fi
 }

--- a/scripts/lib/session-events.sh
+++ b/scripts/lib/session-events.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Session control plane — structured event emit (Phase 2, spec criterion 9).
+#
+# Append-only JSONL ring buffer at $(mpe_run_dir)/events.jsonl. Bash callers
+# source this after audio-engine.sh (for mpe_run_dir).
+
+# shellcheck disable=SC2034
+MPE_SESSION_EVENTS_MAX="${MPE_SESSION_EVENTS_MAX:-2000}"
+
+mpe_session_events_file() {
+    printf '%s' "$(mpe_run_dir)/events.jsonl"
+}
+
+# Emit one line: {"ts":...,"event":"...","source":"...","detail":"..."}
+# Extra keys may be passed as KEY=value pairs after detail.
+mpe_session_event_append() {
+    local event="${1:?event name required}"
+    local detail="${2:-}"
+    local source="${MPE_EVENT_SOURCE:-${0##*/}}"
+    local file tmp line ts
+    file="$(mpe_session_events_file)"
+    ts="$(date +%s)"
+    line="$(printf '{"ts":%s,"event":"%s","source":"%s"' "$ts" "$event" "$source")"
+    if [ -n "$detail" ]; then
+        # shellcheck disable=SC2016
+        line="${line},$(printf '"detail":"%s"' "$detail")"
+    fi
+    shift 2 || shift 1 || true
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            *=*)
+                local k="${1%%=*}" v="${1#*=}"
+                line="${line},$(printf '"%s":"%s"' "$k" "$v")"
+                ;;
+        esac
+        shift
+    done
+    line="${line}}"
+
+    mkdir -p "$(dirname "$file")" 2>/dev/null || true
+    tmp="${file}.tmp.$$"
+    if [ -f "$file" ]; then
+        local count
+        count="$(wc -l <"$file" 2>/dev/null || echo 0)"
+        if [ "$count" -ge "$MPE_SESSION_EVENTS_MAX" ]; then
+            tail -n "$((MPE_SESSION_EVENTS_MAX - 1))" "$file" >"$tmp" 2>/dev/null || : >"$tmp"
+        else
+            cp "$file" "$tmp" 2>/dev/null || : >"$tmp"
+        fi
+    else
+        : >"$tmp"
+    fi
+    printf '%s\n' "$line" >>"$tmp"
+    chmod 0644 "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$file" 2>/dev/null || {
+        rm -f "$tmp" 2>/dev/null || true
+        return 1
+    }
+}

--- a/scripts/lib/session-events.sh
+++ b/scripts/lib/session-events.sh
@@ -3,6 +3,8 @@
 #
 # Append-only JSONL ring buffer at $(mpe_run_dir)/events.jsonl. Bash callers
 # source this after audio-engine.sh (for mpe_run_dir).
+#
+# JSON is built by scripts/mpe-session-event-emit.py (validated names, safe escaping).
 
 # shellcheck disable=SC2034
 MPE_SESSION_EVENTS_MAX="${MPE_SESSION_EVENTS_MAX:-2000}"
@@ -11,49 +13,40 @@ mpe_session_events_file() {
     printf '%s' "$(mpe_run_dir)/events.jsonl"
 }
 
-# Emit one line: {"ts":...,"event":"...","source":"...","detail":"..."}
-# Extra keys may be passed as KEY=value pairs after detail.
+# Emit one line via Python (bash printf cannot safely escape reason= strings).
+# Usage: mpe_session_event_append EVENT [DETAIL] [KEY=value ...]
 mpe_session_event_append() {
     local event="${1:?event name required}"
     local detail="${2:-}"
     local source="${MPE_EVENT_SOURCE:-${0##*/}}"
-    local file tmp line ts
-    file="$(mpe_session_events_file)"
-    ts="$(date +%s)"
-    line="$(printf '{"ts":%s,"event":"%s","source":"%s"' "$ts" "$event" "$source")"
-    if [ -n "$detail" ]; then
-        # shellcheck disable=SC2016
-        line="${line},$(printf '"detail":"%s"' "$detail")"
+    local repo script
+    local -a cmd
+
+    repo="${MPE_MODULE_REPO:-}"
+    if [ -z "$repo" ]; then
+        repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
     fi
-    shift 2 || shift 1 || true
+    script="${repo}/scripts/mpe-session-event-emit.py"
+    if [ ! -f "$script" ]; then
+        echo "mpe_session_event_append: missing $script" >&2
+        return 1
+    fi
+
+    cmd=(python3 "$script" --source "$source")
+    if [ -n "${MPE_RUN_DIR:-}" ]; then
+        cmd+=(--run-dir "$MPE_RUN_DIR")
+    fi
+    if [ -n "$detail" ]; then
+        cmd+=("$event" "$detail")
+    else
+        cmd+=("$event")
+    fi
+    shift 2 2>/dev/null || shift 1 2>/dev/null || true
     while [ "$#" -gt 0 ]; do
         case "$1" in
-            *=*)
-                local k="${1%%=*}" v="${1#*=}"
-                line="${line},$(printf '"%s":"%s"' "$k" "$v")"
-                ;;
+            *=*) cmd+=(--field "$1") ;;
         esac
         shift
     done
-    line="${line}}"
-
-    mkdir -p "$(dirname "$file")" 2>/dev/null || true
-    tmp="${file}.tmp.$$"
-    if [ -f "$file" ]; then
-        local count
-        count="$(wc -l <"$file" 2>/dev/null || echo 0)"
-        if [ "$count" -ge "$MPE_SESSION_EVENTS_MAX" ]; then
-            tail -n "$((MPE_SESSION_EVENTS_MAX - 1))" "$file" >"$tmp" 2>/dev/null || : >"$tmp"
-        else
-            cp "$file" "$tmp" 2>/dev/null || : >"$tmp"
-        fi
-    else
-        : >"$tmp"
-    fi
-    printf '%s\n' "$line" >>"$tmp"
-    chmod 0644 "$tmp" 2>/dev/null || true
-    mv -f "$tmp" "$file" 2>/dev/null || {
-        rm -f "$tmp" 2>/dev/null || true
-        return 1
-    }
+    "${cmd[@]}"
 }

--- a/scripts/mpe-session-event-emit.py
+++ b/scripts/mpe-session-event-emit.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Emit one session control plane event (bash-safe JSON, validated names)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from patch_browser.session_events import emit_event
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Append one session event line")
+    parser.add_argument("event", help="Event name (must be in EVENT_NAMES whitelist)")
+    parser.add_argument("detail", nargs="?", default="", help="Optional detail string")
+    parser.add_argument("--source", default="", help="Event source label")
+    parser.add_argument(
+        "--field",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Extra JSON field (repeatable)",
+    )
+    parser.add_argument("--run-dir", default=None, help="Override MPE_RUN_DIR")
+    args = parser.parse_args(argv)
+
+    fields: dict[str, str] = {}
+    for item in args.field:
+        if "=" not in item:
+            print(f"invalid --field (expected KEY=VALUE): {item}", file=sys.stderr)
+            return 2
+        key, value = item.split("=", 1)
+        fields[key] = value
+
+    run = Path(args.run_dir) if args.run_dir else None
+    try:
+        emit_event(
+            args.event,
+            detail=args.detail,
+            source=args.source or "bash",
+            fields=fields or None,
+            run=run,
+        )
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/surge-watchdog.sh
+++ b/scripts/surge-watchdog.sh
@@ -129,6 +129,10 @@ while true; do
 
     _reconcile_engine
 
+    if [ -x "$MPE_MODULE_REPO/scripts/ensure-looper-units-running.py" ]; then
+        python3 "$MPE_MODULE_REPO/scripts/ensure-looper-units-running.py" >/dev/null 2>&1 || true
+    fi
+
     sleep 5
 done
 fi

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -988,5 +988,34 @@ if mpe_jack_softmode_enabled; then printf 'on'; else printf 'off'; fi
         self.assertNotIn('jackd -R -P"$JACK_PRIO" -s', text)
 
 
+class SessionEventBashTests(unittest.TestCase):
+    def test_engine_transition_emits_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            body = f"""
+source {AUDIO_ENGINE_SH}
+mpe_engine_state_write jack none recovering boot off
+mpe_engine_state_write jack jack ok "" off
+mpe_engine_state_write jack none failed no-server off
+wc -l < "$(mpe_run_dir)/events.jsonl"
+"""
+            result = _run_bash_script(body, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertGreaterEqual(int(result.stdout.strip()), 2)
+
+    def test_buffer_change_emits_event(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            body = f"""
+source {AUDIO_ENGINE_SH}
+mpe_jack_state_write hw:0 256 3 48000
+mpe_jack_state_write hw:0 128 3 48000
+grep -c buffer.changed "$(mpe_run_dir)/events.jsonl"
+"""
+            result = _run_bash_script(body, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "1")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -334,7 +334,7 @@ mpe_restart_audio_graph() {{ printf 'graph-restart\\n'; return 0; }}
 mpe_systemctl() {{
   printf '%s\\n' "$*" >> "{tmp}/systemctl.log"
   case "$*" in
-    restart\ surge-xt-cli.service) touch "{on_graph}" ;;
+    restart\\ surge-xt-cli.service) touch "{on_graph}" ;;
   esac
   return 0
 }}

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -1016,6 +1016,17 @@ grep -c buffer.changed "$(mpe_run_dir)/events.jsonl"
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip(), "1")
 
+    def test_engine_exit_reason_with_quotes_survives_jsonl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            body = f"""
+source {AUDIO_ENGINE_SH}
+mpe_session_event_emit engine.exited 'surge said "no" / path C:\\x' reason='surge said "no"'
+python3 -c "import json; from pathlib import Path; lines=Path('$(mpe_run_dir)/events.jsonl').read_text().splitlines(); obj=json.loads(lines[-1]); assert obj['event']=='engine.exited'; assert 'no' in obj['detail']; assert 'no' in obj['reason']"
+"""
+            result = _run_bash_script(body, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_calibration_handoff.py
+++ b/tests/test_calibration_handoff.py
@@ -52,29 +52,46 @@ class CalibrationHandoffTests(unittest.TestCase):
     def tearDown(self) -> None:
         self._env.stop()
 
+    @mock.patch("patch_browser.calibration_teardown.emit_event")
     @mock.patch("patch_browser.calibration_teardown.time.sleep")
     @mock.patch("patch_browser.calibration_teardown.subprocess.run")
-    def test_stop_skips_touch_browser_when_from_browser(self, run_mock: mock.Mock, _sleep: mock.Mock) -> None:
+    def test_stop_skips_touch_browser_when_from_browser(
+        self, run_mock: mock.Mock, _sleep: mock.Mock, _emit: mock.Mock
+    ) -> None:
         os.environ[MPE_CALIB_FROM_BROWSER] = "1"
         ct.stop_mpe_audio_services()
         stopped = _systemctl_calls(run_mock, "stop")
         self.assertNotIn("touch-patch-browser", stopped)
         self.assertIn("surge-xt-cli", stopped)
 
+    @mock.patch("patch_browser.calibration_teardown.emit_event")
     @mock.patch("patch_browser.calibration_teardown.time.sleep")
     @mock.patch("patch_browser.calibration_teardown.subprocess.run")
-    def test_stop_includes_touch_browser_when_not_from_browser(self, run_mock: mock.Mock, _sleep: mock.Mock) -> None:
+    def test_stop_includes_looper_units(self, run_mock: mock.Mock, _sleep: mock.Mock, _emit: mock.Mock) -> None:
+        ct.stop_mpe_audio_services()
+        stopped = _systemctl_calls(run_mock, "stop")
+        for unit in ct.LOOPER_UNITS_STOP_ORDER:
+            self.assertIn(unit, stopped)
+
+    @mock.patch("patch_browser.calibration_teardown.emit_event")
+    @mock.patch("patch_browser.calibration_teardown.time.sleep")
+    @mock.patch("patch_browser.calibration_teardown.subprocess.run")
+    def test_stop_includes_touch_browser_when_not_from_browser(
+        self, run_mock: mock.Mock, _sleep: mock.Mock, _emit: mock.Mock
+    ) -> None:
         ct.stop_mpe_audio_services()
         stopped = _systemctl_calls(run_mock, "stop")
         self.assertIn("touch-patch-browser", stopped)
         self.assertIn("surge-xt-cli", stopped)
 
+    @mock.patch("patch_browser.calibration_teardown.emit_event")
     @mock.patch("patch_browser.calibration_teardown.time.sleep")
     @mock.patch("patch_browser.calibration_teardown.subprocess.run")
     def test_restore_does_not_systemd_restart_browser_when_from_browser(
         self,
         run_mock: mock.Mock,
         _sleep: mock.Mock,
+        _emit: mock.Mock,
     ) -> None:
         os.environ[MPE_CALIB_FROM_BROWSER] = "1"
         ct.restore_mpe_audio_services(restart_browser=True)
@@ -82,9 +99,25 @@ class CalibrationHandoffTests(unittest.TestCase):
         self.assertNotIn("touch-patch-browser", started)
         self.assertIn("surge-xt-cli", started)
 
+    @mock.patch("patch_browser.calibration_teardown.emit_event")
     @mock.patch("patch_browser.calibration_teardown.time.sleep")
     @mock.patch("patch_browser.calibration_teardown.subprocess.run")
-    def test_restore_sync_starts_browser_when_not_from_browser(self, run_mock: mock.Mock, _sleep: mock.Mock) -> None:
+    def test_restore_starts_looper_units_after_surge(
+        self, run_mock: mock.Mock, _sleep: mock.Mock, _emit: mock.Mock
+    ) -> None:
+        ct.restore_mpe_audio_services(restart_browser=False)
+        started = _systemctl_calls(run_mock, "start")
+        surge_idx = started.index("surge-xt-cli")
+        for unit in ct.LOOPER_UNITS_START_ORDER:
+            self.assertIn(unit, started)
+            self.assertGreater(started.index(unit), surge_idx)
+
+    @mock.patch("patch_browser.calibration_teardown.emit_event")
+    @mock.patch("patch_browser.calibration_teardown.time.sleep")
+    @mock.patch("patch_browser.calibration_teardown.subprocess.run")
+    def test_restore_sync_starts_browser_when_not_from_browser(
+        self, run_mock: mock.Mock, _sleep: mock.Mock, _emit: mock.Mock
+    ) -> None:
         ct.restore_mpe_audio_services(restart_browser=True)
         started = _systemctl_calls(run_mock, "start")
         self.assertIn("touch-patch-browser", started)

--- a/tests/test_calibration_handoff.py
+++ b/tests/test_calibration_handoff.py
@@ -43,6 +43,28 @@ def _systemctl_calls(run_mock: mock.Mock, verb: str) -> list[str]:
     return units
 
 
+class LooperReconcileTests(unittest.TestCase):
+    @mock.patch("patch_browser.calibration_teardown._systemctl")
+    @mock.patch("patch_browser.calibration_teardown._unit_is_active", return_value=False)
+    @mock.patch("patch_browser.calibration_teardown.maintenance_flag_path")
+    def test_ensure_looper_starts_stopped_units(
+        self, maint_mock: mock.Mock, _active: mock.Mock, systemctl_mock: mock.Mock
+    ) -> None:
+        maint_mock.return_value.exists.return_value = False
+        ct.ensure_looper_units_running()
+        started = [c.args[0] for c in systemctl_mock.call_args_list if c.args[1] == "start"]
+        self.assertEqual(started, list(ct.LOOPER_UNITS_START_ORDER))
+
+    @mock.patch("patch_browser.calibration_teardown._systemctl")
+    @mock.patch("patch_browser.calibration_teardown.maintenance_flag_path")
+    def test_ensure_looper_skips_under_maintenance(
+        self, maint_mock: mock.Mock, systemctl_mock: mock.Mock
+    ) -> None:
+        maint_mock.return_value.exists.return_value = True
+        ct.ensure_looper_units_running()
+        systemctl_mock.assert_not_called()
+
+
 class CalibrationHandoffTests(unittest.TestCase):
     def setUp(self) -> None:
         self._env = mock.patch.dict(os.environ, {}, clear=False)

--- a/tests/test_calibration_handoff.py
+++ b/tests/test_calibration_handoff.py
@@ -45,24 +45,54 @@ def _systemctl_calls(run_mock: mock.Mock, verb: str) -> list[str]:
 
 class LooperReconcileTests(unittest.TestCase):
     @mock.patch("patch_browser.calibration_teardown._systemctl")
-    @mock.patch("patch_browser.calibration_teardown._unit_is_active", return_value=False)
-    @mock.patch("patch_browser.calibration_teardown.maintenance_flag_path")
+    @mock.patch("patch_browser.calibration_teardown.systemd_unit_active", return_value=False)
+    @mock.patch("patch_browser.calibration_teardown.maintenance_mode_active", return_value=False)
     def test_ensure_looper_starts_stopped_units(
-        self, maint_mock: mock.Mock, _active: mock.Mock, systemctl_mock: mock.Mock
+        self, _maint: mock.Mock, _active: mock.Mock, systemctl_mock: mock.Mock
     ) -> None:
-        maint_mock.return_value.exists.return_value = False
         ct.ensure_looper_units_running()
         started = [c.args[0] for c in systemctl_mock.call_args_list if c.args[1] == "start"]
         self.assertEqual(started, list(ct.LOOPER_UNITS_START_ORDER))
 
     @mock.patch("patch_browser.calibration_teardown._systemctl")
-    @mock.patch("patch_browser.calibration_teardown.maintenance_flag_path")
+    @mock.patch("patch_browser.calibration_teardown.maintenance_mode_active", return_value=True)
     def test_ensure_looper_skips_under_maintenance(
-        self, maint_mock: mock.Mock, systemctl_mock: mock.Mock
+        self, _maint: mock.Mock, systemctl_mock: mock.Mock
     ) -> None:
-        maint_mock.return_value.exists.return_value = True
         ct.ensure_looper_units_running()
         systemctl_mock.assert_not_called()
+
+
+class CalibrationMaintenanceFlagTests(unittest.TestCase):
+    @mock.patch("patch_browser.calibration_teardown.clear_maintenance_flag")
+    @mock.patch("patch_browser.calibration_teardown.set_maintenance_flag")
+    @mock.patch("patch_browser.calibration_teardown.emit_event")
+    @mock.patch("patch_browser.calibration_teardown.time.sleep")
+    @mock.patch("patch_browser.calibration_teardown.subprocess.run")
+    def test_stop_sets_maintenance_flag(
+        self,
+        _run: mock.Mock,
+        _sleep: mock.Mock,
+        _emit: mock.Mock,
+        set_flag: mock.Mock,
+        _clear: mock.Mock,
+    ) -> None:
+        ct.stop_mpe_audio_services()
+        set_flag.assert_called_once()
+
+    @mock.patch("patch_browser.calibration_teardown.clear_maintenance_flag")
+    @mock.patch("patch_browser.calibration_teardown.emit_event")
+    @mock.patch("patch_browser.calibration_teardown.time.sleep")
+    @mock.patch("patch_browser.calibration_teardown.subprocess.run")
+    def test_restore_clears_maintenance_flag(
+        self,
+        _run: mock.Mock,
+        _sleep: mock.Mock,
+        _emit: mock.Mock,
+        clear_flag: mock.Mock,
+    ) -> None:
+        ct.restore_mpe_audio_services(restart_browser=False)
+        clear_flag.assert_called_once()
 
 
 class CalibrationHandoffTests(unittest.TestCase):

--- a/tests/test_mpe_run_dir.py
+++ b/tests/test_mpe_run_dir.py
@@ -1,0 +1,32 @@
+"""Tests for patch_browser/mpe_run_dir.py."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from patch_browser.mpe_run_dir import run_dir
+
+
+class MpeRunDirTests(unittest.TestCase):
+    def test_falls_back_when_run_dir_not_writable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            blocked = Path(tmp) / "blocked"
+            blocked.mkdir()
+            os.chmod(blocked, 0o555)
+            fallback_root = Path(tmp) / "fallback"
+            with tempfile.TemporaryDirectory(dir=fallback_root.parent) as _:
+                pass
+            with unittest.mock.patch.dict(
+                os.environ,
+                {"MPE_RUN_DIR": str(blocked), "TMPDIR": str(Path(tmp) / "fallback")},
+                clear=False,
+            ):
+                resolved = run_dir()
+                self.assertEqual(resolved, Path(tmp) / "fallback" / "mpe")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_events.py
+++ b/tests/test_session_events.py
@@ -66,5 +66,14 @@ class SessionEventEmitTests(unittest.TestCase):
             self.assertEqual(len(started), 1)
 
 
+
+class SessionEventReadTests(unittest.TestCase):
+    def test_read_events_limit_zero_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            emit_event("engine.started", source="t", ts=1.0, run=run)
+            self.assertEqual(read_events(run=run, limit=0), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_events.py
+++ b/tests/test_session_events.py
@@ -1,0 +1,70 @@
+"""Unit tests for patch_browser/session_events.py — Phase 2."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from patch_browser.session_events import (
+    EVENT_NAMES,
+    emit_event,
+    event_line,
+    format_event,
+    parse_event_line,
+    read_events,
+    trim_ring_buffer,
+)
+
+
+class SessionEventFormatTests(unittest.TestCase):
+    def test_format_known_event(self) -> None:
+        ev = format_event("engine.started", detail="jack", source="test", ts=100.0)
+        self.assertEqual(ev["event"], "engine.started")
+        self.assertEqual(ev["ts"], 100.0)
+        self.assertEqual(ev["detail"], "jack")
+
+    def test_unknown_event_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            format_event("not.real")
+
+    def test_event_line_is_one_json_object(self) -> None:
+        line = event_line(format_event("buffer.changed", ts=1.0, source="t"))
+        parsed = json.loads(line)
+        self.assertIn("buffer.changed", EVENT_NAMES)
+        self.assertEqual(parsed["event"], "buffer.changed")
+
+    def test_parse_invalid_line_returns_none(self) -> None:
+        self.assertIsNone(parse_event_line("not json"))
+        self.assertIsNone(parse_event_line(""))
+
+
+class SessionEventEmitTests(unittest.TestCase):
+    def test_emit_appends_and_reads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            emit_event("engine.started", detail="jack", source="unit-test", ts=10.0, run=run)
+            emit_event("engine.exited", detail="failed", source="unit-test", ts=11.0, run=run)
+            events = read_events(run=run)
+            self.assertEqual(len(events), 2)
+            self.assertEqual(events[0]["event"], "engine.started")
+            self.assertEqual(events[1]["event"], "engine.exited")
+
+    def test_ring_buffer_trims(self) -> None:
+        lines = [f'{{"event":"e{i}"}}' for i in range(5)]
+        trimmed = trim_ring_buffer(lines, max_events=3)
+        self.assertEqual(len(trimmed), 3)
+        self.assertIn("e4", trimmed[-1])
+
+    def test_filter_by_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            emit_event("engine.started", source="t", ts=1.0, run=run)
+            emit_event("buffer.changed", source="t", ts=2.0, run=run)
+            started = read_events(run=run, name="engine.started")
+            self.assertEqual(len(started), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_snapshot.py
+++ b/tests/test_session_snapshot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 import time
 import unittest
@@ -15,9 +16,11 @@ from patch_browser.session_snapshot import (
     field_age_stale,
     looper_guard_label,
     looper_policy,
+    next_seq,
     publish_snapshot,
     read_seq,
     read_snapshot,
+    set_maintenance_flag,
     write_snapshot,
 )
 
@@ -76,8 +79,8 @@ class SnapshotBuildTests(unittest.TestCase):
     def test_maintenance_mode(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             run = Path(tmp)
-            (run / "maintenance").write_text("1\n", encoding="utf-8")
-            snap = build_snapshot(now=time.time(), run=run, seq=3)
+            set_maintenance_flag(run=run, source="test", deadline_s=3600.0, pid=os.getpid())
+            snap = build_snapshot(now=time.time(), run=run, seq=3, unit_active=lambda _u: True)
             self.assertEqual(snap["mode"], "maintenance")
 
 
@@ -159,6 +162,33 @@ class DeriveModeTests(unittest.TestCase):
         from patch_browser.session_snapshot import derive_mode
 
         self.assertEqual(derive_mode({"state": "banana"}), "failed")
+
+class SnapshotLivenessUnknownTests(unittest.TestCase):
+    def test_unknown_liveness_marks_fields_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            now = 2_000_000.0
+            (run / "engine.state").write_text(
+                f"engine=jack\nactive=jack\nstate=ok\nupdated={now - 1}\n",
+                encoding="utf-8",
+            )
+            (run / "jack.state").write_text(f"device=hw:0\nstarted={now - 1}\n", encoding="utf-8")
+            (run / "surge.state").write_text(f"engine=jack\nstarted={now - 1}\n", encoding="utf-8")
+            snap = build_snapshot(now=now, run=run, seq=1, unit_active=lambda _u: None)
+            self.assertTrue(snap["engine"]["stale"])
+            self.assertTrue(snap["jack"]["stale"])
+            self.assertTrue(snap["surge"]["stale"])
+
+
+class SnapshotSeqTests(unittest.TestCase):
+    def test_write_snapshot_does_not_regress_seq(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            first = {"schema": SCHEMA_VERSION, "seq": next_seq(run=run), "published_at": 1.0, "mode": "ok"}
+            second = {"schema": SCHEMA_VERSION, "seq": next_seq(run=run), "published_at": 2.0, "mode": "ok"}
+            write_snapshot(first, run=run)
+            write_snapshot(second, run=run)
+            self.assertEqual(read_seq(run=run), 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_snapshot.py
+++ b/tests/test_session_snapshot.py
@@ -190,5 +190,31 @@ class SnapshotSeqTests(unittest.TestCase):
             write_snapshot(second, run=run)
             self.assertEqual(read_seq(run=run), 2)
 
+class SnapshotEngineRecoveryTests(unittest.TestCase):
+    def test_engine_fresh_when_surge_down_but_watchdog_active(self) -> None:
+        """Surge dead + watchdog publishing recovering — engine.value must carry reason."""
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            now = 3_000_000.0
+            (run / "engine.state").write_text(
+                f"engine=jack\nactive=jack\nstate=recovering\nreason=surge-exited\nupdated={now - 2}\n",
+                encoding="utf-8",
+            )
+
+            def _liveness(unit: str) -> bool | None:
+                if unit == "surge-xt-cli":
+                    return False
+                if unit == "surge-watchdog":
+                    return True
+                return True
+
+            snap = build_snapshot(now=now, run=run, seq=1, unit_active=_liveness)
+            self.assertFalse(snap["engine"]["stale"])
+            self.assertIsNotNone(snap["engine"]["value"])
+            self.assertEqual(snap["engine"]["value"]["state"], "recovering")
+            self.assertEqual(snap["engine"]["value"]["reason"], "surge-exited")
+            self.assertEqual(snap["mode"], "recovering")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_snapshot.py
+++ b/tests/test_session_snapshot.py
@@ -1,0 +1,118 @@
+"""Unit tests for patch_browser/session_snapshot.py — Phase 1."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from patch_browser.session_snapshot import (
+    SCHEMA_VERSION,
+    STALE_THRESHOLD_S,
+    build_snapshot,
+    field_age_stale,
+    looper_guard_label,
+    looper_policy,
+    publish_snapshot,
+    read_seq,
+    read_snapshot,
+    write_snapshot,
+)
+
+
+class SnapshotStalenessTests(unittest.TestCase):
+    def test_field_stale_when_missing_updated(self) -> None:
+        now = 1000.0
+        self.assertTrue(field_age_stale(0.0, now=now))
+
+    def test_field_fresh_within_threshold(self) -> None:
+        now = 1000.0
+        self.assertFalse(field_age_stale(now - 1.0, now=now, threshold=STALE_THRESHOLD_S))
+
+    def test_field_stale_beyond_threshold(self) -> None:
+        now = 1000.0
+        self.assertTrue(field_age_stale(now - STALE_THRESHOLD_S, now=now, threshold=STALE_THRESHOLD_S))
+
+
+class SnapshotBuildTests(unittest.TestCase):
+    def test_build_includes_looper_policy_and_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            (run / "engine.state").write_text(
+                "engine=jack\nactive=jack\nstate=ok\nlooper=off\nupdated=999\n",
+                encoding="utf-8",
+            )
+            snap = build_snapshot(
+                now=1000.0,
+                run=run,
+                looper_policy_env="eval",
+                looper_enabled="1",
+                seq=1,
+            )
+            self.assertEqual(snap["schema"], SCHEMA_VERSION)
+            self.assertEqual(snap["looper"]["policy"]["value"], "eval")
+            self.assertEqual(snap["looper"]["guard"]["value"], "guarded")
+            self.assertFalse(snap["engine"]["stale"])
+
+    def test_stale_engine_suppresses_value(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            (run / "engine.state").write_text(
+                "engine=jack\nactive=jack\nstate=ok\nupdated=990\n",
+                encoding="utf-8",
+            )
+            snap = build_snapshot(now=1000.0, run=run, seq=2)
+            self.assertTrue(snap["engine"]["stale"])
+            self.assertIsNone(snap["engine"]["value"])
+
+    def test_maintenance_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            (run / "maintenance").write_text("1\n", encoding="utf-8")
+            snap = build_snapshot(now=time.time(), run=run, seq=3)
+            self.assertEqual(snap["mode"], "maintenance")
+
+
+class SnapshotReadWriteTests(unittest.TestCase):
+    def test_write_read_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            snap = build_snapshot(now=1000.0, run=run, seq=7)
+            path = write_snapshot(snap, run=run)
+            loaded = read_snapshot(path, now=1000.5)
+            self.assertEqual(loaded["seq"], 7)
+            self.assertEqual(loaded["schema"], SCHEMA_VERSION)
+
+    def test_unknown_schema_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "session.snapshot.json"
+            path.write_text(json.dumps({"schema": 99, "seq": 1}) + "\n", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                read_snapshot(path, max_schema=SCHEMA_VERSION)
+
+    def test_publish_writes_monotonic_seq_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            publish_snapshot(run=run, now=100.0, seq=1)
+            publish_snapshot(run=run, now=101.0, seq=2)
+            path = publish_snapshot(run=run, now=102.0, seq=3)
+            loaded = read_snapshot(path, now=102.0)
+            self.assertEqual(loaded["seq"], 3)
+            self.assertEqual(read_seq(run=run), 3)
+
+
+class LooperPolicyTests(unittest.TestCase):
+    def test_default_eval(self) -> None:
+        self.assertEqual(looper_policy(looper_policy_env=""), "eval")
+
+    def test_guard_off_by_default(self) -> None:
+        self.assertEqual(looper_guard_label(looper_enabled="0"), "off")
+
+    def test_guard_blocked_when_enabled(self) -> None:
+        self.assertEqual(looper_guard_label(looper_enabled="1"), "guarded")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_snapshot.py
+++ b/tests/test_session_snapshot.py
@@ -50,20 +50,26 @@ class SnapshotBuildTests(unittest.TestCase):
                 looper_policy_env="eval",
                 looper_enabled="1",
                 seq=1,
+                unit_active=lambda _u: True,
             )
             self.assertEqual(snap["schema"], SCHEMA_VERSION)
             self.assertEqual(snap["looper"]["policy"]["value"], "eval")
             self.assertEqual(snap["looper"]["guard"]["value"], "guarded")
             self.assertFalse(snap["engine"]["stale"])
 
-    def test_stale_engine_suppresses_value(self) -> None:
+    def test_stale_engine_when_surge_inactive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             run = Path(tmp)
             (run / "engine.state").write_text(
                 "engine=jack\nactive=jack\nstate=ok\nupdated=990\n",
                 encoding="utf-8",
             )
-            snap = build_snapshot(now=1000.0, run=run, seq=2)
+            snap = build_snapshot(
+                now=1000.0,
+                run=run,
+                seq=2,
+                unit_active=lambda _u: False,
+            )
             self.assertTrue(snap["engine"]["stale"])
             self.assertIsNone(snap["engine"]["value"])
 
@@ -95,12 +101,13 @@ class SnapshotReadWriteTests(unittest.TestCase):
     def test_publish_writes_monotonic_seq_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             run = Path(tmp)
-            publish_snapshot(run=run, now=100.0, seq=1)
-            publish_snapshot(run=run, now=101.0, seq=2)
-            path = publish_snapshot(run=run, now=102.0, seq=3)
-            loaded = read_snapshot(path, now=102.0)
-            self.assertEqual(loaded["seq"], 3)
-            self.assertEqual(read_seq(run=run), 3)
+            path = publish_snapshot(run=run, now=100.0, unit_active=lambda _u: True)
+            loaded = read_snapshot(path, now=100.0)
+            self.assertEqual(loaded["seq"], 1)
+            path = publish_snapshot(run=run, now=101.0, unit_active=lambda _u: True)
+            loaded = read_snapshot(path, now=101.0)
+            self.assertEqual(loaded["seq"], 2)
+            self.assertEqual(read_seq(run=run), 2)
 
 
 class LooperPolicyTests(unittest.TestCase):
@@ -113,6 +120,45 @@ class LooperPolicyTests(unittest.TestCase):
     def test_guard_blocked_when_enabled(self) -> None:
         self.assertEqual(looper_guard_label(looper_enabled="1"), "guarded")
 
+
+
+class SnapshotRealisticAgeTests(unittest.TestCase):
+    def test_hours_old_started_not_stale_when_units_active(self) -> None:
+        """Pi state files use transition-only timestamps — age must not null values."""
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            started = 1_000_000.0
+            now = started + 16_200.0  # 4.5 hours later
+            (run / "engine.state").write_text(
+                f"engine=jack\nactive=jack\nstate=ok\nupdated={started}\n",
+                encoding="utf-8",
+            )
+            (run / "jack.state").write_text(
+                f"device=hw:0\nstarted={started}\n",
+                encoding="utf-8",
+            )
+            (run / "surge.state").write_text(
+                f"engine=jack\nstarted={started}\n",
+                encoding="utf-8",
+            )
+            (run / "engine-reconcile.state").write_text(
+                "last_restart=0\ncount=0\n",
+                encoding="utf-8",
+            )
+            snap = build_snapshot(now=now, run=run, seq=1, unit_active=lambda _u: True)
+            self.assertFalse(snap["engine"]["stale"])
+            self.assertIsNotNone(snap["engine"]["value"])
+            self.assertFalse(snap["jack"]["stale"])
+            self.assertFalse(snap["surge"]["stale"])
+            self.assertFalse(snap["reconcile"]["stale"])
+            self.assertEqual(snap["mode"], "ok")
+
+
+class DeriveModeTests(unittest.TestCase):
+    def test_unknown_state_becomes_failed(self) -> None:
+        from patch_browser.session_snapshot import derive_mode
+
+        self.assertEqual(derive_mode({"state": "banana"}), "failed")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements Phases 0–2 of [`Documents/specs/session-control-plane-spec.md`](Documents/specs/session-control-plane-spec.md) — no reconciler, no Phase 3 daemon.

### Phase 0 — calibration looper stop/start
- `calibration_teardown.py` stops and restores all four `Restart=always` looper units: `mpe-sooperlooper`, `mpe-apc-bench`, `sl-hud-monitor`, `sl-watchdog`
- Stop order reverse-deps; start after `surge-xt-cli`
- Emits `looper.units.stopped` / `looper.units.started` + `mode.changed` events

### Phase 1 — snapshot schema v1
- `patch_browser/session_snapshot.py` — aggregates `/run/mpe/*.state` into `session.snapshot.json`
- `schema` + `seq`, 1.5 s staleness (D6), per-field provenance
- `looper.policy` (default `eval`, D15) + `looper.guard` (D16 reflection of `MPE_LOOPER_ENABLED`)
- CLI: `python3 -m patch_browser.session_snapshot`

### Phase 2 — event stream
- `patch_browser/session_events.py` + `scripts/lib/session-events.sh` — append-only JSONL ring at `/run/mpe/events.jsonl`
- Spec event names + calibration looper events
- Surgical emits in `audio-engine.sh`: engine transitions, `buffer.changed`, graph restart

## Acceptance checklist

| Phase | Criterion | Status |
|-------|-----------|--------|
| 0 | Looper units stopped/restored during calibration | ✅ |
| 1 | Single snapshot with schema/seq/staleness | ✅ |
| 1 | Looper policy + guard placeholders | ✅ |
| 1 | Unit tests write/read/staleness | ✅ |
| 2 | Named structured events | ✅ |
| 2 | Emit at engine/graph chokepoints | ✅ |
| 2 | Unit tests format/emit | ✅ |

**Deferred (out of scope):** Phase 1 criterion 6 (mpe-cli re-point), snapshot daemon/publish loop, grid/client leak events, maintenance flag (D11 full).

## Spec ambiguities

- **Q9:** HUD/watchdog home-dir JSON included in snapshot `looper.hud` with staleness; watchdog JSON not yet aggregated (no production reader).
- **`looper.units.*` events:** Added beyond spec list — calibration-specific; spec `mode.changed` also emitted.
- **Auto seq increment:** `publish_snapshot()` bumps seq via sidecar file; no 500 ms publisher yet (Phase 3+).

## Test plan

- [x] `mpe test local all` — 873 tests OK (3 skipped)
- [ ] Pi: run calibration end-to-end; confirm looper units stay stopped during run and restore after
- [ ] Pi: `python3 -m patch_browser.session_snapshot --run-dir /run/mpe` after boot
- [ ] Pi: inspect `/run/mpe/events.jsonl` after buffer change / graph restart
