### PR TITLE
Looper loop seam: input latency + defining-take tail capture (P0+P1)

### DIFF
--- a/Documents/specs/looper-loop-seam-spec.md
+++ b/Documents/specs/looper-loop-seam-spec.md
@@ -1,0 +1,268 @@
+# Looper loop seam — tail capture and wrap continuity
+
+**Issue:** untracked  
+**Status:** Approved (P0 + P1); Tier 3 blocked on spike  
+**Last updated:** 2026-08-18 (America/Toronto)
+
+**Register:** working hypothesis unless labelled **measured**. Builds on shipped grid
+clock work (`looper-transport-clock-spec.md`, `DECISIONS.md` 2026-08-15).
+
+---
+
+## Problem statement
+
+When a take closes (pad-down while recording), the loop often **clicks or drops
+content at the wrap** — sample N−1 → sample 0. Mitch reports:
+
+- Wrap pop on repeat (partially addressed by `fade_samples`; still audible on
+  some material).
+- **Missing release / tail** when stop is immediate — audio still in the JACK
+  graph after the OSC stop is not in the buffer.
+- Confusion between **pre-roll** (capture before record arm) and **post-roll**
+  (capture through release and weld onto the seam). **This spec is post-roll /
+  seam only.**
+
+**Product requirement:** closing a take should produce a loop whose **end flows
+into its start** on playback, without the player changing technique (pad before
+note, EDP threshold tricks, etc.).
+
+**Non-goals:**
+
+- Pre-roll / missing **attack** at loop head (separate concern; may share
+  `input_latency` calibration).
+- Replacing phase re-anchor (`MPE_SL_GRID_ANCHOR_*`) — orthogonal.
+- Overdub as a **performance** mode (Mitch's model is finished clips, not
+  EDP-style open-loop layering — `DECISIONS.md` 2026-08-14).
+
+---
+
+## Background — what “seam good” means
+
+At pad-down close:
+
+1. **Playback starts** from sample 0 (SooperLooper already does this on
+   record-off → Playing).
+2. **Release tail** is still audible (Surge envelope, JACK pipeline).
+3. That tail belongs at the **end** of the buffer (near N), not the start — the
+   wrap seam is **end → start**.
+4. When the envelope is quiet, the tail is **welded** onto `[N−M, N)` and
+   crossfaded into `[0, M)` so repeated wraps are continuous.
+
+**Live vs buffer geometry:** hearing “tail blending into the first part” at the
+moment of stop is correct **live**; storing tail on sample 0 via overdub-at-playhead-0
+fixes the wrong index and can **leak** into the next gesture if the player
+switches loops quickly while SL is still in overdub.
+
+---
+
+## Rejected approaches
+
+| Approach | Why rejected |
+|----------|----------------|
+| Fixed `POST_ROLL_MS` defer before stop | Extends bar by constant ms → wrong BPM on clip 0, fights quantized stop on grid clips. |
+| Extend phase re-anchor wrap window | Timing/phase only; does not add audio to the buffer. |
+| Naive stop → overdub until silence (all clips, no guard) | Tail lands at playhead 0+; **fast pad switch** leaves another loop/channel in overdub, capturing bleed. |
+| `rec_thresh` silence-close in SL alone | SL **ignores threshold on finish** (current docs); not available without bench logic or engine change. |
+
+---
+
+## Design — three tiers (build in order)
+
+### Tier 1 — Latency + crossfade (baseline, all clips)
+
+**Intent:** align SL’s record/stop boundaries with JACK pipeline delay; smooth
+wrap regardless of content.
+
+| Control | Action |
+|---------|--------|
+| `input_latency` | Set per loop (or `-1` all) from JACK reported latency; optional `autoset_latency=1` at engine start. |
+| `fade_samples` | Already set via `MPE_SL_FADE_SAMPLES` (default 256); tune after Tier 2/3 if needed. |
+| `trigger_latency` | Default 0 unless ear tests say otherwise (forum pattern: drop trigger, tune input only). |
+
+**Where:** `sl_grid_sync.py` → `apply_grid_sync()` and/or
+`configure-grid-sync.sh` after engine start.
+
+**Acceptance:** A/B same take with latency unset vs set — wrap pop reduced or
+unchanged (not worse). No change to loop length or grid BPM.
+
+---
+
+### Tier 2 — Envelope-following close (clip 0 / defining take only)
+
+**Intent:** free-form first take **may grow** to include natural release; tempo
+is derived from final length anyway (`sl_grid_state.py`).
+
+**Behavior on pad-down while recording (defining take only):**
+
+1. Enter **`TAIL_CAPTURE`** bench state — **do not** send `record` stop yet.
+2. Continue **Recording** in SL (still `SL_STATE_RECORDING`).
+3. Poll `in_peak_meter` (OSC `/sl/{n}/get`) until peak &lt; `MPE_SL_TAIL_THRESH`
+   for `MPE_SL_TAIL_HOLD_MS` consecutive, or `MPE_SL_TAIL_MAX_MS` elapses.
+4. Send `record` stop → Playing; proceed with existing grid establish +
+   phase re-anchor.
+
+**Guardrails:**
+
+- Only when `grid.is_pending(loop)` / defining take (`loop_model.plan_gesture`
+  `arm_grid` path).
+- **Block** other gestures on **this** loop until capture ends or aborts.
+- Bank switch / pad release on **other** loops unaffected.
+- Long-press clear still cancels (existing hold path).
+
+**Acceptance (B2 / Mitch ear):** one-bar synth phrase, stop on downbeat —
+release audible through wrap; clip 0 `cycle_len` includes tail; derived BPM stable.
+
+---
+
+### Tier 3 — Fixed-bar seam weld (grid clips 1+)
+
+**Intent:** loop length stays **one quantised cycle**; tail after the nominal
+stop is captured in parallel and merged at the seam only.
+
+**Behavior on pad-down while recording (grid established, not defining):**
+
+1. If quantised: wait for existing **WAIT_STOP / boundary** behaviour (unchanged).
+2. On transition to **Playing** (loop length fixed at N):
+   - Enter **`SEAM_WELD`** on this loop only.
+   - Start **parallel tail capture** (see spike below).
+3. While welding: loop plays; tail buffer fills from loop input (or SL overdub
+   scoped to seam — see spike).
+4. When envelope quiet or max ms: apply **seam merge** on `[N−M, N)` and
+   `[0, M)`; exit weld mode; SL returns to normal Playing.
+
+**Guardrails (required — Mitch concern):**
+
+- **Single-loop lock:** while loop *i* is in `SEAM_WELD` or `TAIL_CAPTURE`, ignore
+  record/overdub/mute on *i* except explicit cancel (long-press clear).
+- **No overdub leak:** before any command on loop *j≠i*, ensure loop *i* is not
+  in SL overdub/recording for tail — force `overdub` off or `undo` tail pass if
+  abandoned.
+- **Bank switch:** if the welded loop scrolls off-screen, **finish or abort**
+  weld within `MPE_SL_TAIL_MAX_MS`; do not leave SL overdubbing on a non-visible
+  loop.
+- **Abort:** long-press clear or second pad-down cancel → discard tail scratch,
+  normal idle.
+
+**Spike (Gate A blocker for Tier 3 implementation):**
+
+SooperLooper has **no** “weld tail here” OSC. Candidates to prove on bench:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Stay in Record until silence** after quantize boundary | SL-native | **Extends** N past bar — breaks fixed-bar unless stop aligns perfectly. |
+| **B. Scratch loop slot** — record tail on loop 15, substitute/copy | SL-native-ish | Needs command sequence; 16-loop limit; complex UX. |
+| **C. JACK-side tail tap** (`mpe-looper` or tap port) + offline merge | Full control | New audio path; CPU; not Phase 1. |
+| **D. SL substitute** at end of first playback cycle | One cycle replace | Playhead timing; tail may be gone before playhead reaches N. |
+
+**Decision rule:** Tier 3 code starts only after spike documents **one** viable
+path with ear pass on 1-bar grid clip. Until then, ship Tier 1 + Tier 2.
+
+---
+
+## State machine (bench layer)
+
+New states in `apc_footswitch.py` (per loop, orthogonal to `sl_state`):
+
+```
+IDLE / RECORDING / PLAYING / …  (existing derive_state)
+
+TAIL_CAPTURE   — Tier 2; SL still Recording; waiting for silence
+SEAM_WELD      — Tier 3; SL Playing; tail scratch + merge pending
+```
+
+```mermaid
+stateDiagram-v2
+    [*] --> Recording: pad down (defining)
+    Recording --> TailCapture: pad down close (defining)
+    TailCapture --> Playing: silence or max ms → record stop
+    Recording --> WaitStop: pad down close (grid)
+    WaitStop --> Playing: quantize boundary
+    Playing --> SeamWeld: weld armed (grid, Tier 3)
+    SeamWeld --> Playing: merge done or abort
+    TailCapture --> Idle: long-press clear
+    SeamWeld --> Idle: long-press clear
+```
+
+LED hint (hypothesis): blink **amber** during `TAIL_CAPTURE` / `SEAM_WELD` so
+“still finishing take” is visible and fast switching is discouraged.
+
+---
+
+## Configuration (env)
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `MPE_SL_TAIL_THRESH` | `0.02` | Peak meter below this = silence ( tune on Pi ) |
+| `MPE_SL_TAIL_HOLD_MS` | `80` | Consecutive silence before close |
+| `MPE_SL_TAIL_MAX_MS` | `750` | Force close / abort weld |
+| `MPE_SL_SEAM_MERGE_SAMPLES` | `2048` | Crossfade width M at seam (Tier 3) |
+| `MPE_SL_TAIL_CAPTURE` | `1` | Master enable Tier 2; `0` = Tier 1 only |
+| `MPE_SL_SEAM_WELD` | `0` | Tier 3 off until spike passes |
+| `MPE_SL_INPUT_LATENCY` | *(unset)* | Override; else JACK autoset |
+| `MPE_SL_FADE_SAMPLES` | `256` | Existing global crossfade |
+
+---
+
+## Acceptance criteria
+
+| ID | Tier | Criterion | Test type |
+|----|------|-----------|-----------|
+| S1 | 1 | `input_latency` / `fade_samples` applied on every `sl-grid-sync` / engine restart | Unit + `dump-loop-levels` |
+| S2 | 1 | Wrap pop not worse than baseline on clip 0 (Mitch ear) | Manual B2 |
+| S3 | 2 | Defining take includes release; no infinite record on stuck note (max ms) | Unit poll logic + ear |
+| S4 | 2 | Long-press clear during tail capture → idle, no orphan SL Recording | Manual |
+| S5 | 3 | Grid clip length = exactly one cycle after weld; tail at seam not at sample 0 only | Ear + `cycle_len` OSC |
+| S6 | * | Fast switch to another pad during weld → **no** overdub bleed on other loop | Manual (Mitch scenario) |
+| S7 | * | Grid BPM unchanged by tail capture on clips 1+ | `derive_tempo` unchanged |
+
+---
+
+## Implementation plan
+
+| Phase | Deliverable | Gate |
+|-------|-------------|------|
+| **P0** | Tier 1: wire latency + document tuning procedure | Mitch ear S2 |
+| **P1** | Tier 2: `TAIL_CAPTURE` in `apc_footswitch.py`, peak poll, tests | Spec review + S3–S4 |
+| **P2** | Tier 3 spike write-up in `docs/measurements/` | Pick option A–D |
+| **P3** | Tier 3 implementation (if spike passes) | S5–S7 |
+
+**Files (expected touch):**
+
+- `scripts/sooperlooper/sl_grid_sync.py` — Tier 1
+- `scripts/sooperlooper/apc_footswitch.py` — state machine, peak poll
+- `scripts/sooperlooper/loop_model.py` — gesture plans for tail vs immediate stop
+- `tests/test_apc_footswitch.py` — tail timeout, thresh hold, abort
+- `config/mpe.env.example` — new vars
+- `Documents/DECISIONS.md` — row on seam policy when promoted
+
+---
+
+## Falsification
+
+| If | Then |
+|----|------|
+| Tier 1 alone fixes wrap on clip 0 + grid clips | Stop at P0; defer P1–P3 |
+| Tier 2 makes clip 0 length unstable / weird BPM | Lower max ms or disable Tier 2; rely on Tier 1 |
+| No Tier 3 spike passes | Document “grid clips: quantize stop + Tier 1 only”; close Tier 3 |
+| Peak meter too noisy on Pi | RMS from JACK tap or higher thresh; do not ship hot-loop overdub |
+
+---
+
+## References
+
+- SooperLooper sync/latency: https://sonosaurus.com/sooperlooper/doc_sync.html  
+- OSC `in_peak_meter`, `input_latency`: https://sonosaurus.com/sooperlooper/doc_osc.html  
+- Grid / phase: `Documents/specs/looper-transport-clock-spec.md` §K  
+- Pad gesture plan: `scripts/sooperlooper/loop_model.py`  
+- Wrap pop history: `looper-transport-clock-spec.md` §B  
+
+---
+
+## Open questions (for spec review)
+
+1. **Tier 2 on grid defining take only** — confirm clip 0 always free-form even
+   if grid was dropped and re-armed on same pad.
+2. **LED colour** during tail capture — amber vs faster blink green?
+3. **Tier 3 spike owner** — bench session vs nerdrack YOLO after Gate A.
+
+**Next step:** `spec-review` → Gate A → P0 implementation.

