### PR TITLE
perf: skip jack_lsp on steady-state surge-watchdog tick

### DIFF
--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -259,20 +259,28 @@ mpe_jack_graph_user() {
     id -un 2>/dev/null || printf '%s' "${USER:-root}"
 }
 
+_mpe_jack_lsp_bin() {
+    if [ "${_MPE_JACK_LSP_BIN_RESOLVED:-}" != 1 ]; then
+        _MPE_JACK_LSP_BIN="$(command -v jack_lsp 2>/dev/null || true)"
+        _MPE_JACK_LSP_BIN_RESOLVED=1
+    fi
+    [ -n "$_MPE_JACK_LSP_BIN" ]
+}
+
 mpe_jack_lsp() {
     local timeout_s="${MPE_JACK_LSP_TIMEOUT_S:-3}"
-    if ! command -v jack_lsp >/dev/null 2>&1; then
+    if ! _mpe_jack_lsp_bin; then
         return 127
     fi
     if [ "$(id -u)" -eq 0 ]; then
         local owner
         owner="$(mpe_jack_graph_user)"
         if [ -n "$owner" ] && [ "$owner" != root ]; then
-            timeout "$timeout_s" sudo -u "$owner" -E jack_lsp "$@"
+            timeout "$timeout_s" sudo -u "$owner" -E "$_MPE_JACK_LSP_BIN" "$@"
             return $?
         fi
     fi
-    timeout "$timeout_s" jack_lsp "$@"
+    timeout "$timeout_s" "$_MPE_JACK_LSP_BIN" "$@"
 }
 
 # Running is not the same as accepting clients. jack_lsp is a hard prerequisite
