### PR TITLE
fix: bound jack_lsp short-circuit; forkless mpe_state_get

### DIFF
--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -176,8 +176,12 @@ mpe_surge_state_file() {
 mpe_state_get() {
     local file="${1:?state file required}"
     local key="${2:?key required}"
+    local k v val=""
     [ -r "$file" ] || return 0
-    grep -E "^${key}=" "$file" 2>/dev/null | tail -1 | cut -d= -f2-
+    while IFS='=' read -r k v; do
+        [ "$k" = "$key" ] && val="$v"
+    done < "$file"
+    printf '%s\n' "$val"
 }
 
 # Publish engine state for `mpe engine status` and the touch HUD.

--- a/scripts/surge-watchdog.sh
+++ b/scripts/surge-watchdog.sh
@@ -71,17 +71,18 @@ _reconcile_engine() {
         return 0
     fi
 
-    # Steady state: unit active and engine already ok — skip jack_lsp (~116 ms/call,
-    # registers an ephemeral JACK client each time). Graph probe only when action
-    # may be needed (same pattern as looper reconcile pre-filter, PR #68).
+    # Steady state: unit active and engine already ok — skip jack_lsp if a full
+    # graph probe ran recently. Unbounded skip is indistinguishable from stopping
+    # to look (orphaned JACK client, DECISIONS.md 2026-08-15).
     if systemctl is-active --quiet "$SURGE_SERVICE" 2>/dev/null; then
         state="$(mpe_engine_state_get state)"
         active="$(mpe_engine_state_get active)"
-        if [ "$state" = ok ] && [ "$active" = jack ]; then
+        if [ "$state" = ok ] && [ "$active" = jack ]            && [ $((EPOCHSECONDS - _last_jack_probe)) -lt "$JACK_PROBE_INTERVAL_S" ]; then
             return 0
         fi
     fi
 
+    _last_jack_probe=$EPOCHSECONDS
     if mpe_surge_on_jack_graph; then
         mpe_engine_state_write "$MPE_ENGINE_NAME" jack ok "" "$looper_label"
         mpe_engine_reconcile_reset
@@ -110,6 +111,11 @@ _reconcile_engine() {
 
 LOOPER_RECONCILE_INTERVAL_S="${MPE_LOOPER_RECONCILE_INTERVAL_S:-30}"
 _last_looper_reconcile=0
+
+# Bound the healthy-path short-circuit: full graph probe at least once per interval
+# (116 ms / 60 s = 0.19% of a core). _last_jack_probe=0 forces probe on first tick.
+JACK_PROBE_INTERVAL_S="${MPE_JACK_PROBE_INTERVAL_S:-60}"
+_last_jack_probe=0
 
 # Batched systemctl pre-filter: fork Python (~400 ms on Pi) only when a looper
 # unit is non-active. Steady state is one systemctl call (~22 ms) every 30 s.

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -365,6 +365,19 @@ printf '%s' "$(mpe_engine_reconcile_count)"
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip(), "2")
 
+    def test_mpe_state_get_last_match_wins(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            state_file = Path(tmp) / "engine.state"
+            state_file.write_text("state=recovering\nstate=ok\nactive=jack\n", encoding="utf-8")
+            body = f"""
+source {AUDIO_ENGINE_SH}
+printf 'state=%s active=%s\n' "$(mpe_state_get '{state_file}' state)" "$(mpe_state_get '{state_file}' active)"
+"""
+            result = _run_bash_script(body, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "state=ok active=jack")
+
     def test_atomic_engine_state_roundtrip(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             env = _bash_env(tmp)
@@ -538,6 +551,8 @@ class NoAlsaPathTests(unittest.TestCase):
         text = SURGE_WATCHDOG_SH.read_text(encoding="utf-8")
         self.assertIn('systemctl is-active --quiet "$SURGE_SERVICE"', text)
         self.assertIn('[ "$state" = ok ] && [ "$active" = jack ]', text)
+        self.assertIn("JACK_PROBE_INTERVAL_S", text)
+        self.assertIn("_last_jack_probe=$EPOCHSECONDS", text)
 
     def test_surge_watchdog_looper_reconcile_batched_and_throttled(self) -> None:
         text = SURGE_WATCHDOG_SH.read_text(encoding="utf-8")
@@ -655,6 +670,8 @@ mpe_surge_on_jack_graph() { return 0; }
                 encoding="utf-8",
             )
             stubs = """
+_last_jack_probe=$EPOCHSECONDS
+JACK_PROBE_INTERVAL_S=60
 mpe_jack_server_ready() { echo JACK_LSP_PROBE >&2; return 1; }
 mpe_surge_on_jack_graph() { echo GRAPH_PROBE >&2; return 1; }
 export -f mpe_jack_server_ready mpe_surge_on_jack_graph
@@ -671,6 +688,27 @@ export -f systemctl
             self.assertEqual(result.stdout.strip(), "ok:jack")
             self.assertNotIn("JACK_LSP_PROBE", result.stderr)
             self.assertNotIn("GRAPH_PROBE", result.stderr)
+
+    def test_reconcile_probes_graph_again_after_the_interval(self) -> None:
+        """A short-circuit that never re-probes cannot see an orphaned JACK client."""
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _bash_env(tmp)
+            engine = Path(tmp) / "engine.state"
+            engine.write_text(
+                "engine=jack\nactive=jack\nstate=ok\nupdated=1\nlooper=off\n",
+                encoding="utf-8",
+            )
+            stubs = """
+_last_jack_probe=0
+JACK_PROBE_INTERVAL_S=60
+mpe_surge_on_jack_graph() { echo GRAPH_PROBE >&2; return 0; }
+export -f mpe_surge_on_jack_graph
+systemctl() { case "$*" in is-active*surge-xt-cli*) return 0 ;; esac; return 1; }
+export -f systemctl
+"""
+            result = self._run_reconcile(env=env, stubs=stubs)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("GRAPH_PROBE", result.stderr, "stale short-circuit never re-probes")
 
     def test_jackd_never_ready_restarts_surge_as_jackd_down(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Bound the `_reconcile_engine` short-circuit with `JACK_PROBE_INTERVAL_S` (default 60s) so orphaned JACK clients are re-detected without jack_lsp every 5s (~0.19% CPU vs blind steady state).
- Set `_last_jack_probe` before `mpe_surge_on_jack_graph` so the interval records "I looked," not "I liked what I saw."
- Replaced `grep|tail|cut` in `mpe_state_get` with a while-read loop (zero forks per key lookup).

## Test plan
- [x] `bash scripts/yolo/check-backpressure.sh` — 895 tests pass
- [x] `test_reconcile_skips_jack_probe_when_surge_ok` — still skips when probe is recent
- [x] `test_reconcile_probes_graph_again_after_the_interval` — re-probes when interval expired
- [x] `test_mpe_state_get_last_match_wins` — last-match semantics preserved
- [ ] Pi soak: steady-state tick ~1% with graph probe every 60s


Made with [Cursor](https://cursor.com)