--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -161,6 +161,14 @@ MPE_MIDI_CLOCK_IN_PORT=RC-5
 # MPE_SL_GRID_ANCHOR_MAX_S=0.015
 # MPE_SL_GRID_ANCHOR_FALLBACK_CYCLES=1.1
 # MPE_SL_BENCH_LOOP_POS_MS=20     # loop_pos poll for phase re-anchor (default 20 ms)
+# Loop seam (looper-loop-seam-spec.md): tail capture on defining take close.
+# MPE_SL_TAIL_CAPTURE=1
+# MPE_SL_TAIL_THRESH=0.02
+# MPE_SL_TAIL_HOLD_MS=80
+# MPE_SL_TAIL_MAX_MS=750
+# MPE_SL_TAIL_PEAK_MS=100
+# MPE_SL_AUTOSET_LATENCY=1
+# MPE_SL_INPUT_LATENCY=           # optional override in samples
 
 # --- Touch UI (5" DSI test Pi — touch-patch-browser.service) ---
 # MPE_TOUCH_WINDOWED=1          # windowed dev mode instead of fullscreen KMS

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -291,6 +291,7 @@ def main() -> int:
 
     def poll_holds() -> None:
         for fs in footswitches:
+            fs.poll_tail_capture()
             fs.poll_hold()
             fs.poll_led()
 

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -236,6 +236,9 @@ def main() -> int:
     )
     state_listener.start()
     state_listener.register(osc, num_loops=num_loops)
+    for fs in footswitches:
+        fs._on_tail_capture_begin = state_listener.register_tail_peak
+        fs._on_tail_capture_end = state_listener.unregister_tail_peak
 
     arrow_notes = resolve_arrow_notes(port_name, variant=apc_variant)
     # One shift latch for the whole event loop. ShiftHoldCombo keeps its own

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -37,6 +37,7 @@ from sl_bench_listener import SlBenchStateListener  # noqa: E402
 from sl_grid_state import GridState, display_bpm  # noqa: E402
 from sl_grid_sync import (  # noqa: E402
     RESTART_SENTINEL,
+    TAIL_CAPTURE_ENABLED,
     apply_freeform,
     apply_grid_sync,
     establish_grid_clock,
@@ -236,9 +237,12 @@ def main() -> int:
     )
     state_listener.start()
     state_listener.register(osc, num_loops=num_loops)