@@ -281,7 +289,7 @@ mpe_jack_lsp() {
 mpe_jack_server_ready() {
     local quiet="${1:-0}"
     mpe_jack_server_running || return 1
-    if ! command -v jack_lsp >/dev/null 2>&1; then
+    if ! _mpe_jack_lsp_bin; then
         [ "$quiet" = 1 ] || echo "ERROR: jack_lsp not found — install jack-example-tools" >&2
         return 1
     fi
@@ -293,7 +301,7 @@ mpe_wait_for_jack_server() {
     local timeout="${1:-$(mpe_jack_ready_timeout)}"
     local waited=0
     local step_ms=250
-    if mpe_jack_server_running && ! command -v jack_lsp >/dev/null 2>&1; then
+    if mpe_jack_server_running && ! _mpe_jack_lsp_bin; then
         echo "ERROR: jack_lsp not found — install jack-example-tools" >&2
         return 1
     fi
@@ -647,7 +655,7 @@ mpe_engine_reconcile_reset() {
 
 mpe_surge_on_jack_graph() {
     mpe_jack_server_ready || return 1
-    if ! command -v jack_lsp >/dev/null 2>&1; then
+    if ! _mpe_jack_lsp_bin; then
         return 1
     fi
     mpe_jack_lsp 2>/dev/null | grep -qi 'surge'

--- a/scripts/surge-watchdog.sh
+++ b/scripts/surge-watchdog.sh
@@ -23,7 +23,7 @@ _supervisor_restart_surge() {
         return 1
     fi
     local now decision last count jackd_start looper_label
-    now=$(date +%s)
+    now=$EPOCHSECONDS
     last=$(mpe_engine_reconcile_last_restart)
     count=$(mpe_engine_reconcile_count)
     jackd_start=$(mpe_jack_start_epoch)
@@ -63,12 +63,23 @@ _supervisor_restart_surge() {
 # budget, then treat jackd as down and restart Surge (it will fail loud and
 # retry on its own until jackd recovers — spec D3 amended 2026-08-13).
 _reconcile_engine() {
-    local waited looper_label
+    local waited looper_label state active
 
     looper_label="$(mpe_looper_state_label)"
 
     if mpe_planned_promote_flag_set; then
         return 0
+    fi
+
+    # Steady state: unit active and engine already ok — skip jack_lsp (~116 ms/call,
+    # registers an ephemeral JACK client each time). Graph probe only when action
+    # may be needed (same pattern as looper reconcile pre-filter, PR #68).
+    if systemctl is-active --quiet "$SURGE_SERVICE" 2>/dev/null; then
+        state="$(mpe_engine_state_get state)"
+        active="$(mpe_engine_state_get active)"
+        if [ "$state" = ok ] && [ "$active" = jack ]; then
+            return 0
+        fi
     fi
 
     if mpe_surge_on_jack_graph; then
@@ -157,7 +168,7 @@ while true; do
 
     _reconcile_engine
 
-    now=$(date +%s)
+    now=$EPOCHSECONDS
     if [ $((now - _last_looper_reconcile)) -ge "$LOOPER_RECONCILE_INTERVAL_S" ]; then
         _reconcile_looper_units_if_needed
         _last_looper_reconcile=$now

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -529,6 +529,16 @@ class NoAlsaPathTests(unittest.TestCase):
         for token in ("active=alsa", "mpe_surge_active_engine", "release-alsa-for-jackd", "degraded"):
             self.assertNotIn(token, text, f"surge-watchdog.sh still references {token!r}")
 
+    def test_surge_watchdog_uses_epochseconds(self) -> None:
+        text = SURGE_WATCHDOG_SH.read_text(encoding="utf-8")
+        self.assertIn("now=$EPOCHSECONDS", text)
+        self.assertNotIn("now=$(date +%s)", text)
+
+    def test_surge_watchdog_reconcile_short_circuits_on_ok_surge(self) -> None:
+        text = SURGE_WATCHDOG_SH.read_text(encoding="utf-8")
+        self.assertIn('systemctl is-active --quiet "$SURGE_SERVICE"', text)
+        self.assertIn('[ "$state" = ok ] && [ "$active" = jack ]', text)
+
     def test_surge_watchdog_looper_reconcile_batched_and_throttled(self) -> None:
         text = SURGE_WATCHDOG_SH.read_text(encoding="utf-8")
         self.assertIn("_reconcile_looper_units_if_needed", text)
@@ -604,6 +614,14 @@ exit 1
         self.assertNotIn("detect-audio-device.sh\"", text)
 
 
+class JackLspPathTests(unittest.TestCase):
+    def test_jack_lsp_uses_resolved_absolute_path(self) -> None:
+        text = AUDIO_ENGINE_SH.read_text(encoding="utf-8")
+        self.assertIn("_mpe_jack_lsp_bin", text)
+        self.assertIn('"$_MPE_JACK_LSP_BIN"', text)
+        self.assertNotIn('timeout "$timeout_s" jack_lsp "$@"', text)
+
+
 class WatchdogReconcileArmTests(unittest.TestCase):
     """B3 — reconcile arms via surge-watchdog.sh _reconcile_engine (finding 8).
     Single-engine: on graph -> ok; ready but off graph -> promote; not ready ->
@@ -627,6 +645,32 @@ mpe_surge_on_jack_graph() { return 0; }
             result = self._run_reconcile(env=env, stubs=stubs)
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip(), "ok:jack")
+
+    def test_reconcile_skips_jack_probe_when_surge_ok(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            engine = Path(tmp) / "engine.state"
+            engine.write_text(
+                "engine=jack\nactive=jack\nstate=ok\nupdated=1\nlooper=off\n",
+                encoding="utf-8",
+            )
+            stubs = """
+mpe_jack_server_ready() { echo JACK_LSP_PROBE >&2; return 1; }
+mpe_surge_on_jack_graph() { echo GRAPH_PROBE >&2; return 1; }
+export -f mpe_jack_server_ready mpe_surge_on_jack_graph
+systemctl() {
+  case "$*" in
+    is-active*surge-xt-cli*) return 0 ;;
+  esac
+  return 1
+}
+export -f systemctl
+"""
+            result = self._run_reconcile(env=env, stubs=stubs)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "ok:jack")
+            self.assertNotIn("JACK_LSP_PROBE", result.stderr)
+            self.assertNotIn("GRAPH_PROBE", result.stderr)
 
     def test_jackd_never_ready_restarts_surge_as_jackd_down(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- `_reconcile_engine` short-circuits when `surge-xt-cli` is active and engine state is ok/jack — no `jack_lsp` on healthy 5 s ticks (~4.6% core saved)
- Cache `jack_lsp` absolute path (`_mpe_jack_lsp_bin`) — avoids repeated PATH misses
- `date +%s` → `$EPOCHSECONDS` in surge-watchdog looper/reconcile timing

## Test plan
- [x] 893 tests (new reconcile short-circuit + jack_lsp path tests)
- [ ] Pi: strace/count jack_lsp invocations on steady-state watchdog

Made with [Cursor](https://cursor.com)