### PR TITLE
perf: batch looper reconcile in bash; throttle to 30s

### DIFF
--- a/Documents/specs/session-control-plane-spec.md
+++ b/Documents/specs/session-control-plane-spec.md
@@ -354,6 +354,22 @@ retirement schedule.
 
 ### Phase 2 — Event stream
 
+**Event emitter cost constraint (Phase 2 expansion).** Bash callers emit via
+`scripts/mpe-session-event-emit.py`, which forks a Python interpreter per event
+(~360 ms on Pi). That is acceptable for transition-only events (engine start/stop,
+buffer change, calibration stop/restore). It is **not** acceptable for periodic or
+high-rate events — deferred names like `client.registered` during a graph rebuild
+can fire dozens of times per second on the recovery path where jackd is already
+missing deadlines. Before adding chatty events, the emitter must become long-lived
+or move in-process. Criterion 11 assumes events stay rare.
+
+**Snapshot publisher cost (Phase 3).** `build_snapshot()` is ~58 ms in-process on
+the Pi (~36 ms of that is systemctl). At `PUBLISH_INTERVAL_S = 0.5` that is ~12%
+of a core unless unit liveness is batched and cached (~1 s TTL). Batch the three
+distinct units into one `systemctl is-active` call when building the Phase 3
+publisher — not speculative work until that publisher lands.
+
+
 | # | Criterion | Verification |
 |---|---|---|
 | 9 | Discrete events with stable names, one line each, structured | `engine.started`, `engine.exited`, `grid.established`, `grid.dropped`, `buffer.changed`, `client.registered`, `client.leaked`, `mode.changed` |

--- a/patch_browser/session_snapshot.py
+++ b/patch_browser/session_snapshot.py
@@ -3,6 +3,10 @@
 Aggregates existing runtime truth under ``/run/mpe/session.snapshot.json``.
 Does not own engine state; readers treat stale sub-sources as unknown (never
 last-known-good).
+
+Do not run ``python3 -m patch_browser.session_snapshot`` on a systemd
+timer — CLI startup is ~360 ms on the Pi vs ~58 ms in-process. The CLI is
+for debugging; Phase 3 publisher must call ``build_snapshot()`` in-process.
 """
 
 from __future__ import annotations

--- a/scripts/surge-watchdog.sh
+++ b/scripts/surge-watchdog.sh
@@ -96,6 +96,34 @@ _reconcile_engine() {
     _supervisor_restart_surge "promote-to-jack"
 }
 
+
+LOOPER_RECONCILE_INTERVAL_S="${MPE_LOOPER_RECONCILE_INTERVAL_S:-30}"
+_last_looper_reconcile=0
+
+# Batched systemctl pre-filter: fork Python (~400 ms on Pi) only when a looper
+# unit is non-active. Steady state is one systemctl call (~22 ms) every 30 s.
+_reconcile_looper_units_if_needed() {
+    local script need=0 state
+    local -a units=(
+        mpe-sooperlooper.service
+        mpe-apc-bench.service
+        sl-hud-monitor.service
+        sl-watchdog.service
+    )
+    script="${MPE_MODULE_REPO}/scripts/ensure-looper-units-running.py"
+
+    while IFS= read -r state; do
+        if [ "$state" != "active" ]; then
+            need=1
+            break
+        fi
+    done < <(systemctl is-active "${units[@]}" 2>/dev/null)
+
+    [ "$need" = 0 ] && return 0
+    [ -x "$script" ] || return 0
+    python3 "$script" >/dev/null 2>&1 || true
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 log "=== Surge Watchdog Started (engine=jack) ==="
 
@@ -129,8 +157,10 @@ while true; do
 
     _reconcile_engine
 
-    if [ -x "$MPE_MODULE_REPO/scripts/ensure-looper-units-running.py" ]; then
-        python3 "$MPE_MODULE_REPO/scripts/ensure-looper-units-running.py" >/dev/null 2>&1 || true
+    now=$(date +%s)
+    if [ $((now - _last_looper_reconcile)) -ge "$LOOPER_RECONCILE_INTERVAL_S" ]; then
+        _reconcile_looper_units_if_needed
+        _last_looper_reconcile=$now
     fi
 
     sleep 5

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -529,6 +529,16 @@ class NoAlsaPathTests(unittest.TestCase):
         for token in ("active=alsa", "mpe_surge_active_engine", "release-alsa-for-jackd", "degraded"):
             self.assertNotIn(token, text, f"surge-watchdog.sh still references {token!r}")
 
+    def test_surge_watchdog_looper_reconcile_batched_and_throttled(self) -> None:
+        text = SURGE_WATCHDOG_SH.read_text(encoding="utf-8")
+        self.assertIn("_reconcile_looper_units_if_needed", text)
+        self.assertIn("LOOPER_RECONCILE_INTERVAL_S", text)
+        self.assertIn('systemctl is-active "${units[@]}"', text)
+        self.assertNotIn(
+            "python3 \"$MPE_MODULE_REPO/scripts/ensure-looper-units-running.py\" >/dev/null 2>&1 || true\n    fi\n\n    sleep 5",
+            text,
+        )
+
     def test_engine_guard_offers_no_engine_switch(self) -> None:
         text = ENGINE_GUARD_SH.read_text(encoding="utf-8")
         self.assertNotIn("MPE_AUDIO_ENGINE", text)


### PR DESCRIPTION
## Summary
- Post-#66 fix: surge-watchdog batched `systemctl is-active` pre-filter; Python only on non-active looper units
- Reconcile cadence 30s (was 5s) — ~22 ms steady state vs ~437 ms every 5s
- Spec/doc notes on snapshot CLI and event-emitter cost constraints

## Context
PR #66 merged to dev; this commit was still on `yolo/session-control-phase0-2`.

## Test plan
- [x] `bash scripts/yolo/check-backpressure.sh` (889 tests)
- [ ] Pi: confirm steady-state watchdog CPU drop

Made with [Cursor](https://cursor.com)