-    for fs in footswitches:
-        fs._on_tail_capture_begin = state_listener.register_tail_peak
-        fs._on_tail_capture_end = state_listener.unregister_tail_peak
+    state_listener.wire_tail_capture(footswitches)
+    if not TAIL_CAPTURE_ENABLED:
+        print(
+            "bench: MPE_SL_TAIL_CAPTURE off — defining-take tail capture disabled",
+            flush=True,
+        )
 
     arrow_notes = resolve_arrow_notes(port_name, variant=apc_variant)
     # One shift latch for the whole event loop. ShiftHoldCombo keeps its own

--- a/scripts/sooperlooper/apc_footswitch.py
+++ b/scripts/sooperlooper/apc_footswitch.py
@@ -451,16 +451,16 @@ class LoopFootswitch:
         self._mark_action()
 
     def _gesture(self, edge: str) -> None:
+        if self._tail_capture:
+            if edge == "down":
+                self._finish_tail_capture("pad down — immediate close")
+                self._mark_action()
+            return
         if self._debounced():
             log(f"loop {self.loop}: -> {edge} ignored (debounce)")
             return
         if self._waiting_for_quantize():
             log(f"loop {self.loop}: -> {edge} ignored (quantize wait)")
-            return
-        if self._tail_capture:
-            if edge == "down":
-                self._finish_tail_capture("pad down — immediate close")
-                self._mark_action()
             return
 
         self._expire_pending()

--- a/scripts/sooperlooper/apc_footswitch.py
+++ b/scripts/sooperlooper/apc_footswitch.py
@@ -208,6 +208,16 @@ class LoopFootswitch:
         self._hit("record")
         self._expect(STATE_PLAYING)
         self._sync_led()
+        self._mark_action()
+
+    def set_tail_capture_hooks(
+        self,
+        on_begin,
+        on_end,
+    ) -> None:
+        """Subscribe/unsubscribe in_peak_meter during defining-take tail capture."""
+        self._on_tail_capture_begin = on_begin
+        self._on_tail_capture_end = on_end
 
     def poll_tail_capture(self) -> None:
         """Close a defining take once release falls below threshold (Tier 2)."""
@@ -560,8 +570,6 @@ def build_footswitches(
     on_grid_established=None,
     on_phase_reanchor=None,
     on_grid_dropped=None,
-    on_tail_capture_begin=None,
-    on_tail_capture_end=None,
 ) -> tuple[dict[int, LoopFootswitch], list[LoopFootswitch]]:
     """One footswitch per track, bound to the pad showing it in `view`.
 
@@ -584,8 +592,6 @@ def build_footswitches(
             on_grid_established=on_grid_established,
             on_phase_reanchor=on_phase_reanchor,
             on_grid_dropped=on_grid_dropped,
-            on_tail_capture_begin=on_tail_capture_begin,
-            on_tail_capture_end=on_tail_capture_end,
         )
         fs.bind(osc, midi_out, view.note_for_loop(loop_i))
         footswitches.append(fs)

--- a/scripts/sooperlooper/apc_footswitch.py
+++ b/scripts/sooperlooper/apc_footswitch.py
@@ -126,6 +126,7 @@ class LoopFootswitch:
         self._tail_capture_since = 0.0
         self._tail_silence_since: float | None = None
         self._in_peak = 0.0
+        self._in_peak_seen = False
 
     def bind(self, osc, midi_out, note: int | None) -> None:
         self._osc = osc
@@ -187,6 +188,7 @@ class LoopFootswitch:
 
     def sync_in_peak(self, peak: float) -> None:
         self._in_peak = max(0.0, float(peak))
+        self._in_peak_seen = True
 
     def _cancel_tail_capture(self) -> None:
         if self._tail_capture and self._on_tail_capture_end is not None:
@@ -210,6 +212,8 @@ class LoopFootswitch:
     def poll_tail_capture(self) -> None:
         """Close a defining take once release falls below threshold (Tier 2)."""
         if not self._tail_capture:
+            return
+        if not self._in_peak_seen:
             return
         now = time.monotonic()
         if (now - self._tail_capture_since) >= TAIL_MAX_S:
@@ -479,6 +483,8 @@ class LoopFootswitch:
             self._tail_capture = True
             self._tail_capture_since = time.monotonic()
             self._tail_silence_since = None
+            self._in_peak = 0.0
+            self._in_peak_seen = False
             if self._on_tail_capture_begin is not None:
                 self._on_tail_capture_begin(self.loop)
             self._expect(STATE_RECORDING)

--- a/scripts/sooperlooper/apc_footswitch.py
+++ b/scripts/sooperlooper/apc_footswitch.py
@@ -20,6 +20,8 @@ from led_table import (  # noqa: F401
 )
 from loop_model import (
     STATE_IDLE,
+    STATE_PLAYING,
+    STATE_RECORDING,
     STATE_STOPPED,
     effective_state,
     pending_resolved,
@@ -29,6 +31,10 @@ from sl_grid_state import GridState, derive_tempo
 from sl_grid_sync import (
     GRID_ANCHOR_FALLBACK_CYCLES,
     GRID_ANCHOR_MAX_S,
+    TAIL_CAPTURE_ENABLED,
+    TAIL_HOLD_S,
+    TAIL_MAX_S,
+    TAIL_THRESH,
     detect_loop_wrap,
     should_defer_phase_anchor,
 )
@@ -112,6 +118,10 @@ class LoopFootswitch:
         self._stop_queued = False
         self._led_transition: tuple[int, int] | None = None
         self._led_last: int | None = None
+        self._tail_capture = False
+        self._tail_capture_since = 0.0
+        self._tail_silence_since: float | None = None
+        self._in_peak = 0.0
 
     def bind(self, osc, midi_out, note: int | None) -> None:
         self._osc = osc
@@ -170,6 +180,42 @@ class LoopFootswitch:
                 f"{PENDING_TIMEOUT_S:.0f}s (sl_state={self.sl_state}) — "
                 f"deferring to the engine")
             self._pending = None
+
+    def sync_in_peak(self, peak: float) -> None:
+        self._in_peak = max(0.0, float(peak))
+
+    def _cancel_tail_capture(self) -> None:
+        self._tail_capture = False
+        self._tail_capture_since = 0.0
+        self._tail_silence_since = None
+
+    def _finish_tail_capture(self, reason: str) -> None:
+        if not self._tail_capture:
+            return
+        self._cancel_tail_capture()
+        log(f"loop {self.loop}: tail capture done ({reason}) — sending record stop")
+        self._hit("record")
+        self._expect(STATE_PLAYING)
+        self._sync_led()
+
+    def poll_tail_capture(self) -> None:
+        """Close a defining take once release falls below threshold (Tier 2)."""
+        if not self._tail_capture:
+            return
+        now = time.monotonic()
+        if (now - self._tail_capture_since) >= TAIL_MAX_S:
+            self._finish_tail_capture(f"max {TAIL_MAX_S:.2f}s")
+            return
+        if self._in_peak >= TAIL_THRESH:
+            self._tail_silence_since = None
+            return
+        if self._tail_silence_since is None:
+            self._tail_silence_since = now
+            return
+        if (now - self._tail_silence_since) >= TAIL_HOLD_S:
+            self._finish_tail_capture(
+                f"peak<{TAIL_THRESH} for {TAIL_HOLD_S * 1000:.0f}ms"
+            )
 
     def sync_from_sl(self, sl_state: int) -> bool:
         """Mirror SooperLooper state → bench LED (all loops incl. 0)."""
@@ -323,7 +369,11 @@ class LoopFootswitch:
         self._midi_out.send_message([0x90, self._note, velocity])
 
     def _led_target(self) -> tuple[int, ...]:
-        return led_for(self.sl_state, pending=self._pending)
+        return led_for(
+            self.sl_state,
+            pending=self._pending,
+            tail_capture=self._tail_capture,
+        )
 
     def _sync_led(self) -> None:
         """Paint the pad from engine truth plus unconfirmed intent.
@@ -373,6 +423,7 @@ class LoopFootswitch:
 
     def _clear_loop(self) -> None:
         self._stop_queued = False
+        self._cancel_tail_capture()
         if self.grid is not None:
             self.grid.cancel(self.loop)
         self._hit("undo_all")
@@ -393,6 +444,11 @@ class LoopFootswitch:
         if self._waiting_for_quantize():
             log(f"loop {self.loop}: -> {edge} ignored (quantize wait)")
             return
+        if self._tail_capture:
+            if edge == "down":
+                self._finish_tail_capture("pad down — immediate close")
+                self._mark_action()
+            return
 
         self._expire_pending()
         plan = plan_gesture(
@@ -402,13 +458,26 @@ class LoopFootswitch:
             grid_established=self.grid is None or self.grid.established,
             is_defining=self.grid is not None and self.grid.is_pending(self.loop),
             quantized=self.quantized,
+            tail_capture_enabled=TAIL_CAPTURE_ENABLED,
         )
-        if not (plan.commands or plan.queue_stop or plan.arm_grid):
+        if not (plan.commands or plan.queue_stop or plan.arm_grid or plan.begin_tail_capture):
             return
         if plan.note:
             log(f"loop {self.loop}: {plan.note}")
         if plan.arm_grid and self.grid is not None:
             self.grid.arm(self.loop)
+        if plan.begin_tail_capture:
+            self._tail_capture = True
+            self._tail_capture_since = time.monotonic()
+            self._tail_silence_since = None
+            self._expect(STATE_RECORDING)
+            self._sync_led()
+            self._mark_action()
+            log(
+                f"loop {self.loop}: -> {edge} done (tail capture, "
+                f"state={self.state}, sl_state={self.sl_state})"
+            )
+            return
         for cmd in plan.commands:
             self._hit(cmd)
         if plan.queue_stop:
@@ -568,6 +637,7 @@ def reset_all_loops(
     for fs in footswitches:
         fs.awaiting_quantize = False
         fs._stop_queued = False
+        fs._cancel_tail_capture()
         fs._expect(STATE_IDLE)
         fs._sync_led()
     for row, col in all_clip_pads():

--- a/scripts/sooperlooper/apc_footswitch.py
+++ b/scripts/sooperlooper/apc_footswitch.py
@@ -86,12 +86,16 @@ class LoopFootswitch:
         on_grid_established=None,
         on_phase_reanchor=None,
         on_grid_dropped=None,
+        on_tail_capture_begin=None,
+        on_tail_capture_end=None,
     ) -> None:
         self.loop = loop
         self.grid = grid
         self._on_grid_established = on_grid_established
         self._on_phase_reanchor = on_phase_reanchor
         self._on_grid_dropped = on_grid_dropped
+        self._on_tail_capture_begin = on_tail_capture_begin
+        self._on_tail_capture_end = on_tail_capture_end
         self.loop_len = 0.0
         self.loop_pos = 0.0
         self._loop_pos_seen = False
@@ -185,6 +189,8 @@ class LoopFootswitch:
         self._in_peak = max(0.0, float(peak))
 
     def _cancel_tail_capture(self) -> None:
+        if self._tail_capture and self._on_tail_capture_end is not None:
+            self._on_tail_capture_end(self.loop)
         self._tail_capture = False
         self._tail_capture_since = 0.0
         self._tail_silence_since = None
@@ -193,6 +199,9 @@ class LoopFootswitch:
         if not self._tail_capture:
             return
         self._cancel_tail_capture()
+        self._pad_down = False
+        self._pad_down_at = 0.0
+        self._hold_fired = False
         log(f"loop {self.loop}: tail capture done ({reason}) — sending record stop")
         self._hit("record")
         self._expect(STATE_PLAYING)
@@ -470,6 +479,8 @@ class LoopFootswitch:
             self._tail_capture = True
             self._tail_capture_since = time.monotonic()
             self._tail_silence_since = None
+            if self._on_tail_capture_begin is not None:
+                self._on_tail_capture_begin(self.loop)
             self._expect(STATE_RECORDING)
             self._sync_led()
             self._mark_action()
@@ -543,6 +554,8 @@ def build_footswitches(
     on_grid_established=None,
     on_phase_reanchor=None,
     on_grid_dropped=None,
+    on_tail_capture_begin=None,
+    on_tail_capture_end=None,
 ) -> tuple[dict[int, LoopFootswitch], list[LoopFootswitch]]:
     """One footswitch per track, bound to the pad showing it in `view`.
 
@@ -565,6 +578,8 @@ def build_footswitches(
             on_grid_established=on_grid_established,
             on_phase_reanchor=on_phase_reanchor,
             on_grid_dropped=on_grid_dropped,
+            on_tail_capture_begin=on_tail_capture_begin,
+            on_tail_capture_end=on_tail_capture_end,
         )
         fs.bind(osc, midi_out, view.note_for_loop(loop_i))
         footswitches.append(fs)
@@ -676,5 +691,6 @@ def stop_all_loops(
         fs.awaiting_quantize = False
         if fs.state != STATE_IDLE:
             fs._expect(STATE_STOPPED)
+        fs._cancel_tail_capture()
         fs._sync_led()
     print(f"-> stop all: paused {num_loops} loops", flush=True)

--- a/scripts/sooperlooper/apc_footswitch.py
+++ b/scripts/sooperlooper/apc_footswitch.py
@@ -213,11 +213,11 @@ class LoopFootswitch:
         """Close a defining take once release falls below threshold (Tier 2)."""
         if not self._tail_capture:
             return
-        if not self._in_peak_seen:
-            return
         now = time.monotonic()
         if (now - self._tail_capture_since) >= TAIL_MAX_S:
             self._finish_tail_capture(f"max {TAIL_MAX_S:.2f}s")
+            return
+        if not self._in_peak_seen:
             return
         if self._in_peak >= TAIL_THRESH:
             self._tail_silence_since = None

--- a/scripts/sooperlooper/led_table.py
+++ b/scripts/sooperlooper/led_table.py
@@ -65,7 +65,9 @@ _BLINK = {
 RECORD_TO_PLAY = (LED_OFF, LED_RED, LED_OFF, LED_GREEN)
 
 
-def led_for(sl_state: int, *, pending: str | None = None) -> tuple[int, ...]:
+def led_for(
+    sl_state: int, *, pending: str | None = None, tail_capture: bool = False
+) -> tuple[int, ...]:
     """Pad colour, as a blink sequence. Length 1 means hold it steady.
 
     Returning one shape for both cases keeps the caller from having to know
@@ -76,6 +78,8 @@ def led_for(sl_state: int, *, pending: str | None = None) -> tuple[int, ...]:
     what let a poll clear the flag while the launch was still pending, leaving
     the pad blinking green forever after it had already landed.
     """
+    if tail_capture:
+        return (LED_YELLOW_BLINK,)
     if sl_state == SL_STATE_WAIT_STOP:
         return RECORD_TO_PLAY
     if sl_state == SL_STATE_WAIT_START:

--- a/scripts/sooperlooper/loop_model.py
+++ b/scripts/sooperlooper/loop_model.py
@@ -96,6 +96,7 @@ class Plan:
     arm_grid: bool = False
     queue_stop: bool = False
     begin_quantize_wait: bool = False
+    begin_tail_capture: bool = False
     note: str = ""
 
 
@@ -107,6 +108,7 @@ def plan_gesture(
     grid_established: bool,
     is_defining: bool,
     quantized: bool,
+    tail_capture_enabled: bool = False,
 ) -> Plan:
     """The whole gesture vocabulary, split by which physical edge fired.
 
@@ -152,6 +154,16 @@ def plan_gesture(
                 expect=STATE_RECORDING,
                 note="stop queued — will record exactly one cycle",
             )
+        if (
+            sl_state == SL_STATE_RECORDING
+            and is_defining
+            and tail_capture_enabled
+        ):
+            return Plan(
+                begin_tail_capture=True,
+                expect=STATE_RECORDING,
+                note="tail capture — close when release falls below threshold",
+            )
         wait = quantized and not is_defining
         return Plan(
             commands=("record",),
@@ -187,6 +199,7 @@ def plan_tap(
     grid_established: bool,
     is_defining: bool,
     quantized: bool,
+    tail_capture_enabled: bool = False,
 ) -> Plan:
     """Legacy entry: both edges on release. Prefer plan_gesture in the bench."""
     down = plan_gesture(
@@ -196,8 +209,9 @@ def plan_tap(
         grid_established=grid_established,
         is_defining=is_defining,
         quantized=quantized,
+        tail_capture_enabled=tail_capture_enabled,
     )
-    if down.commands or down.queue_stop or down.arm_grid:
+    if down.commands or down.queue_stop or down.arm_grid or down.begin_tail_capture:
         return down
     return plan_gesture(
         edge="up",
@@ -206,4 +220,5 @@ def plan_tap(
         grid_established=grid_established,
         is_defining=is_defining,
         quantized=quantized,
+        tail_capture_enabled=tail_capture_enabled,
     )

--- a/scripts/sooperlooper/sl_bench_listener.py
+++ b/scripts/sooperlooper/sl_bench_listener.py
@@ -128,12 +128,20 @@ class SlBenchStateListener:
             return
         loop = self._tail_peak_loop
         self._tail_peak_loop = None
-        # Interval 0 stops auto-updates for this control on this loop.
         returl = f"{LISTEN_HOST}:{LISTEN_PORT}"
+        retpath = "/sl/bench/state"
         self._osc_client.send_message(
-            f"/sl/{loop}/register_auto_update",
-            ["in_peak_meter", 0, returl, "/sl/bench/state"],
+            f"/sl/{loop}/unregister_auto_update",
+            ["in_peak_meter", returl, retpath],
         )
+
+    def wire_tail_capture(self, footswitches: list[LoopFootswitch]) -> None:
+        """Bind peak-meter subscribe/unsubscribe to footswitch tail capture."""
+        for fs in footswitches:
+            fs.set_tail_capture_hooks(
+                self.register_tail_peak,
+                self.unregister_tail_peak,
+            )
 
     def maybe_reregister(self) -> None:
         import time

--- a/scripts/sooperlooper/sl_bench_listener.py
+++ b/scripts/sooperlooper/sl_bench_listener.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from apc_footswitch import LoopFootswitch
 
+from sl_grid_sync import TAIL_CAPTURE_ENABLED, TAIL_PEAK_UPDATE_MS
+
 LISTEN_HOST = os.environ.get("MPE_SL_BENCH_LISTEN_HOST", "127.0.0.1")
 LISTEN_PORT = int(os.environ.get("MPE_SL_BENCH_LISTEN_PORT", "9953"))
 UPDATE_MS = int(os.environ.get("MPE_SL_BENCH_STATE_MS", "100"))
@@ -56,6 +58,8 @@ class SlBenchStateListener:
             fs.sync_loop_len(float(value))
         elif control == "loop_pos":
             fs.sync_loop_pos(float(value))
+        elif control == "in_peak_meter":
+            fs.sync_in_peak(float(value))
 
     def on_global_update(self, _addr: str, _loop_index: int, control: str,
                          value: float) -> None:
@@ -85,6 +89,11 @@ class SlBenchStateListener:
                 f"/sl/{loop}/register_auto_update",
                 ["wet", WET_UPDATE_MS, returl, retpath],
             )
+            if TAIL_CAPTURE_ENABLED:
+                client.send_message(
+                    f"/sl/{loop}/register_auto_update",
+                    ["in_peak_meter", TAIL_PEAK_UPDATE_MS, returl, retpath],
+                )
         # Global (no /sl/N prefix) — verified against control_osc.cpp:178 and
         # live on the engine: replies carry loop index -2. This is how the bench
         # notices the engine restarted underneath it, which otherwise leaves the

--- a/scripts/sooperlooper/sl_bench_listener.py
+++ b/scripts/sooperlooper/sl_bench_listener.py
@@ -39,6 +39,7 @@ class SlBenchStateListener:
         self._last_register = 0.0
         self._osc_client = None
         self._num_loops = 16
+        self._tail_peak_loop: int | None = None
 
     def on_update(self, _addr: str, loop_index: int, control: str, value: float) -> None:
         if control == "wet":
@@ -59,6 +60,8 @@ class SlBenchStateListener:
         elif control == "loop_pos":
             fs.sync_loop_pos(float(value))
         elif control == "in_peak_meter":
+            if loop_index != self._tail_peak_loop:
+                return
             fs.sync_in_peak(float(value))
 
     def on_global_update(self, _addr: str, _loop_index: int, control: str,
@@ -89,11 +92,6 @@ class SlBenchStateListener:
                 f"/sl/{loop}/register_auto_update",
                 ["wet", WET_UPDATE_MS, returl, retpath],
             )
-            if TAIL_CAPTURE_ENABLED:
-                client.send_message(
-                    f"/sl/{loop}/register_auto_update",
-                    ["in_peak_meter", TAIL_PEAK_UPDATE_MS, returl, retpath],
-                )
         # Global (no /sl/N prefix) — verified against control_osc.cpp:178 and
         # live on the engine: replies carry loop index -2. This is how the bench
         # notices the engine restarted underneath it, which otherwise leaves the
@@ -109,6 +107,32 @@ class SlBenchStateListener:
             f"sl-bench-listener: state updates for loops 0..{num_loops - 1} "
             f"on {LISTEN_HOST}:{LISTEN_PORT}",
             flush=True,
+        )
+
+    def register_tail_peak(self, loop: int) -> None:
+        """Subscribe in_peak_meter for one loop during defining-take tail capture."""
+        if not TAIL_CAPTURE_ENABLED or self._osc_client is None:
+            return
+        if self._tail_peak_loop is not None:
+            self.unregister_tail_peak()
+        self._tail_peak_loop = loop
+        returl = f"{LISTEN_HOST}:{LISTEN_PORT}"
+        self._osc_client.send_message(
+            f"/sl/{loop}/register_auto_update",
+            ["in_peak_meter", TAIL_PEAK_UPDATE_MS, returl, "/sl/bench/state"],
+        )
+
+    def unregister_tail_peak(self) -> None:
+        if self._osc_client is None or self._tail_peak_loop is None:
+            self._tail_peak_loop = None
+            return
+        loop = self._tail_peak_loop
+        self._tail_peak_loop = None
+        # Interval 0 stops auto-updates for this control on this loop.
+        returl = f"{LISTEN_HOST}:{LISTEN_PORT}"
+        self._osc_client.send_message(
+            f"/sl/{loop}/register_auto_update",
+            ["in_peak_meter", 0, returl, "/sl/bench/state"],
         )
 
     def maybe_reregister(self) -> None:

--- a/scripts/sooperlooper/sl_bench_listener.py
+++ b/scripts/sooperlooper/sl_bench_listener.py
@@ -122,7 +122,7 @@ class SlBenchStateListener:
             ["in_peak_meter", TAIL_PEAK_UPDATE_MS, returl, "/sl/bench/state"],
         )
 
-    def unregister_tail_peak(self) -> None:
+    def unregister_tail_peak(self, _loop: int | None = None) -> None:
         if self._osc_client is None or self._tail_peak_loop is None:
             self._tail_peak_loop = None
             return

--- a/scripts/sooperlooper/sl_grid_sync.py
+++ b/scripts/sooperlooper/sl_grid_sync.py
@@ -152,7 +152,7 @@ def apply_loop_latency(
     MPE_SL_INPUT_LATENCY (samples) when ear calibration needs a fixed value.
     """
     override = os.environ.get("MPE_SL_INPUT_LATENCY", "").strip()
-    autoset_off = os.environ.get("MPE_SL_AUTOSET_LATENCY", "1").strip().lower() in (
+    autoset_disabled = os.environ.get("MPE_SL_AUTOSET_LATENCY", "1").strip().lower() in (
         "0",
         "off",
         "false",
@@ -165,9 +165,11 @@ def apply_loop_latency(
             send(prefix, ["autoset_latency", 0.0])
             send(prefix, ["input_latency", val])
             send(prefix, ["trigger_latency", 0.0])
-    elif not autoset_off:
+    elif not autoset_disabled:
         for loop in range(num_loops):
-            send(f"/sl/{loop}/set", ["autoset_latency", 1.0])
+            prefix = f"/sl/{loop}/set"
+            send(prefix, ["autoset_latency", 1.0])
+            send(prefix, ["trigger_latency", 0.0])
 
 
 def apply_grid_sync(

--- a/scripts/sooperlooper/sl_grid_sync.py
+++ b/scripts/sooperlooper/sl_grid_sync.py
@@ -25,6 +25,18 @@ DEFAULT_FADE_SAMPLES = int(os.environ.get("MPE_SL_FADE_SAMPLES", "256"))
 DEFAULT_BPM = float(os.environ.get("MPE_LOOPER_BPM", "120"))
 DEFAULT_CLOCK = os.environ.get("MPE_SL_GRID_CLOCK", "internal").strip().lower()
 
+# Tail capture on defining take close — looper-loop-seam-spec.md Tier 2.
+TAIL_CAPTURE_ENABLED = os.environ.get("MPE_SL_TAIL_CAPTURE", "1").strip().lower() not in (
+    "0",
+    "off",
+    "false",
+    "",
+)
+TAIL_THRESH = float(os.environ.get("MPE_SL_TAIL_THRESH", "0.02"))
+TAIL_HOLD_S = float(os.environ.get("MPE_SL_TAIL_HOLD_MS", "80")) / 1000.0
+TAIL_MAX_S = float(os.environ.get("MPE_SL_TAIL_MAX_MS", "750")) / 1000.0
+TAIL_PEAK_UPDATE_MS = int(os.environ.get("MPE_SL_TAIL_PEAK_MS", "100"))
+
 # Phase re-anchor: when PLAYING arrives mid-bar, defer a second set_tempo until
 # loop_pos is near the defining take's wrap (set_tempo zeroes phase). Grid
 # establishment itself is immediate — this only realigns phase for clip 2+.
@@ -131,6 +143,33 @@ def expected_sentinel(clock: str = DEFAULT_CLOCK) -> float:
     return float(SYNC_SOURCE_JACK if clock == "transport" else SYNC_SOURCE_INTERNAL)
 
 
+def apply_loop_latency(
+    send: Callable[[str, list], None], *, num_loops: int = 16
+) -> None:
+    """Align record/stop boundaries with JACK pipeline delay (Tier 1).
+
+    Prefer SooperLooper autoset from JACK port latency. Override with
+    MPE_SL_INPUT_LATENCY (samples) when ear calibration needs a fixed value.
+    """
+    override = os.environ.get("MPE_SL_INPUT_LATENCY", "").strip()
+    autoset_off = os.environ.get("MPE_SL_AUTOSET_LATENCY", "1").strip().lower() in (
+        "0",
+        "off",
+        "false",
+        "",
+    )
+    if override:
+        val = float(override)
+        for loop in range(num_loops):
+            prefix = f"/sl/{loop}/set"
+            send(prefix, ["autoset_latency", 0.0])
+            send(prefix, ["input_latency", val])
+            send(prefix, ["trigger_latency", 0.0])
+    elif not autoset_off:
+        for loop in range(num_loops):
+            send(f"/sl/{loop}/set", ["autoset_latency", 1.0])
+
+
 def apply_grid_sync(
     send: Callable[[str, list], None],
     *,
@@ -157,6 +196,7 @@ def apply_grid_sync(
 
     send("/set", ["eighth_per_cycle", float(eighth_per_cycle)])
     send("/set", ["fade_samples", float(fade_samples)])
+    apply_loop_latency(send, num_loops=num_loops)
     # No grid until a take defines one, so start free-form.
     set_grid_active(send, num_loops=num_loops, active=False)
 
@@ -225,6 +265,7 @@ def main() -> int:
 
     if mode in ("free", "freeform", "0", "off"):
         apply_freeform(send, num_loops=num_loops)
+        apply_loop_latency(send, num_loops=num_loops)
         print(f"sl-grid-sync: free-form ({num_loops} loops)", flush=True)
     else:
         apply_grid_sync(send, num_loops=num_loops)

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -4,6 +4,7 @@ import conftest  # noqa: F401 — bare sooperlooper imports (apc_grid, …)
 
 import unittest
 from unittest.mock import MagicMock, patch
+import time
 
 import scripts.sooperlooper.apc_footswitch as footswitch_mod
 from scripts.sooperlooper.apc_footswitch import LoopFootswitch, build_footswitches
@@ -118,6 +119,17 @@ class GridEstablishmentTests(unittest.TestCase):
         fs.bind(MagicMock(), MagicMock(), 36 + loop)
         return fs
 
+    def _start_defining_take(self, fs) -> None:
+        fs.on_pad_down()
+        fs.on_pad_up()
+        fs.sync_from_sl(SL_STATE_RECORDING)
+
+    def _close_defining_take(self, fs) -> None:
+        fs.on_pad_down()
+        fs.on_pad_up()
+        if fs._tail_capture:
+            fs._finish_tail_capture("test")
+
     def test_first_take_records_instantly_and_sets_tempo(self) -> None:
         from scripts.sooperlooper.sl_grid_state import GridState
 
@@ -125,10 +137,19 @@ class GridEstablishmentTests(unittest.TestCase):
         grid = GridState()
         fs = self._fs(0, grid, lambda bpm, bars: seen.append((bpm, bars)))
 
-        fs.on_pad_down(); fs.on_pad_up()          # start
+        self._start_defining_take(fs)
         self.assertTrue(grid.is_pending(0))
-        fs.on_pad_down(); fs.on_pad_up()          # stop — must NOT wait
+        fs.on_pad_down(); fs.on_pad_up()          # stop — tail capture, not instant
+        self.assertTrue(fs._tail_capture)
         self.assertFalse(fs.awaiting_quantize)
+        from scripts.sooperlooper.sl_grid_sync import TAIL_HOLD_S
+
+        fs.sync_in_peak(0.0)
+        fs._tail_silence_since = TAIL_HOLD_S * -2 + time.monotonic()
+        fs.poll_tail_capture()
+        hits = [c.args[1] for c in fs._osc.send_message.call_args_list
+                if c.args[0] == "/sl/0/hit"]
+        self.assertEqual(hits.count("record"), 2)
 
         fs.sync_loop_len(2.0)
         fs.sync_loop_pos(0.0)
@@ -149,8 +170,8 @@ class GridEstablishmentTests(unittest.TestCase):
             lambda bpm: reanchored.append(bpm),
         )
 
-        fs.on_pad_down(); fs.on_pad_up()
-        fs.on_pad_up()
+        self._start_defining_take(fs)
+        self._close_defining_take(fs)
         fs.sync_loop_len(2.0)
         fs.sync_loop_pos(0.08)  # late OSC — mid-bar
         fs.sync_from_sl(SL_STATE_PLAYING)
@@ -168,8 +189,8 @@ class GridEstablishmentTests(unittest.TestCase):
 
         grid = GridState()
         fs = self._fs(0, grid)
-        fs.on_pad_down(); fs.on_pad_up()
-        fs.on_pad_up()
+        self._start_defining_take(fs)
+        self._close_defining_take(fs)
         fs.sync_loop_len(2.0)
         fs.sync_loop_pos(0.0)
         fs.sync_from_sl(SL_STATE_PLAYING)
@@ -190,8 +211,8 @@ class GridEstablishmentTests(unittest.TestCase):
 
         grid = GridState()
         fs = self._fs(0, grid)
-        fs.on_pad_down(); fs.on_pad_up()
-        fs.on_pad_up()
+        self._start_defining_take(fs)
+        self._close_defining_take(fs)
         fs.sync_loop_len(2.0)
         fs.sync_loop_pos(0.0)
         fs.sync_from_sl(SL_STATE_PLAYING)
@@ -216,6 +237,29 @@ class GridEstablishmentTests(unittest.TestCase):
         fs.sync_from_sl(SL_STATE_RECORDING)
         fs.on_pad_down(); fs.on_pad_up()
         self.assertTrue(fs.awaiting_quantize, "quantized clip must wait for the bar")
+
+
+class TailCaptureTests(unittest.TestCase):
+    def test_pad_down_during_tail_immediate_close(self) -> None:
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs._tail_capture = True
+        fs._tail_capture_since = time.monotonic()
+        fs.on_pad_down()
+        hits = [c.args[1] for c in fs._osc.send_message.call_args_list
+                if c.args[0] == "/sl/0/hit"]
+        self.assertEqual(hits, ["record"])
+        self.assertFalse(fs._tail_capture)
+
+    def test_tail_led_is_yellow_blink(self) -> None:
+        from scripts.sooperlooper.led_table import LED_YELLOW_BLINK, led_for
+
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs.sync_from_sl(SL_STATE_RECORDING)
+        fs._tail_capture = True
+        self.assertEqual(fs._led_target(), (LED_YELLOW_BLINK,))
+        self.assertEqual(led_for(SL_STATE_RECORDING, tail_capture=True), (LED_YELLOW_BLINK,))
 
 
 class DoubleTapRecordsOneCycleTests(unittest.TestCase):

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -261,6 +261,43 @@ class TailCaptureTests(unittest.TestCase):
         self.assertEqual(fs._led_target(), (LED_YELLOW_BLINK,))
         self.assertEqual(led_for(SL_STATE_RECORDING, tail_capture=True), (LED_YELLOW_BLINK,))
 
+    def test_tail_max_timeout_closes_capture(self) -> None:
+        from scripts.sooperlooper.sl_grid_sync import TAIL_MAX_S
+
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs._tail_capture = True
+        fs._tail_capture_since = time.monotonic() - TAIL_MAX_S - 0.01
+        fs.poll_tail_capture()
+        self.assertFalse(fs._tail_capture)
+        hits = [c.args[1] for c in fs._osc.send_message.call_args_list
+                if c.args[0] == "/sl/0/hit"]
+        self.assertEqual(hits, ["record"])
+
+    def test_finish_tail_resets_hold_timer(self) -> None:
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs._tail_capture = True
+        fs._pad_down = True
+        fs._pad_down_at = time.monotonic() - 5.0
+        fs._finish_tail_capture("test")
+        self.assertFalse(fs._pad_down)
+        self.assertEqual(fs._pad_down_at, 0.0)
+
+    def test_stop_all_cancels_tail_and_calls_end_callback(self) -> None:
+        from scripts.sooperlooper.apc_footswitch import stop_all_loops
+
+        ended = []
+        fs = LoopFootswitch(
+            loop=0, hold_ms=1000.0, debounce_ms=0.0,
+            on_tail_capture_end=lambda loop: ended.append(loop),
+        )
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs._tail_capture = True
+        stop_all_loops(MagicMock(), num_loops=1, footswitches=[fs])
+        self.assertFalse(fs._tail_capture)
+        self.assertEqual(ended, [0])
+
 
 class DoubleTapRecordsOneCycleTests(unittest.TestCase):
     """Double-tap while armed must record exactly one cycle, not cancel."""

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -241,10 +241,11 @@ class GridEstablishmentTests(unittest.TestCase):
 
 class TailCaptureTests(unittest.TestCase):
     def test_pad_down_during_tail_immediate_close(self) -> None:
-        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=200.0)
         fs.bind(MagicMock(), MagicMock(), 36)
         fs._tail_capture = True
         fs._tail_capture_since = time.monotonic()
+        fs._last_action_at = time.monotonic()
         fs.on_pad_down()
         hits = [c.args[1] for c in fs._osc.send_message.call_args_list
                 if c.args[0] == "/sl/0/hit"]

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -285,6 +285,18 @@ class TailCaptureTests(unittest.TestCase):
         self.assertFalse(fs._pad_down)
         self.assertEqual(fs._pad_down_at, 0.0)
 
+    def test_finish_tail_marks_action_for_debounce(self) -> None:
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=200.0)
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs._tail_capture = True
+        fs._last_action_at = 0.0
+        fs._finish_tail_capture("test")
+        fs.on_pad_down()
+        fs.on_pad_up()
+        hits = [c.args[1] for c in fs._osc.send_message.call_args_list
+                if c.args[0] == "/sl/0/hit" and c.args[1] != "record"]
+        self.assertEqual(hits, [], "gesture after auto-close should be debounced")
+
     def test_tail_max_timeout_without_peak_reading(self) -> None:
         from scripts.sooperlooper.sl_grid_sync import TAIL_MAX_S
 

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -284,6 +284,17 @@ class TailCaptureTests(unittest.TestCase):
         self.assertFalse(fs._pad_down)
         self.assertEqual(fs._pad_down_at, 0.0)
 
+    def test_tail_max_timeout_without_peak_reading(self) -> None:
+        from scripts.sooperlooper.sl_grid_sync import TAIL_MAX_S
+
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs._tail_capture = True
+        fs._tail_capture_since = time.monotonic() - TAIL_MAX_S - 0.01
+        fs._in_peak_seen = False
+        fs.poll_tail_capture()
+        self.assertFalse(fs._tail_capture)
+
     def test_tail_waits_for_first_peak_reading(self) -> None:
         from scripts.sooperlooper.sl_grid_sync import TAIL_HOLD_S
 

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -284,6 +284,20 @@ class TailCaptureTests(unittest.TestCase):
         self.assertFalse(fs._pad_down)
         self.assertEqual(fs._pad_down_at, 0.0)
 
+    def test_tail_waits_for_first_peak_reading(self) -> None:
+        from scripts.sooperlooper.sl_grid_sync import TAIL_HOLD_S
+
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs._tail_capture = True
+        fs._tail_capture_since = time.monotonic()
+        fs._tail_silence_since = TAIL_HOLD_S * -2 + time.monotonic()
+        fs.poll_tail_capture()
+        self.assertTrue(fs._tail_capture)
+        fs.sync_in_peak(0.0)
+        fs.poll_tail_capture()
+        self.assertFalse(fs._tail_capture)
+
     def test_stop_all_cancels_tail_and_calls_end_callback(self) -> None:
         from scripts.sooperlooper.apc_footswitch import stop_all_loops
 

--- a/tests/test_footswitch_against_engine.py
+++ b/tests/test_footswitch_against_engine.py
@@ -180,7 +180,8 @@ class FootswitchOnEngineTests(unittest.TestCase):
 
         self._tap(fs)
         engine.poll(fs)
-        self._tap(fs)                    # free-form: lands immediately
+        self._tap(fs)                    # defining take: tail capture first
+        fs.on_pad_down()                 # immediate close (or wait for silence on Pi)
         engine.poll(fs)
         self.assertTrue(grid.established, "first take defines the grid")
 

--- a/tests/test_sl_bench_listener.py
+++ b/tests/test_sl_bench_listener.py
@@ -68,8 +68,10 @@ class SlBenchStateListenerTests(unittest.TestCase):
         fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
         listener = SlBenchStateListener({0: fs})
         listener.wire_tail_capture([fs])
-        self.assertIs(fs._on_tail_capture_begin, listener.register_tail_peak)
-        self.assertIs(fs._on_tail_capture_end, listener.unregister_tail_peak)
+        # Bound methods compare equal but are freshly created per attribute
+        # access, so `is` never holds — assertEqual is the correct identity here.
+        self.assertEqual(fs._on_tail_capture_begin, listener.register_tail_peak)
+        self.assertEqual(fs._on_tail_capture_end, listener.unregister_tail_peak)
 
 
 if __name__ == "__main__":

--- a/tests/test_sl_bench_listener.py
+++ b/tests/test_sl_bench_listener.py
@@ -3,7 +3,7 @@
 import conftest  # noqa: F401 — bare sooperlooper imports (apc_grid, …)
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 from scripts.sooperlooper.apc_footswitch import LoopFootswitch
 from scripts.sooperlooper.sl_bench_listener import SlBenchStateListener
@@ -28,6 +28,41 @@ class SlBenchStateListenerTests(unittest.TestCase):
         listener = SlBenchStateListener({3: fs})
         listener.on_update("/sl/bench/state", 3, "state", 4.0)
         self.assertEqual(fs.state, "playing")
+
+    def test_register_tail_peak_scoped_to_one_loop(self) -> None:
+        by_loop = {0: LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)}
+        listener = SlBenchStateListener(by_loop)
+        client = MagicMock()
+        listener.register(client, num_loops=1)
+        client.reset_mock()
+        listener.register_tail_peak(0)
+        self.assertEqual(listener._tail_peak_loop, 0)
+        paths = [c.args[0] for c in client.send_message.call_args_list]
+        self.assertEqual(paths, ["/sl/0/register_auto_update"])
+
+    def test_in_peak_ignored_for_other_loops(self) -> None:
+        fs0 = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs1 = LoopFootswitch(loop=1, hold_ms=1000.0, debounce_ms=0.0)
+        listener = SlBenchStateListener({0: fs0, 1: fs1})
+        listener._tail_peak_loop = 0
+        listener.on_update("/sl/bench/state", 1, "in_peak_meter", 0.5)
+        self.assertEqual(fs0._in_peak, 0.0)
+        self.assertEqual(fs1._in_peak, 0.0)
+        listener.on_update("/sl/bench/state", 0, "in_peak_meter", 0.5)
+        self.assertEqual(fs0._in_peak, 0.5)
+        self.assertEqual(fs1._in_peak, 0.0)
+
+    def test_unregister_tail_peak_clears_loop(self) -> None:
+        listener = SlBenchStateListener({})
+        client = MagicMock()
+        listener._osc_client = client
+        listener._tail_peak_loop = 2
+        listener.unregister_tail_peak()
+        self.assertIsNone(listener._tail_peak_loop)
+        client.send_message.assert_called_once_with(
+            "/sl/2/register_auto_update",
+            ["in_peak_meter", 0, ANY, "/sl/bench/state"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sl_bench_listener.py
+++ b/tests/test_sl_bench_listener.py
@@ -60,9 +60,16 @@ class SlBenchStateListenerTests(unittest.TestCase):
         listener.unregister_tail_peak()
         self.assertIsNone(listener._tail_peak_loop)
         client.send_message.assert_called_once_with(
-            "/sl/2/register_auto_update",
-            ["in_peak_meter", 0, ANY, "/sl/bench/state"],
+            "/sl/2/unregister_auto_update",
+            ["in_peak_meter", ANY, "/sl/bench/state"],
         )
+
+    def test_wire_tail_capture_sets_hooks(self) -> None:
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        listener = SlBenchStateListener({0: fs})
+        listener.wire_tail_capture([fs])
+        self.assertIs(fs._on_tail_capture_begin, listener.register_tail_peak)
+        self.assertIs(fs._on_tail_capture_end, listener.unregister_tail_peak)
 
 
 if __name__ == "__main__":

--- a/tests/test_sl_grid_sync.py
+++ b/tests/test_sl_grid_sync.py
@@ -1,7 +1,7 @@
 """SooperLooper grid-sync OSC configuration."""
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from scripts.sooperlooper.sl_grid_sync import (
     apply_freeform,
@@ -89,6 +89,43 @@ class SlGridSyncTests(unittest.TestCase):
         self.assertTrue(should_defer_phase_anchor(0.0, 2.0, loop_pos_seen=False))
         self.assertTrue(detect_loop_wrap(1.9, 0.01, 2.0))
         self.assertFalse(detect_loop_wrap(0.5, 0.6, 2.0))
+
+    def test_apply_loop_latency_autoset(self) -> None:
+        from scripts.sooperlooper.sl_grid_sync import apply_loop_latency
+
+        sent: list[tuple[str, list]] = []
+
+        def send(path: str, args: list) -> None:
+            sent.append((path, args))
+
+        apply_loop_latency(send, num_loops=2)
+        self.assertIn(("/sl/0/set", ["autoset_latency", 1.0]), sent)
+        self.assertIn(("/sl/1/set", ["autoset_latency", 1.0]), sent)
+
+    def test_apply_loop_latency_override(self) -> None:
+        from scripts.sooperlooper.sl_grid_sync import apply_loop_latency
+
+        sent: list[tuple[str, list]] = []
+
+        def send(path: str, args: list) -> None:
+            sent.append((path, args))
+
+        with unittest.mock.patch.dict(
+            "os.environ", {"MPE_SL_INPUT_LATENCY": "2048"}, clear=False
+        ):
+            apply_loop_latency(send, num_loops=1)
+        self.assertIn(("/sl/0/set", ["autoset_latency", 0.0]), sent)
+        self.assertIn(("/sl/0/set", ["input_latency", 2048.0]), sent)
+        self.assertIn(("/sl/0/set", ["trigger_latency", 0.0]), sent)
+
+    def test_grid_sync_applies_loop_latency(self) -> None:
+        sent: list[tuple[str, list]] = []
+
+        def send(path: str, args: list) -> None:
+            sent.append((path, args))
+
+        apply_grid_sync(send, num_loops=2, fade_samples=64, bpm=100.0)
+        self.assertIn(("/sl/0/set", ["autoset_latency", 1.0]), sent)
 
     def test_default_fade_samples_is_256(self) -> None:
         from scripts.sooperlooper import sl_grid_sync


### PR DESCRIPTION
## Summary

Implements **P0 + P1** of the loop seam spec (`Documents/specs/looper-loop-seam-spec.md`):

- **Tier 1 (latency):** `apply_loop_latency()` — JACK autoset or `MPE_SL_INPUT_LATENCY` override, plus existing fade samples
- **Tier 2 (defining-take tail):** Stay in Record after stop tap until `in_peak_meter` silence (or max ms); yellow-blink LED; pad-down abort; scoped peak subscription via `unregister_auto_update`

Tier 3 (fixed-bar seam weld) is spec-gated and not included.

## Test plan

- [x] `mpe test` — 929 tests OK locally
- [ ] Pi ear test: defining take with release tail; verify wrap/seam
- [ ] Confirm `in_peak_meter` subscription tears down after take (`unregister_auto_update`)

## Env knobs

See `config/mpe.env.example` — `MPE_SL_TAIL_*`, `MPE_SL_AUTOSET_LATENCY`, optional `MPE_SL_INPUT_LATENCY`.