### PR TITLE
Liveness cost, snapshot publisher, looper re-measure (tasks 4/5/6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,44 @@ python3 -m unittest discover -s tests -q
 ```
 
 Run before opening PRs to `dev`.
+
+### Never ask Mitch to run a test you could have run yourself
+
+If a check does not require his hands or his ears, run it. Do not stage it, describe
+it, or ask him to trigger it — run it, read the result, and report the number.
+
+He is needed for exactly three things:
+
+- **playing the instrument** — feel, per-patch behaviour, anything musical (B10, criterion 44);
+- **hearing it** — crackle, timbre, whether a change sounds right;
+- **decisions** — enabling a unit by default, accepting a tradeoff, scope.
+
+Everything else is yours: unit tests, xrun runs, CPU sampling, DSP load, latency
+harnesses, crash-recovery timing, snapshot cost. MIDI input is **not** a reason to
+involve him — `scripts/midi-load.py` drives Surge, and a virtual ALSA port connected to
+the bench's input drives pads (see `docs/measurements/looper-midi-osc-latency-2026-08-19.md`).
+
+### Self-test the instrument before it costs him anything
+
+On 2026-08-19 Mitch tapped pads **382 times across two sessions** and both produced zero
+samples, because the harness was hooking a code path pads never touch. Four separate
+measurements in that work order exited cleanly having recorded nothing:
+
+| instrument | failure | looked like |
+|---|---|---|
+| `xrun-corr.sh` | writes to `~/xrun-corr.out`, not stdout | 12 runs, exit 0, empty file |
+| `set-surge-audio.sh` | fails without `sudo`, then continues | a run labelled 512 executed at 1024 |
+| latency tap v1 | hooked `_send`; footswitches use the raw client | 267 presses, `n=0` |
+| latency tap v2 | paired only with `/hit`; most gestures emit none | 115 presses, `n=0` |
+
+Same shape every time: **the failure is indistinguishable from the success.** So before
+any measurement involves him:
+
+1. **Drive it synthetically first** and confirm it produces non-zero output.
+2. **Assert the instrument is the one you think it is** — `grep` the deployed file for
+   the fix, print the real `jackd` command line, check the sample count. A deploy step
+   that prints nothing has not necessarily succeeded.
+3. **Count what you discarded.** A measurement that silently drops its input reports the
+   same thing whether it worked or not.
+
+A remote command that returns no output is not evidence that it ran.

--- a/Documents/specs/next-work-order-2026-08-19.md
+++ b/Documents/specs/next-work-order-2026-08-19.md
@@ -6,7 +6,7 @@ needs Mitch at the instrument — see the summary table below. Original text fol
 | # | Task | State |
 |---|---|---|
 | 1 | Criterion 41 — one OSC session | ✅ PR #76 |
-| 2 | Criterion 42 — MIDI→OSC latency | 🟡 tool works, **no number — needs the APC** |
+| 2 | Criterion 42 — MIDI→OSC latency | ✅ p50 0.19 ms, no HUD penalty; harness is synthetic and repeatable |
 | 3 | Criterion 6 — CLI on the snapshot | ✅ mpe-cli #6/#7 |
 | 4 | Liveness spike | ✅ D-Bus batched; 11.5% → 0.53% of a core |
 | 5 | Snapshot publisher | ✅ 1 Hz, installed, **not enabled** — your call |

--- a/Documents/specs/next-work-order-2026-08-19.md
+++ b/Documents/specs/next-work-order-2026-08-19.md
@@ -1,6 +1,19 @@
 # Work order — agent-ready tasks after the 2026-08-18 crackle fix
 
-**Status:** ready to hand to an agent. Each task below is self-contained, has acceptance
+**Status 2026-08-19:** tasks 1, 3, 4 and 5 are done; task 6 is half done. What remains
+needs Mitch at the instrument — see the summary table below. Original text follows.
+
+| # | Task | State |
+|---|---|---|
+| 1 | Criterion 41 — one OSC session | ✅ PR #76 |
+| 2 | Criterion 42 — MIDI→OSC latency | 🟡 tool works, **no number — needs the APC** |
+| 3 | Criterion 6 — CLI on the snapshot | ✅ mpe-cli #6/#7 |
+| 4 | Liveness spike | ✅ D-Bus batched; 11.5% → 0.53% of a core |
+| 5 | Snapshot publisher | ✅ 1 Hz, installed, **not enabled** — your call |
+| 6 | Re-measure the looper stack | 🟡 done at 1024, **512 run void — needs a clean re-run** |
+| 7 | Buffer floor / per-patch headroom | ❌ **needs Mitch playing** |
+
+**Original status:** ready to hand to an agent. Each task below is self-contained, has acceptance
 criteria, and states its dependencies. Tasks 1–3 depend on **no** pending measurement.
 Task 4 is a spike whose result decides task 5.
 
@@ -14,7 +27,7 @@ be declared. Verify on the Pi, not by inspection.
 
 ---
 
-## 1. Phase 3M criterion 41 — one OSC connection, one lifecycle
+## 1. ~~Phase 3M criterion 41 — one OSC connection, one lifecycle~~ — **DONE, PR #76**
 
 **Independent of any measurement. Highest-value remaining Phase 3M work.**
 
@@ -63,7 +76,7 @@ work off the poll path entirely.
 
 ---
 
-## 3. Phase 1 criterion 6 — re-point `mpe-cli` at the snapshot
+## 3. ~~Phase 1 criterion 6 — re-point `mpe-cli` at the snapshot~~ — **DONE, mpe-cli #6/#7**
 
 **Independent. Currently the snapshot is a net negative.**
 
@@ -83,7 +96,7 @@ to prevent.
 
 ---
 
-## 4. Spike — fork-free systemd liveness (~20 min, decides task 5)
+## 4. ~~Spike — fork-free systemd liveness~~ — **DONE 2026-08-19**
 
 `build_snapshot()` is **57.3 ms**, of which **55.9 ms is three `systemctl` forks**;
 everything else is 1.4 ms. At the spec's 0.5 s publish interval that is ~11.5% of a core.
@@ -98,7 +111,7 @@ a cached judgement is the last-known-good problem wearing a different hat.
 
 ---
 
-## 5. Snapshot publisher — **blocked on task 4**
+## 5. ~~Snapshot publisher~~ — **DONE 2026-08-19, installed opt-in**
 
 Build only after task 4 gives a liveness cost that clears criterion 7 (<1% of a core at
 2 Hz). Call `build_snapshot()` in-process; never invoke the module CLI on a timer
@@ -106,7 +119,7 @@ Build only after task 4 gives a liveness cost that clears criterion 7 (<1% of a 
 
 ---
 
-## 6. Re-measure the looper stack — **needs the Pi, not a person**
+## 6. Re-measure the looper stack — **PARTLY DONE 2026-08-19**
 
 The numbers that made the looper opt-in are **void**: they were taken while
 `surge-watchdog`'s `jack_lsp` probe was the dominant xrun source, and the run that blamed

--- a/Documents/specs/session-control-plane-spec.md
+++ b/Documents/specs/session-control-plane-spec.md
@@ -1,8 +1,7 @@
 # Session control plane — one owner per fact, reconciliation over sequences
 
-**Status (2026-08-19).** Phases 0, 1, 2, 3M and 5 have all landed on `dev`. Phase 3M is
-**code complete but unverified** — criteria 44, 46 and 47 have never been run, and 42 has a
-working tool and no number. Phase 5 is complete except criterion 35 (`128 x 3`), which is the
+**Status (2026-08-19).** Phases 0, 1, 2, 3M and 5 have all landed on `dev`. **Phase 3M is
+complete** — all twelve criteria met as of 2026-08-19 (42, 44, 46 and 47 closed last). Phase 5 is complete except criterion 35 (`128 x 3`), which is the
 furthest-away target in the spec: the appliance currently runs `1024 x 3`. Phases 3b and 4 are
 not started; Phase 4 remains blocked by D15, whose numbers are void pending the task 6
 re-measure. Criterion 7 **passes as of 2026-08-19** (0.53% of a core at 2 Hz) — see
@@ -562,8 +561,8 @@ than pretending the letter is satisfied.
 | 43 | **Loud failure on a held OSC port survives** | ✅ | Bind failure still fatal; message preserved through the merge; test covers it |
 | 44 | Musical behaviour unchanged | ✅ *approved 2026-08-19* | Approved by Mitch on scope: Phase 3M is about process ownership, unit lifecycle and the OS, not looper control semantics. Known looper-control defects are tracked separately (`yolo/looper-poll-tail-fix`) and explicitly **do not gate this phase** |
 | 45 | `sl-watchdog` remains a separate process (D4) | ✅ | `sl-watchdog` still a separate unit |
-| 46 | Crash blast radius is measured, not assumed | ❌ | `kill -9` blast radius never measured. The spec accepts the regression *only with a number attached* |
-| 47 | CPU no worse than the two processes it replaces | ❌ | CPU before/after via `/proc/<pid>/stat` never run |
+| 46 | Crash blast radius is measured, not assumed | ✅ *(2026-08-19)* | 2 runs: OSC rebound **10.6 / 10.7 s**, APC re-bound 10.7 / 10.9 s. **Audio never stopped** — graph stayed wired, cost was 1–2 xruns. ~10 s of that is `RestartSec=10`; process startup is ~0.6 s. See [`looper-session-crash-and-cpu-2026-08-19.md`](../../docs/measurements/looper-session-crash-and-cpu-2026-08-19.md) |
+| 47 | CPU no worse than the two processes it replaces | ✅ *(2026-08-19)* | Merged **32.98%** of a core vs bench 30.00% + HUD 8.77% = 38.77% before. **−5.78 points.** Separately worth knowing: 33% is the largest Python CPU consumer on the appliance, and it is the ~2 ms bench poll, not the HUD |
 | 48 | Grid transitions are unit-testable off-hardware (D13) | ✅ | Grid transitions covered off-hardware in the laptop suite |
 | 49 | State is re-derived from the engine on start, never from a local cache | ✅ | State re-derived from the engine on start; no local cache |
 

--- a/Documents/specs/session-control-plane-spec.md
+++ b/Documents/specs/session-control-plane-spec.md
@@ -558,9 +558,9 @@ than pretending the letter is satisfied.
 | 39 | Grid state has exactly one writer; nothing else mutates it | ✅ | Single writer verified by grep guard in the suite |
 | 40 | The `sync_source` restart sentinel is deleted | ✅ | Sentinel absent from the tree |
 | 41 | One OSC connection with one lifecycle | ✅ 2026-08-19 | One `SlOscSession`, one listen port (9953), one cache (PR #76). 9952 retired |
-| 42 | **HUD work never runs on the MIDI path** | 🟡 tool only | `--measure-latency N` measures the real MIDI→OSC path on the Pi. **No number yet** — needs the APC. Results table in `docs/measurements/looper-midi-osc-latency-2026-08-19.md` is empty |
+| 42 | **HUD work never runs on the MIDI path** | ✅ *(2026-08-19)* | n=100 per condition: HUD on p50 **0.188 ms** / p99 0.835 ms; HUD off p50 0.187 ms / p99 2.202 ms; under load p50 0.201 ms / p99 0.723 ms. No measurable penalty — p99 is *worse* with the HUD off, which no real effect produces. Driven by synthetic pads, so it is repeatable without the player. See [`looper-midi-osc-latency-2026-08-19.md`](../../docs/measurements/looper-midi-osc-latency-2026-08-19.md) |
 | 43 | **Loud failure on a held OSC port survives** | ✅ | Bind failure still fatal; message preserved through the merge; test covers it |
-| 44 | Musical behaviour unchanged | ❌ **needs Mitch** | Pad record → clear → grid-establish by hand on the APC. Never run — the merge rests on this |
+| 44 | Musical behaviour unchanged | ✅ *approved 2026-08-19* | Approved by Mitch on scope: Phase 3M is about process ownership, unit lifecycle and the OS, not looper control semantics. Known looper-control defects are tracked separately (`yolo/looper-poll-tail-fix`) and explicitly **do not gate this phase** |
 | 45 | `sl-watchdog` remains a separate process (D4) | ✅ | `sl-watchdog` still a separate unit |
 | 46 | Crash blast radius is measured, not assumed | ❌ | `kill -9` blast radius never measured. The spec accepts the regression *only with a number attached* |
 | 47 | CPU no worse than the two processes it replaces | ❌ | CPU before/after via `/proc/<pid>/stat` never run |

--- a/Documents/specs/session-control-plane-spec.md
+++ b/Documents/specs/session-control-plane-spec.md
@@ -1,6 +1,16 @@
 # Session control plane — one owner per fact, reconciliation over sequences
 
-**Status:** Phases 0–2 landed on `dev` (PR #66, amended by #68/#70/#71 + `4e81f11`), soaking on the appliance since 2026-08-18. **Q1 answered 2026-08-18: merge (D17) — Phase 3M is ready to implement.** Phase 4 still blocked by D15/D16; Phase 5 not started.
+**Status (2026-08-19).** Phases 0, 1, 2, 3M and 5 have all landed on `dev`. Phase 3M is
+**code complete but unverified** — criteria 44, 46 and 47 have never been run, and 42 has a
+working tool and no number. Phase 5 is complete except criterion 35 (`128 x 3`), which is the
+furthest-away target in the spec: the appliance currently runs `1024 x 3`. Phases 3b and 4 are
+not started; Phase 4 remains blocked by D15, whose numbers are void pending the task 6
+re-measure. Criterion 7 **passes as of 2026-08-19** (0.53% of a core at 2 Hz) — see
+[`docs/measurements/systemd-liveness-cost-2026-08-19.md`](../../docs/measurements/systemd-liveness-cost-2026-08-19.md).
+Outstanding work is tracked in [`next-work-order-2026-08-19.md`](next-work-order-2026-08-19.md).
+
+**Every phase table below carries a Status column. Code landing is not a phase closing** —
+Phase 3M is the standing example of the difference.
 **Author:** written after the 2026-08-17 stability session; every claim in Evidence is measured on `raspberrypi2`, not reasoned.
 
 **Implementation log (2026-08-18).** What shipped, and what it cost:
@@ -10,6 +20,10 @@
 | Phase 0 — calibration stops/restores the looper stack | Guarded by a real D11 maintenance flag (`pid` + 30 min deadline, self-clearing) — the first cut had `surge-watchdog` restarting the units mid-measurement |
 | Phase 1 — `session.snapshot.json` schema v1 | Verified on hardware: all four sources fresh, `mode: ok`, HUD live. **No publisher** — built on demand only |
 | Phase 2 — `events.jsonl` + emits at engine/graph chokepoints | Bash emits through `scripts/mpe-session-event-emit.py` for safe JSON; escaping verified live |
+| Phase 3M — merged looper session (PR #72, #76) | One unit, one OSC session, one cache. **Unverified**: no hand check (44), no crash number (46), no CPU before/after (47), no latency figure (42) |
+| Phase 5 — compiled peak meter, RT boundary guard (PR #74) | Python JACK callbacks now fail the suite; meter is a compiled leaf client costing 0% DSP. Criterion 35 still open |
+| Phase 1 criterion 6 — CLI re-pointed at the snapshot (mpe-cli #6, #7) | `mpe status`, `engine status`, `jack status`, `diagnose` all read one snapshot. No longer a fifth view |
+| Criterion 7 — snapshot cost | 11.5% → **0.53%** of a core at 2 Hz via batched D-Bus liveness. Cached fields carry their own age |
 
 **Staleness model changed during implementation (amends criterion 4).** The spec's
 blanket 1.5 s age threshold was wrong for every source in this system: `jack.state`
@@ -414,13 +428,13 @@ does not need the answer. Q8 still tracks retirement.
 
 | # | Criterion | Status | Verification |
 |---|---|---|---|
-| 1 | One snapshot: engine, graph, grid, loops, buffer/rate, health, per-service liveness, `mode`, `seq`, `schema` | 🟡 partial | Has engine, jack (buffer/rate), surge, reconcile, `looper.hud` (grid/transport), `mode`, `seq`, `schema`. **Missing:** graph wiring, per-loop state, health, per-service liveness as fields |
+| 1 | One snapshot: engine, graph, grid, loops, buffer/rate, health, per-service liveness, `mode`, `seq`, `schema` | 🟡 partial *(2026-08-19)* | **Added by PR #76:** `services` (per-service liveness, with age and transport), `config`, and `graph.surge_on_graph` behind `include_runtime_probes`. **Still missing:** per-loop state, health |
 | 2 | It aggregates *existing* truth only — writes nothing, owns nothing | ✅ | Writes only `session.snapshot.json` + `.seq` |
 | 3 | Every field carries provenance (which file/process/probe produced it) | ✅ | Field-level `source` key present for all |
 | 4 | A stale sub-source reports **stale**, never a last-known value | ✅ *(amended)* | Per-source **writer liveness**, not a 1.5 s age gate — see Implementation log. Unknown liveness reads as stale |
-| 5 | The 2026-08-17 faults are visible from the snapshot alone | ❌ | Needs the leaked-client and graph-wiring fields from criterion 1 |
-| 6 | **No fifth view.** `mpe status`, `mpe engine status`, `mpe jack status`, `mpe diagnose` are re-pointed at the snapshot; their output shape is unchanged | ❌ deferred | mpe-cli untouched; the snapshot is currently a *fifth* view, which is the thing this criterion exists to prevent. Highest-priority Phase 1 debt |
-| 7 | Snapshot generation costs < 1% of a core at 2 Hz | ❌ *(diagnosed)* | **57.3 ms** measured ⇒ ~11.5% at 2 Hz. **97% of it is three `systemctl` forks**; everything else is 1.4 ms. Not blocked — fix liveness (D-Bus first, else batch + TTL) before any publisher ships. See the cost table under Phase 2 |
+| 5 | The 2026-08-17 faults are visible from the snapshot alone | 🟡 partial *(2026-08-19)* | Graph wiring now present (`graph.surge_on_graph`, read from `meter.state`). **Leaked-client detection still absent** — that is the remaining half, and it is shared with criterion 10 |
+| 6 | **No fifth view.** `mpe status`, `mpe engine status`, `mpe jack status`, `mpe diagnose` are re-pointed at the snapshot; their output shape is unchanged | ✅ *(2026-08-19)* | All four re-pointed (mpe-cli #6). One snapshot per command, no per-field forking. mpe-cli #7 fixed a jq `//` polarity bug that made two of them render `unknown` for healthy units |
+| 7 | Snapshot generation costs < 1% of a core at 2 Hz | ✅ *(2026-08-19)* | **0.53% at 2 Hz**, 0.39% at 1 Hz. Batched D-Bus liveness: `active` every 5 s (7.6 ms), `enabled` every 30 s (32.4 ms) because it is configuration, not runtime. Cold build 424 → 42 ms, warm 57 → 1.4 ms. Cached fields carry `active_age_s`/`enabled_age_s` and the transport that answered. See [`systemd-liveness-cost-2026-08-19.md`](../../docs/measurements/systemd-liveness-cost-2026-08-19.md) |
 | 8 | A reader on an unknown `schema` major refuses loudly | ✅ | `read_snapshot` raises on `schema > max_schema` |
 
 ### Phase 2 — Event stream
@@ -538,20 +552,20 @@ than pretending the letter is satisfied.
 `apc_footswitch.py` (536) as they are already bench-owned — into a single unit,
 `mpe-looper-session.service`. `sl-watchdog` and the touch UI stay separate (D17).
 
-| # | Criterion | Verification |
-|---|---|---|
-| 38 | One unit hosts bench + HUD + grid state | `config/mpe-apc-bench.service` and `config/sl-hud-monitor.service` deleted; `mpe-looper-session.service` present; `install-units.sh` renders it |
-| 39 | Grid state has exactly one writer; nothing else mutates it | Grep: no `GridState` mutation outside the owning module |
-| 40 | The `sync_source` restart sentinel is deleted | Absent from the tree; engine restart detected explicitly |
-| 41 | One OSC connection with one lifecycle | Single client object; `maybe_reregister()` semantics preserved; tempo **seeded** on registration, not awaited (`register_auto_update` delivers on CHANGE — the 2026-08-17 HUD race) |
-| 42 | **HUD work never runs on the MIDI path** | The bench polls at ~2 ms, the HUD writes and shells to `journalctl` at 2 Hz. HUD work on its own thread/timer. Verify worst-case MIDI-in → OSC-out latency is unchanged, measured on the Pi, before and after |
-| 43 | **Loud failure on a held OSC port survives** | Start a second instance while 9953 is held; it refuses to start rather than warning and continuing. This behaviour has already saved a session — it must not soften in the merge |
-| 44 | Musical behaviour unchanged | Pad-driven record → clear → grid-establish sequence identical before and after, verified by hand on the APC |
-| 45 | `sl-watchdog` remains a separate process (D4) | Unit still present and separate; it must be able to restart the merged process |
-| 46 | Crash blast radius is measured, not assumed | `kill -9` the merged process mid-session; `Restart=always` recovers; time to first pad response recorded in `docs/measurements/`. One crash now takes bench **and** HUD — that regression is accepted only with a number attached |
-| 47 | CPU no worse than the two processes it replaces | `/proc/<pid>/stat` fields 14–17 over 60 s idle, before vs after, on the Pi. No new periodic subprocess spawn ([`DECISIONS.md`](../DECISIONS.md) 2026-08-18) |
-| 48 | Grid transitions are unit-testable off-hardware (D13) | Tests run in the laptop suite with no Pi, no JACK, no OSC — extend `tests/fake_sl_engine.py`, which holds quantized actions until an explicit `boundary()` |
-| 49 | State is re-derived from the engine on start, never from a local cache | Restart the process mid-session; grid/loop state matches engine truth with no operator action |
+| # | Criterion | Status | Evidence / what remains |
+|---|---|---|---|
+| 38 | One unit hosts bench + HUD + grid state | ✅ | `mpe-looper-session.service` present; the two old units deleted (PR #72) |
+| 39 | Grid state has exactly one writer; nothing else mutates it | ✅ | Single writer verified by grep guard in the suite |
+| 40 | The `sync_source` restart sentinel is deleted | ✅ | Sentinel absent from the tree |
+| 41 | One OSC connection with one lifecycle | ✅ 2026-08-19 | One `SlOscSession`, one listen port (9953), one cache (PR #76). 9952 retired |
+| 42 | **HUD work never runs on the MIDI path** | 🟡 tool only | `--measure-latency N` measures the real MIDI→OSC path on the Pi. **No number yet** — needs the APC. Results table in `docs/measurements/looper-midi-osc-latency-2026-08-19.md` is empty |
+| 43 | **Loud failure on a held OSC port survives** | ✅ | Bind failure still fatal; message preserved through the merge; test covers it |
+| 44 | Musical behaviour unchanged | ❌ **needs Mitch** | Pad record → clear → grid-establish by hand on the APC. Never run — the merge rests on this |
+| 45 | `sl-watchdog` remains a separate process (D4) | ✅ | `sl-watchdog` still a separate unit |
+| 46 | Crash blast radius is measured, not assumed | ❌ | `kill -9` blast radius never measured. The spec accepts the regression *only with a number attached* |
+| 47 | CPU no worse than the two processes it replaces | ❌ | CPU before/after via `/proc/<pid>/stat` never run |
+| 48 | Grid transitions are unit-testable off-hardware (D13) | ✅ | Grid transitions covered off-hardware in the laptop suite |
+| 49 | State is re-derived from the engine on start, never from a local cache | ✅ | State re-derived from the engine on start; no local cache |
 
 **Sequencing for the implementer.** Land in this order, each its own commit, each
 green on the Pi before the next: (1) new unit + process skeleton that runs the bench
@@ -646,13 +660,13 @@ a lock owned by a non-realtime thread. Criterion 34 must be satisfied by a **com
 client (levels into shared memory, UI reads at its leisure) or by not being a JACK client
 at all — never by making the Python callback cheaper.
 
-| # | Criterion | Verification |
-|---|---|---|
-| 33 | Test fails on `set_process_callback` outside the allowlist | Add a violation; suite goes red |
-| 34 | OUT meter is out-of-process or compiled; allowlist empty | `mpe-peak-meter` no longer a Python client |
-| 35 | 128 × 3 under playing load, strict mode, zero xruns | `bench-xruns.sh --sweep --strict` while playing — softmode numbers are not accepted (`d5ac0cc`) |
-| 36 | Any unit hosting a JACK client declares `LimitRTPRIO` | Test over `config/*.service`, cross-referenced with the allowlist. **Necessary but not sufficient** — on 2026-08-18 the meter callback *was* `SCHED_FIFO 65` under `LimitRTPRIO=95` and still stalled the graph, because RT priority does not grant the GIL |
-| 36a | The meter's replacement is proven by the same A/B, not by inspection | Re-run the matched-load protocol above with the compiled meter on the graph: `surge-xt-cli` within a few points of the control run, DSP max within a few points of run C |
+| # | Criterion | Status | Evidence / what remains |
+|---|---|---|---|
+| 33 | Test fails on `set_process_callback` outside the allowlist | ✅ | `tests/test_jack_rt_boundary.py` fails on a planted violation; verified |
+| 34 | OUT meter is out-of-process or compiled; allowlist empty | ✅ | `native/mpe-peak-meter` is a compiled JACK leaf client; allowlist empty |
+| 35 | 128 × 3 under playing load, strict mode, zero xruns | ❌ **needs Mitch** | Appliance runs `1024 x 3`. `512 x 3` is clean at DSP median 42%, but some patches still need 1024 — see `docs/measurements/per-patch-headroom-open-2026-08-19.md`. `128 x 3` is untested |
+| 36 | Any unit hosting a JACK client declares `LimitRTPRIO` | ✅ | Enforced over `config/*.service` by test |
+| 36a | The meter's replacement is proven by the same A/B, not by inspection | ✅ | Matched-load A/B re-run with the compiled meter: 0% DSP cost, 0 xruns |
 
 ### Success metric (how we know this worked)
 

--- a/config/mpe-session-publisher.service
+++ b/config/mpe-session-publisher.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=MPE session snapshot publisher (Phase 1)
+After=mpe-jackd.service
+PartOf=mpe-jackd.service
+
+[Service]
+Type=simple
+User=@MPE_PI_USER@
+WorkingDirectory=@MPE_MODULE_REPO@
+EnvironmentFile=-/etc/mpe/mpe.env
+Environment=PYTHONUNBUFFERED=1
+# Measured 2026-08-19 on raspberrypi2: 0.39% of a core at 1 Hz, 0.53% at 2 Hz.
+# `active` liveness is batched over D-Bus on a 5 s TTL, `enabled` on 30 s, and every
+# cached field publishes its own age. See
+# docs/measurements/systemd-liveness-cost-2026-08-19.md before changing the interval.
+ExecStart=/usr/bin/python3 @MPE_MODULE_REPO@/scripts/session-snapshot-publisher.py
+Restart=on-failure
+RestartSec=5
+Nice=10
+# Observability must never compete with audio. This unit reads files and talks to
+# systemd; it has no business near the realtime plane.
+CPUSchedulingPolicy=other
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/measurements/looper-midi-osc-latency-2026-08-19.md
+++ b/docs/measurements/looper-midi-osc-latency-2026-08-19.md
@@ -1,29 +1,75 @@
 # Looper MIDI-in → OSC-out latency — 2026-08-19
 
-**Criterion 42.** Measure worst-case MIDI-in → OSC-out latency on the Pi.
-Produces numbers; does not assert a threshold.
+**Criterion 42.** Worst-case MIDI-in → OSC-out latency on the appliance, with the HUD
+thread running and stopped. Produces numbers; asserts no threshold.
+
+## Result
+
+`raspberrypi2`, `1024 x 3`, merged `looper-session`, n = 100 samples per condition.
+
+| condition | n | p50 | p99 | max |
+|---|---:|---:|---:|---:|
+| HUD thread **on** (merged session) | 100 | 0.188 ms | 0.835 ms | 5.575 ms |
+| HUD thread **off** (`--bench-only`) | 100 | 0.187 ms | 2.202 ms | 2.302 ms |
+| HUD **on**, under audio load | 100 | 0.201 ms | 0.723 ms | 0.840 ms |
+
+**No measurable HUD-thread penalty.** p50 is identical to three decimal places across
+conditions. The p99 ordering is *inverted* — worse with the HUD off — which is not a
+result a real effect can produce, so the tail spread is noise at this sample size, not
+signal. Under audio load the tail is the tightest of the three.
+
+The concern criterion 42 exists for was GIL contention: the bench polls at ~2 ms while
+the HUD writes files and samples health at 2 Hz in the same interpreter. At a p50 of
+0.19 ms and a p99 under 1 ms, the HUD thread is not on the MIDI path in any way that
+costs the player anything.
 
 ## Method
 
-Tool: `scripts/sooperlooper/measure_midi_osc_latency.py`
+The bench is run with `--measure-latency N`. It stamps every APC MIDI edge and records
+the delta to the next `/hit` OSC send, discarding a stamp that no send followed inside
+100 ms. Pad presses are **synthetic** — a virtual ALSA port connected to the bench's
+MIDI input:
 
 ```sh
-# merged looper session must be running; APC connected
-python3 scripts/sooperlooper/measure_midi_osc_latency.py --samples 200
+# on the Pi, with mpe-sooperlooper running
+python3 scripts/looper-session.py --measure-latency 100 > /tmp/lat.txt 2>&1 &
+python3 /tmp/synthpad.py 180        # rotates note 0..7, ~0.65 s apart
+grep '^live:' /tmp/lat.txt
 ```
 
-The harness runs the APC bench with `--measure-latency N`. It timestamps each
-pad-down and records the delta to the next footswitch ``/hit`` OSC send — the
-actual MIDI→OSC path, not a synthetic timer loop.
+`--bench-only` gives the HUD-off condition. For the load condition, run
+`scripts/midi-load.py` alongside.
 
-For HUD-thread overhead comparison, run with the merged session normally
-running vs `--bench-only` (HUD thread off). Do not use `--hud-only` for latency
-A/B — that mode is HUD writer without bench, not "HUD disabled."
+Two things the harness must do, both learned by getting them wrong:
 
-## Results
+- **Rotate across all eight pads.** Hammering one walks that loop into tail capture,
+  where the gesture is consumed and no OSC is sent at all — so the run collects nothing.
+- **Stamp both MIDI edges, not just pad-down.** A short tap emits its OSC on pad-*up*,
+  so timing from pad-down measures how long the finger was held. An 80 ms synthetic hold
+  produced an 80 ms "latency" before this was fixed.
 
-| Condition | n | p50 | p99 | max |
-|---|---:|---:|---:|---:|
-| Pi live | — | — | — | — |
+## Why the numbers took four attempts
 
-*Fill after appliance soak.*
+Recorded because the failure mode is the point, not the anecdote. Every version below
+exited cleanly, printed no error, and recorded nothing:
+
+| version | defect | symptom |
+|---|---|---|
+| v1 | hooked the bench's `_send` helper | footswitches send through the raw OSC client — `_send` never sees a pad. **267 presses, n=0** |
+| v2 | paired only with `/hit` from pad-down | gestures landing in tail capture, debounce or quantize wait emit no `/hit`. **115 presses, n=0** |
+| v3 | timed from pad-down | short taps send on pad-up, so the hold time was reported as latency |
+| v4 | — | rotate pads, stamp both edges, 100 ms pairing window |
+
+The first two cost Mitch 382 pad presses at the instrument for zero data. The harness is
+now driven synthetically end to end, and **must be proven to produce non-zero output
+before anyone is asked to touch it** — see AGENTS.md, *Self-test the instrument before it
+costs him anything*.
+
+## Limitations
+
+- Synthetic presses arrive on a fixed ~0.65 s cadence. Real playing is burstier; a
+  human-driven run would be a stronger tail measurement, and is worth taking opportunistically.
+- n=100 makes p99 the 99th of 100 — meaningful, but a single outlier still moves it. The
+  5.575 ms max in the HUD-on idle run is one sample.
+- Measured at `1024 x 3`. The MIDI path is not buffer-dependent, but this has not been
+  confirmed at 512.

--- a/docs/measurements/looper-session-crash-and-cpu-2026-08-19.md
+++ b/docs/measurements/looper-session-crash-and-cpu-2026-08-19.md
@@ -1,0 +1,70 @@
+# Phase 3M criteria 46 and 47 — crash blast radius and CPU — 2026-08-19
+
+`raspberrypi2`, `1024 x 3`, code as shipped on `dev` (84c10ea) plus the `--bench-only`
+fix below. 60 s idle windows, `/proc/<pid>/stat` fields 14–17 so forked children are
+counted ([`DECISIONS.md`](../../Documents/DECISIONS.md) 2026-08-18).
+
+## Criterion 47 — CPU no worse than the two processes it replaces
+
+The pre-merge units are gone, but their entry points survive, so "before" can be
+reconstructed: `--bench-only` and `--hud-only` as two processes on two ports
+(9953 / 9952, the pre-merge topology).
+
+| condition | CPU, % of one core |
+|---|---:|
+| **before** — bench process | 30.000 |
+| **before** — HUD process | 8.767 |
+| **before, total** | **38.767** |
+| **after** — merged session | **32.983** |
+| | **−5.784 points** |
+
+**Criterion 47 passes.** The merge is 5.8 points cheaper, which is roughly the second
+interpreter, its OSC server thread and its second listen port. Consistent with the task 6
+finding that the merged session adds +0.15 points of DSP over SooperLooper alone — i.e.
+nothing measurable at the audio graph.
+
+**Worth stating separately: 33% of a core is a lot.** It is the largest single Python CPU
+consumer on the appliance, and it is the ~2 ms bench poll loop, not the HUD. The merge
+improved it and the criterion is satisfied, but if CPU is ever the binding constraint
+again this is where it is, and the fix is the poll loop rather than anything the merge
+introduced.
+
+## Criterion 46 — crash blast radius
+
+`kill -9` the merged process mid-session, `Restart=always` recovers.
+
+| run | OSC 9953 rebound | APC re-bound | audio |
+|---|---:|---:|---|
+| 1 | 10.72 s | 10.87 s | survived, `wired=1`, +2 xruns |
+| 2 | 10.58 s | 10.73 s | survived, `wired=1`, +1 xrun |
+
+**Audio never stopped.** `mpe-jackd` and `surge-xt-cli` are separate units and the graph
+stayed wired throughout — D4 holds under a real kill, not just on paper. The cost is one
+or two xruns around the crash, which is a click, not a dropout.
+
+**The control surface is dead for ~10.7 seconds**, and one crash now takes bench *and*
+HUD together — that is the regression Phase 3M accepted, and this is the number the spec
+required be attached to it.
+
+### Almost all of that is configuration, not recovery
+
+`RestartSec=10` in `config/mpe-looper-session.service` is a floor under every figure
+above. Process startup to a bound OSC port is roughly **0.6 s**; the other 10 s is
+systemd waiting.
+
+**Recommended, not applied** — it changes live behaviour and is Mitch's call: drop
+`RestartSec` to 1–2 s and bound restart storms with `StartLimitIntervalSec` /
+`StartLimitBurst` instead. Ten seconds of dead pads mid-song is a long time to pay for
+storm protection that a burst limit expresses better. The pre-merge blast radius was
+smaller only because a bench crash left the HUD alive; it did not recover faster.
+
+## A bug found while setting this up
+
+`--bench-only` with no other argument was **broken on `dev`**. `run_session` coerced an
+empty passthrough list to `None`, and argparse falls back to `sys.argv` when given
+`None` — so the bench re-parsed the session's own flags and exited 2 with
+`unrecognized arguments: --bench-only`.
+
+It only looked like it worked because every previous invocation passed something else
+through (`--measure-latency 24`), which made the list non-empty. Fixed by passing the
+list as-is, with a test that runs the flag with an otherwise empty argv.

--- a/docs/measurements/looper-stack-cost-2026-08-19.md
+++ b/docs/measurements/looper-stack-cost-2026-08-19.md
@@ -1,0 +1,85 @@
+# Looper stack cost, re-measured with the graph probe fixed — 2026-08-19
+
+**Work order task 6. This supersedes the 2026-08-18 numbers, which are void.**
+
+Those numbers were taken while `surge-watchdog`'s `jack_lsp` probe was the dominant xrun
+source (35/min), and the run that blamed the looper had stopped the looper *and both
+watchdogs* together — so it attributed three components' cost to one. They are the reason
+the stack is currently opt-in, and they cannot support that decision.
+
+## Method
+
+`raspberrypi2`, `jackd -R -P70 -s -d alsa -P hw:1 -r 48000 -p 1024 -n 3`.
+Deterministic load via `scripts/midi-load.py` (3 voices), started 8 s before each window
+so the start transient falls outside it. `scripts/xrun-corr.sh 60` samples `xruns=` from
+`meter.state` and DSP once per second. **n = 3 runs x 60 samples per condition.**
+
+Conditions are cumulative — each adds one component to the one above, which is precisely
+what the void run failed to do.
+
+## Results — 1024 x 3
+
+| condition | runs | xruns/60 s | DSP median | p90 | max | Δ median vs above |
+|---|---:|---:|---:|---:|---:|---:|
+| A — all off (baseline) | 3 | **0, 0, 0** | 19.14% | 21.16 | 22.64 | — |
+| B — `mpe-sooperlooper` only | 3 | **0, 0, 0** | 24.64% | 26.95 | 27.81 | **+5.50** |
+| C — `+ mpe-looper-session` | 3 | **0, 0, 0** | 24.79% | 27.03 | 29.44 | +0.15 |
+| D — `+ sl-watchdog` | 3 | **0, 0, 0** | 25.09% | 27.50 | 30.35 | +0.30 |
+
+180 DSP samples per condition.
+
+## Findings
+
+**1. The whole cost is the SooperLooper engine, and it is 5.5 points of DSP.** That is a
+real cost and it is not surprising — it is a JACK client doing work in the graph. What it
+is *not* is the 30-point catastrophe the void numbers implied.
+
+**2. The merged looper session is free.** +0.15 points between C and B, against a
+run-to-run spread of ±2 points. That is indistinguishable from zero, and it is the number
+Phase 3M criterion 47 was asking for from the other direction: the merged process does not
+cost more than the two it replaced — it costs nothing measurable at all.
+
+**3. `sl-watchdog` is free.** +0.30, same argument.
+
+**4. Zero xruns in all twelve runs.** At 1024 x 3 with a baseline of 19% DSP there is
+enough headroom that no condition can be made to fail, which means **this run establishes
+cost but cannot establish safety.** Stated plainly because the distinction is the entire
+lesson of the void measurement: an experiment that returns the same answer in every
+condition has not tested anything.
+
+## What this does not settle
+
+**The 512 x 3 comparison is still missing**, and it is the one that matters — 512 is the
+buffer the instrument is played at, and crackle at 512 is what caused the stack to be
+switched off. That run was attempted and is **void by operator error**: two measurement
+scripts overlapped, and the first one's cleanup trap stopped the looper units partway
+through the second one's condition D. The resulting file has 259 samples in one condition
+and 111 in another against an expected 180, which is how it was caught.
+
+It needs a clean re-run:
+
+```sh
+sudo ./scripts/set-surge-audio.sh --buffer 512     # needs sudo — writes /etc/mpe/mpe.env
+# then A (all off) vs D (full stack), 3 x 60 s each, one script at a time
+sudo ./scripts/set-surge-audio.sh --buffer 1024    # restore
+```
+
+Two further traps worth recording, both of which produced a clean exit code and no data:
+
+- `xrun-corr.sh` writes to `~/xrun-corr.out`, **not stdout**, and truncates it per run.
+  The first attempt redirected its stdout: twelve runs, zero readings, exit 0. Every run
+  is now copied out immediately and asserted non-empty.
+- `set-surge-audio.sh` without `sudo` fails on `/etc/mpe/mpe.env` and **carries on**, so a
+  run labelled 512 executed entirely at 1024. Caught only because the script prints the
+  real `jackd` command line into its own output. Assert the period; do not assume it.
+
+## Bearing on D15 and on `install-units.sh`
+
+D15 (the SooperLooper adopt/kill gate) must no longer inherit the void numbers. On cost
+grounds the stack is affordable: 5.5 points of DSP at 1024 x 3, all of it the engine, with
+the Phase 3M merge and the watchdog free.
+
+**Recommendation held, not acted on.** Returning the stack to `ENABLED` needs the 512 run
+above plus B10 (feel), which cannot be delegated. The opt-in default stays until then —
+but it now stands on "not yet re-measured at the buffer that matters", not on a number
+that was wrong.

--- a/docs/measurements/systemd-liveness-cost-2026-08-19.md
+++ b/docs/measurements/systemd-liveness-cost-2026-08-19.md
@@ -1,0 +1,106 @@
+# systemd liveness cost — D-Bus vs fork (work order task 4)
+
+**Question.** `build_snapshot()` was 57.3 ms, of which 55.9 ms was three `systemctl`
+forks. Criterion 7 wants the whole snapshot under 1% of a core at 2 Hz. Can systemd's
+`ActiveState` be read without spawning a process?
+
+**Answer: yes, and it is ~29× cheaper than forking per unit.** But the second half of the
+question — `UnitFileState`, the `enabled` flag — is expensive over D-Bus *too*, and that
+turns out to be the finding that matters.
+
+## Method
+
+`raspberrypi2`, systemd 257, python3-dbus 1.4.0 (already installed — no new dependency).
+11 units, the `STATUS_SERVICE_UNITS` set. Median of 3–10 runs, warm connection.
+
+## Results — active state (the runtime fact)
+
+| approach | 11 units | per unit | at 2 Hz |
+|---|---:|---:|---:|
+| `systemctl is-active` × 11 forks | 201.93 ms | 18.4 ms | 40% of a core |
+| `systemctl is-active u1 … u11` (one fork) | 46.45 ms | 4.2 ms | 9.3% |
+| **`ListUnitsByNames` over D-Bus** | **6.98 ms** | **0.63 ms** | **1.4%** |
+| `ListUnitsByNames`, 1 unit | 0.44 ms | 0.44 ms | — |
+
+The 1-unit figure shows ~0.4 ms of fixed round-trip and ~0.6 ms per unit after that.
+
+## Results — enabled state (the configuration fact)
+
+| approach | 11 units | at 2 Hz |
+|---|---:|---:|
+| `ListUnitFilesByPatterns` over D-Bus | 31.43 ms | 6.3% |
+| `GetUnitFileState` × 11 over D-Bus | 42.71 ms | 8.5% |
+| `systemctl is-enabled` × 11 forks | ~220 ms | 44% |
+
+D-Bus barely helps here, because the cost is not IPC — systemd reads unit files off disk
+and walks the enablement symlink tree. Nothing makes that cheap.
+
+## What this decides
+
+**`enabled` must not be sampled at publish rate.** It is not a runtime signal. It changes
+only when someone runs `systemctl enable/disable` or a deploy runs `install-units.sh` —
+events measured in weeks, not milliseconds. Sampling a configuration fact at 2 Hz was the
+whole mistake; the fix is not a faster probe, it is a correct cadence.
+
+Both probes are batched, and both are served from one cache that the per-unit entry points
+also consult — `systemd_unit_active()` and `systemd_unit_enabled_raw()` read the batch when
+the unit is one of the eleven, rather than reimplementing it.
+
+## Implemented result, measured on the appliance
+
+| | probe cost (11 units) | TTL | contribution at 2 Hz |
+|---|---:|---:|---:|
+| `active` — `ListUnitsByNames` | 7.60 ms | 5 s | 1.52 ms/s |
+| `enabled` — `ListUnitFilesByPatterns` | 32.36 ms | 30 s | 1.08 ms/s |
+| everything else in the build | 1.35 ms | per build | 2.70 ms/s |
+| **total** | | | **5.29 ms/s = 0.53% of a core** |
+
+At 1 Hz it is 0.39%. **Criterion 7 passes**, against 11.5% before.
+
+| | before | after |
+|---|---:|---:|
+| cold build (both caches empty) | 424.50 ms | **42.47 ms** |
+| warm build | 57.30 ms | **1.35 ms** |
+
+### The bug that hid inside the fix
+
+The first cut batched both probes and the cold build did not move — still 424 ms. The
+reason was that `build_snapshot()` constructed the per-unit default callables and injected
+them into `build_services()`, so the batch was built and then bypassed, 22 forks deep.
+Profiling caught it; inspection would not have. `build_snapshot()` now forwards only the
+caller's own injections, and the defaults route through the batch.
+
+Worth stating plainly: the batching was written, tested green, and measurably did nothing
+until it was measured end to end. The unit tests asserted the batch was *called*, which was
+true, and irrelevant.
+
+## The condition attached to caching
+
+The work order is explicit that a cached judgement is the last-known-good problem wearing
+a different hat, and that a TTL is only acceptable if the snapshot carries the age of what
+it cached. Implemented — every service entry now carries both the age and the transport:
+
+```json
+"mpe-jackd": {
+  "active": "active", "enabled": "enabled", "stale": false,
+  "active_source": "dbus", "enabled_source": "dbus",
+  "active_age_s": 0.072, "enabled_age_s": 0.067
+}
+```
+
+A reader can tell a fresh `enabled` from a 29-second-old one, which is the difference
+between a reading and a memory. `*_source` is recorded for the same reason: if the fallback
+is ever in use, the 6x cost difference is visible in the snapshot rather than inferred.
+
+## Fallback
+
+D-Bus absent or refusing (no `python3-dbus`, systemd not on the bus) falls back to a
+**single batched** fork — `systemctl is-active u1 … u11` at 46 ms, still 4.3x better than
+the per-unit forking it replaces. A short answer (fewer lines than units) is treated as
+unknown for every unit rather than mapped positionally onto a guess.
+
+## Recommendation for the publisher
+
+Run at **1 Hz**, not 2. Nothing in the snapshot changes faster than a second except
+`loop_pos`, which the HUD already owns on its own path. 1 Hz halves the dominant term
+(the per-build work) for no loss of fidelity.

--- a/patch_browser/session_snapshot.py
+++ b/patch_browser/session_snapshot.py
@@ -57,17 +57,182 @@ STATUS_SERVICE_UNITS = (
 MPE_ENV_PATH = Path("/etc/mpe/mpe.env")
 MPE_ENV_STATUS_KEYS = ("MPE_UI_MODE", "MPE_AUDIO_PROFILE")
 
+# Liveness probe cadence. `active` is a runtime fact and is sampled every build;
+# `enabled` is a CONFIGURATION fact that changes only on `systemctl enable/disable`
+# or a deploy, so sampling it at publish rate was the original mistake — measured at
+# 31-43 ms for 11 units no matter the transport, because systemd walks the enablement
+# symlink tree on disk. See docs/measurements/systemd-liveness-cost-2026-08-19.md.
 SERVICES_PROBE_TTL_S = float(os.environ.get("MPE_SNAPSHOT_SERVICES_TTL_S", "5"))
+ENABLED_PROBE_TTL_S = float(os.environ.get("MPE_SNAPSHOT_ENABLED_TTL_S", "30"))
+
 _services_probe_cache: dict[str, tuple[float, object]] = {}
-def _ttl_probe(key: str, probe: Callable[[], object]) -> object:
-    """Cache systemd probe results briefly — publisher builds at 2 Hz."""
+
+
+def _ttl_probe(key: str, probe: Callable[[], object], ttl: float | None = None) -> object:
+    """Cache a systemd probe result. Callers must surface the age (see _probe_age_s)."""
     now = time.monotonic()
+    limit = SERVICES_PROBE_TTL_S if ttl is None else ttl
     cached = _services_probe_cache.get(key)
-    if cached is not None and (now - cached[0]) < SERVICES_PROBE_TTL_S:
+    if cached is not None and (now - cached[0]) < limit:
         return cached[1]
     value = probe()
     _services_probe_cache[key] = (now, value)
     return value
+
+
+def _probe_age_s(key: str) -> float | None:
+    """Seconds since the cached probe behind `key` was actually taken.
+
+    A cached judgement is the last-known-good problem wearing a different hat. Every
+    cached field in the snapshot must be able to say how old it is, or a reader cannot
+    tell a live reading from a memory.
+    """
+    cached = _services_probe_cache.get(key)
+    if cached is None:
+        return None
+    return round(max(0.0, time.monotonic() - cached[0]), 3)
+
+
+def _reset_probe_cache() -> None:
+    """Test seam — the cache is process-global and must not leak between cases."""
+    _services_probe_cache.clear()
+
+
+# --- batched liveness -------------------------------------------------------------
+#
+# Measured on the appliance, 11 units: 202 ms as one fork per unit, 46 ms as a single
+# batched fork, 7.0 ms over D-Bus. The publisher runs at 1-2 Hz, so the transport is
+# the difference between 40% of a core and 1.4%.
+
+_DBUS_MANAGER: Any = None
+_DBUS_UNAVAILABLE = False
+
+
+def _dbus_manager() -> Any:
+    global _DBUS_MANAGER, _DBUS_UNAVAILABLE
+    if _DBUS_MANAGER is not None or _DBUS_UNAVAILABLE:
+        return _DBUS_MANAGER
+    try:
+        import dbus  # type: ignore[import-not-found]
+
+        bus = dbus.SystemBus()
+        _DBUS_MANAGER = dbus.Interface(
+            bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1"),
+            "org.freedesktop.systemd1.Manager",
+        )
+    except Exception:
+        _DBUS_UNAVAILABLE = True
+        _DBUS_MANAGER = None
+    return _DBUS_MANAGER
+
+
+def _dbus_active_states(units: tuple[str, ...]) -> dict[str, bool | None] | None:
+    """ActiveState for every unit in one round trip. None when D-Bus is unusable."""
+    mgr = _dbus_manager()
+    if mgr is None:
+        return None
+    try:
+        rows = mgr.ListUnitsByNames([f"{u}.service" for u in units])
+    except Exception:
+        return None
+    out: dict[str, bool | None] = {}
+    for row in rows:
+        name = str(row[0])
+        if not name.endswith(".service"):
+            continue
+        state = str(row[3])
+        if state == "active":
+            out[name[: -len(".service")]] = True
+        elif state in {"inactive", "failed"}:
+            out[name[: -len(".service")]] = False
+        else:
+            out[name[: -len(".service")]] = None
+    return out
+
+
+def _fork_active_states(units: tuple[str, ...]) -> dict[str, bool | None]:
+    """Fallback: ONE fork for all units, never one per unit (202 ms -> 46 ms)."""
+    names = [f"{u}.service" for u in units]
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", *names],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {u: None for u in units}
+    lines = (result.stdout or "").strip().splitlines()
+    if len(lines) != len(units):
+        return {u: None for u in units}
+    out: dict[str, bool | None] = {}
+    for unit, line in zip(units, lines):
+        state = line.strip()
+        if state == "active":
+            out[unit] = True
+        elif state in {"inactive", "failed"}:
+            out[unit] = False
+        else:
+            out[unit] = None
+    return out
+
+
+def batched_active_states(units: tuple[str, ...]) -> tuple[dict[str, bool | None], str]:
+    """Return (states, source). Source is recorded so the cost stays visible."""
+    states = _dbus_active_states(units)
+    if states is not None:
+        return {u: states.get(u) for u in units}, "dbus"
+    return _fork_active_states(units), "fork"
+
+
+def _dbus_enabled_states(units: tuple[str, ...]) -> dict[str, str | None] | None:
+    """UnitFileState for every unit in one round trip.
+
+    A unit with no unit file simply does not appear in the reply, which is the same
+    signal `systemctl is-enabled` gives as "not-found" — build_services skips those
+    rather than rendering a phantom inactive row.
+    """
+    mgr = _dbus_manager()
+    if mgr is None:
+        return None
+    names = [f"{u}.service" for u in units]
+    try:
+        rows = mgr.ListUnitFilesByPatterns([], names)
+    except Exception:
+        return None
+    found: dict[str, str | None] = {}
+    for row in rows:
+        leaf = str(row[0]).rsplit("/", 1)[-1]
+        if leaf.endswith(".service"):
+            found[leaf[: -len(".service")]] = str(row[1])
+    return {u: found.get(u, "not-found") for u in units}
+
+
+def _fork_enabled_states(units: tuple[str, ...]) -> dict[str, str | None]:
+    """Fallback: ONE fork for all units (220 ms -> 46 ms)."""
+    names = [f"{u}.service" for u in units]
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-enabled", *names],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {u: None for u in units}
+    lines = (result.stdout or "").strip().splitlines()
+    if len(lines) != len(units):
+        return {u: None for u in units}
+    return {u: (line.strip() or None) for u, line in zip(units, lines)}
+
+
+def batched_enabled_states(units: tuple[str, ...]) -> tuple[dict[str, str | None], str]:
+    states = _dbus_enabled_states(units)
+    if states is not None:
+        return states, "dbus"
+    return _fork_enabled_states(units), "fork"
 
 
 
@@ -151,32 +316,66 @@ def _surge_on_jack_graph(*, jackd_pid: int | None = None, now: float | None = No
     return wired == "1"
 
 
+def _enabled_label(raw_enabled: str | None) -> str:
+    if raw_enabled in {"masked", "masked-runtime"}:
+        return "masked"
+    if raw_enabled in {"enabled", "enabled-runtime", "static", "indirect", "alias"}:
+        return "enabled"
+    if raw_enabled == "disabled":
+        return "disabled"
+    return "unknown"
+
+
 def build_services(
     *,
     unit_active: Callable[[str], bool | None] | None = None,
     unit_enabled: Callable[[str], str | None] | None = None,
 ) -> dict[str, Any]:
-    check_active = _memoized_unit_active(unit_active or systemd_unit_active)
-    check_enabled_raw = _memoized_unit_enabled_raw(unit_enabled or systemd_unit_enabled_raw)
+    """Per-unit liveness. Every cached field carries the age of what it cached.
+
+    `active` comes from one batched probe (D-Bus where available, otherwise a single
+    fork); `enabled` is per-unit on a long TTL because it is configuration, not
+    runtime. See docs/measurements/systemd-liveness-cost-2026-08-19.md.
+    """
+    if unit_enabled is None:
+        enabled_batch = _batched_enabled_cache()
+        enabled_source = _services_probe_cache["enabled:batch"][1][1]  # type: ignore[index]
+        enabled_age = _probe_age_s("enabled:batch")
+        check_enabled_raw: Callable[[str], str | None] = lambda u: enabled_batch.get(u)
+    else:
+        check_enabled_raw = _memoized_unit_enabled_raw(unit_enabled)
+        enabled_source = "injected"
+        enabled_age = None
+
+    batch: dict[str, bool | None] | None = None
+    active_source = "injected"
+    active_age: float | None = None
+    if unit_active is None:
+        batch = _batched_active_cache()
+        active_source = _services_probe_cache["active:batch"][1][1]  # type: ignore[index]
+        active_age = _probe_age_s("active:batch")
+        check_active: Callable[[str], bool | None] = lambda u: batch.get(u)  # type: ignore[union-attr]
+    else:
+        check_active = _memoized_unit_active(unit_active)
+
     services: dict[str, Any] = {}
     for unit in STATUS_SERVICE_UNITS:
         raw_enabled = check_enabled_raw(unit)
         if raw_enabled == "not-found":
             continue
         active = check_active(unit)
-        if raw_enabled in {"masked", "masked-runtime"}:
-            enabled_label = "masked"
-        elif raw_enabled in {"enabled", "enabled-runtime", "static", "indirect", "alias"}:
-            enabled_label = "enabled"
-        elif raw_enabled in {"disabled"}:
-            enabled_label = "disabled"
-        else:
-            enabled_label = "unknown"
-        services[unit] = {
+        entry: dict[str, Any] = {
             "active": _tri_state_label(active, true_label="active", false_label="inactive"),
-            "enabled": enabled_label,
+            "enabled": _enabled_label(raw_enabled),
             "stale": active is None and raw_enabled is None,
+            "active_source": active_source,
+            "enabled_source": enabled_source,
         }
+        if active_age is not None:
+            entry["active_age_s"] = active_age
+        if enabled_age is not None:
+            entry["enabled_age_s"] = enabled_age
+        services[unit] = entry
     return services
 
 
@@ -319,7 +518,24 @@ def _systemd_unit_active_raw(unit: str) -> bool | None:
     return None
 
 
+def _batched_active_cache() -> dict[str, bool | None]:
+    states, _source = _ttl_probe(  # type: ignore[misc]
+        "active:batch",
+        lambda: batched_active_states(STATUS_SERVICE_UNITS),
+    )
+    return states
+
+
 def systemd_unit_active(unit: str) -> bool | None:
+    """Liveness for one unit, served from the batch when the unit is in it.
+
+    build_snapshot() asks about three units and build_services() about eleven. Answering
+    each with its own probe was 22 forks per snapshot; the batch answers all of them in
+    one round trip, so the per-unit entry point must consult it rather than reimplement
+    it. A unit outside STATUS_SERVICE_UNITS still gets its own probe.
+    """
+    if unit in STATUS_SERVICE_UNITS:
+        return _batched_active_cache().get(unit)
     return _ttl_probe(f"active:{unit}", lambda: _systemd_unit_active_raw(unit))  # type: ignore[return-value]
 
 
@@ -338,8 +554,24 @@ def _systemd_unit_enabled_raw(unit: str) -> str | None:
     return state or None
 
 
+def _batched_enabled_cache() -> dict[str, str | None]:
+    states, _source = _ttl_probe(  # type: ignore[misc]
+        "enabled:batch",
+        lambda: batched_enabled_states(STATUS_SERVICE_UNITS),
+        ttl=ENABLED_PROBE_TTL_S,
+    )
+    return states
+
+
 def systemd_unit_enabled_raw(unit: str) -> str | None:
-    return _ttl_probe(f"enabled:{unit}", lambda: _systemd_unit_enabled_raw(unit))  # type: ignore[return-value]
+    # Configuration, not runtime — long TTL, and build_services reports its age.
+    if unit in STATUS_SERVICE_UNITS:
+        return _batched_enabled_cache().get(unit)
+    return _ttl_probe(  # type: ignore[return-value]
+        f"enabled:{unit}",
+        lambda: _systemd_unit_enabled_raw(unit),
+        ttl=ENABLED_PROBE_TTL_S,
+    )
 
 
 def systemd_unit_enabled(unit: str) -> bool | None:
@@ -566,9 +798,11 @@ def build_snapshot(
         },
     }
     if include_services:
+        # Pass the caller's injections through, never our own defaults — injecting
+        # the per-unit defaults here bypassed the batch and cost 22 forks per build.
         snap["services"] = build_services(
-            unit_active=check_unit,
-            unit_enabled=check_enabled_raw,
+            unit_active=check_unit if unit_active is not None else None,
+            unit_enabled=check_enabled_raw if unit_enabled is not None else None,
         )
     if include_runtime_probes:
         snap["processes"] = build_processes()

--- a/scripts/install-units.sh
+++ b/scripts/install-units.sh
@@ -80,6 +80,13 @@ DISABLED=(
     mpe-sooperlooper
     mpe-looper-session
     sl-watchdog
+    # Phase 1 snapshot publisher. Installed, not started: measured at 0.39% of a
+    # core at 1 Hz — see docs/measurements/systemd-liveness-cost-2026-08-19.md —
+    # which clears criterion 7 comfortably. But it is a new always-on poll on an
+    # instrument whose scarcest resource is CPU, so switching it on is an operator
+    # decision, not a deploy side effect. Enable with:
+    #   sudo systemctl enable --now mpe-session-publisher
+    mpe-session-publisher
 )
 
 # No [Install] section — cannot be enabled, only pulled in by another unit.

--- a/scripts/session-snapshot-publisher.py
+++ b/scripts/session-snapshot-publisher.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Publish session.snapshot.json on a timer (Phase 1, work-order task 5).
+
+Calls ``build_snapshot()`` **in-process**. Never invoke the module CLI on a timer:
+measured 418 ms per invocation against 42 ms in-process, 360 ms of which is
+interpreter start. See docs/measurements/systemd-liveness-cost-2026-08-19.md.
+
+Default cadence is 1 Hz, not 2. Nothing in the snapshot changes faster than a second
+except ``loop_pos``, which the HUD owns on its own path, and 1 Hz halves the dominant
+per-build term for no loss of fidelity. Measured cost at 1 Hz: 0.39% of a core.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from patch_browser.session_snapshot import (  # noqa: E402
+    build_snapshot,
+    next_seq,
+    write_snapshot,
+)
+
+DEFAULT_INTERVAL_S = float(os.environ.get("MPE_SNAPSHOT_PUBLISH_INTERVAL_S", "1.0"))
+# A publisher that cannot keep up is a publisher whose readings are older than they
+# claim. Log it rather than silently drifting; the age fields would still be honest,
+# but the cadence would not be what the unit says it is.
+OVERRUN_WARN_RATIO = 0.5
+
+
+class _Stop:
+    def __init__(self) -> None:
+        self.flag = False
+        for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            signal.signal(sig, self._handle)
+
+    def _handle(self, _signum: int, _frame: object) -> None:
+        self.flag = True
+
+
+def run(interval_s: float, *, run_dir: Path | None = None, once: bool = False) -> int:
+    stop = _Stop()
+    overruns = 0
+    published = 0
+    while True:
+        started = time.monotonic()
+        try:
+            snap = build_snapshot(run=run_dir, seq=next_seq(run=run_dir))
+            write_snapshot(snap, run=run_dir)
+            published += 1
+        except Exception as exc:  # noqa: BLE001 — a publisher must not die on one bad build
+            print(f"session-snapshot-publisher: build failed: {exc}", file=sys.stderr, flush=True)
+        elapsed = time.monotonic() - started
+        if elapsed > interval_s * OVERRUN_WARN_RATIO:
+            overruns += 1
+            if overruns in (1, 10, 100) or overruns % 1000 == 0:
+                print(
+                    f"session-snapshot-publisher: build took {elapsed * 1000:.1f} ms "
+                    f"against a {interval_s:.2f} s interval ({overruns} so far)",
+                    file=sys.stderr,
+                    flush=True,
+                )
+        if once or stop.flag:
+            return 0
+        remaining = interval_s - elapsed
+        # Sleep in slices so SIGTERM is honoured promptly rather than at interval edge.
+        while remaining > 0 and not stop.flag:
+            nap = min(0.2, remaining)
+            time.sleep(nap)
+            remaining -= nap
+        if stop.flag:
+            return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL_S)
+    parser.add_argument("--run-dir", default=None)
+    parser.add_argument("--once", action="store_true", help="Publish one snapshot and exit")
+    args = parser.parse_args(argv)
+    if args.interval <= 0:
+        print("session-snapshot-publisher: --interval must be > 0", file=sys.stderr)
+        return 2
+    run_dir = Path(args.run_dir) if args.run_dir else None
+    print(
+        f"session-snapshot-publisher: publishing every {args.interval:.2f} s",
+        flush=True,
+    )
+    return run(args.interval, run_dir=run_dir, once=args.once)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -132,6 +132,14 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
     osc = osc_session.client
     midi_osc_latencies: list[float] = []
     midi_osc_pending: list[float] = []
+    if args.measure_latency:
+        # Tap the CLIENT, not the bench's _send helper. Footswitches are handed the raw
+        # client by build_footswitches(osc=...) and send /hit through it directly, so a
+        # hook in _send sees nothing a pad ever does. Measured on the appliance
+        # 2026-08-19: 267 pad presses, zero samples, no result printed.
+        from latency_tap import LatencyTapClient
+
+        osc = LatencyTapClient(osc, midi_osc_pending, midi_osc_latencies)
     measure_deadline = (
         time.monotonic()
         + float(os.environ.get("MPE_MEASURE_LATENCY_DEADLINE_S", "300"))
@@ -140,11 +148,6 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
     )
 
     def _send(path: str, a: list) -> None:
-        # Pad-downs routed to fader/mute without /hit leave orphan timestamps;
-        # the next /hit pairs with that stale sample (diagnostic-only inflation).
-        if midi_osc_pending and "/hit" in path:
-            t0 = midi_osc_pending.pop(0)
-            midi_osc_latencies.append((time.monotonic() - t0) * 1000.0)
         osc.send_message(path, a)
 
     grid_active = True

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -461,9 +461,14 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
             continue
 
         if down is not None and n in by_note:
+            if args.measure_latency:
+                # Stamp BOTH edges. A short tap sends its OSC on pad-up, so timing from
+                # pad-down measures how long the finger was held, not how long the code
+                # took: an 80 ms synthetic hold produced an 80 ms "latency" on
+                # 2026-08-19. The slot holds the most recent MIDI event, which is the
+                # one that caused whatever send comes next.
+                midi_osc_pending[:] = [time.monotonic()]
             if down:
-                if args.measure_latency:
-                    midi_osc_pending.append(time.monotonic())
                 by_note[n].on_pad_down()
             else:
                 by_note[n].on_pad_up()

--- a/scripts/sooperlooper/latency_tap.py
+++ b/scripts/sooperlooper/latency_tap.py
@@ -8,6 +8,11 @@ from __future__ import annotations
 
 import time
 
+# A pad press that causes an OSC send causes it immediately — the bench is a poll loop,
+# not a scheduler. Anything later is a coincidence: a quantised launch firing on the
+# bar, a fader flush, an auto-update reply. Pair inside the window, count outside it.
+PAIR_WINDOW_S = 0.1
+
 
 class LatencyTapClient:
     """Wraps the OSC client so every send is seen, whoever makes it.
@@ -29,10 +34,18 @@ class LatencyTapClient:
         self._inner = inner
         self._pending = pending
         self._out = out
+        self.dropped = 0
 
     def send_message(self, path: str, args) -> None:
         if self._pending and "/hit" in path:
-            self._out.append((time.monotonic() - self._pending.pop(0)) * 1000.0)
+            delta = time.monotonic() - self._pending.pop(0)
+            if delta <= PAIR_WINDOW_S:
+                self._out.append(delta * 1000.0)
+            else:
+                # The MIDI event that armed this slot did not cause this send — a
+                # quantised launch firing on the bar, or a grid action. Pairing them
+                # would report the grid as latency.
+                self.dropped += 1
         self._inner.send_message(path, args)
 
     def __getattr__(self, name):

--- a/scripts/sooperlooper/latency_tap.py
+++ b/scripts/sooperlooper/latency_tap.py
@@ -1,0 +1,39 @@
+"""Pad-down -> next ``/hit`` OSC timing for criterion 42.
+
+Lives in its own module so tests can import it without executing the bench, which
+binds MIDI and mutates shared footswitch state on import.
+"""
+
+from __future__ import annotations
+
+import time
+
+
+class LatencyTapClient:
+    """Wraps the OSC client so every send is seen, whoever makes it.
+
+    The footswitches hold the client directly — ``build_footswitches(osc=...)`` hands
+    it to each one — and the bench's ``_send`` helper goes through it too, so there is
+    exactly one pairing point rather than two that can disagree.
+
+    This exists because the first cut hooked ``_send`` instead. Pads never touch
+    ``_send``, so the instrument measured nothing and exited without a number:
+    267 pad presses, zero samples, on the appliance 2026-08-19.
+
+    A pad-down routed to the fader/mute layer emits no ``/hit`` and leaves an orphan
+    timestamp, which the next ``/hit`` pairs with and inflates. Diagnostic only — read
+    the percentiles, not a single max.
+    """
+
+    def __init__(self, inner, pending: list[float], out: list[float]) -> None:
+        self._inner = inner
+        self._pending = pending
+        self._out = out
+
+    def send_message(self, path: str, args) -> None:
+        if self._pending and "/hit" in path:
+            self._out.append((time.monotonic() - self._pending.pop(0)) * 1000.0)
+        self._inner.send_message(path, args)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)

--- a/scripts/sooperlooper/looper_session.py
+++ b/scripts/sooperlooper/looper_session.py
@@ -112,7 +112,12 @@ def run_session(argv: list[str] | None = None) -> int:
 
     bench = _load_bench_module()
     try:
-        return bench.run_bench(bench_argv or None, osc_session=session)
+        # Pass the list even when empty. Coercing an empty list to None handed
+        # argparse a None argv, and argparse falls back to sys.argv in that case — so
+        # the bench re-parsed the session's own flags and died on them. `--bench-only`
+        # with no other argument was broken outright; it only appeared to work when a
+        # passthrough flag made the list non-empty. Found on the appliance 2026-08-19.
+        return bench.run_bench(bench_argv, osc_session=session)
     finally:
         if hud_stop is not None and hud_thread is not None:
             hud_stop.set()

--- a/scripts/sooperlooper/synthpad.py
+++ b/scripts/sooperlooper/synthpad.py
@@ -1,0 +1,67 @@
+"""Drive the APC bench with synthetic pad presses — criterion 42 self-test.
+
+Connects a virtual ALSA port to the bench's MIDI input so a latency run can be proven
+to produce non-zero output without anyone touching the instrument. See AGENTS.md,
+"Never ask Mitch to run a test you could have run yourself".
+
+    python3 scripts/looper-session.py --measure-latency 100 > /tmp/lat.txt 2>&1 &
+    python3 scripts/sooperlooper/synthpad.py 180
+    grep '^live:' /tmp/lat.txt
+"""
+import re
+import subprocess
+import sys
+import time
+
+import rtmidi
+
+out = rtmidi.MidiOut()
+out.open_virtual_port("synthpad")
+time.sleep(0.6)
+
+listing = subprocess.run(["aconnect", "-l"], capture_output=True, text=True).stdout
+# The client is named for the process ("RtMidiOut Client"); "synthpad" is the PORT
+# name and appears on an indented line under it.
+src = None
+current = None
+for line in listing.splitlines():
+    m = re.match(r"client (\d+):", line)
+    if m:
+        current = m.group(1)
+    elif "synthpad" in line and current:
+        src = current
+print("virtual client:", src)
+if src is None:
+    sys.exit("could not find virtual port")
+
+# Find the bench input by asking where the APC is routed, rather than hardcoding a
+# client number — ALSA renumbers on every replug.
+dest = None
+in_apc = False
+for line in listing.splitlines():
+    m = re.match(r"client (\d+): '(.*?)'", line)
+    if m:
+        in_apc = "APC" in m.group(2)
+    elif in_apc:
+        c = re.search(r"Connecting To: (\d+):(\d+)", line)
+        if c:
+            dest = f"{c.group(1)}:{c.group(2)}"
+if dest is None:
+    sys.exit("APC is not routed anywhere — is the bench running?")
+print("bench input:", dest)
+
+rc = subprocess.run(["aconnect", f"{src}:0", dest], capture_output=True, text=True)
+print("aconnect rc:", rc.returncode, rc.stderr.strip())
+time.sleep(0.5)
+
+N = int(sys.argv[1]) if len(sys.argv) > 1 else 6
+# Rotate across all eight pads. Hammering one walks it into tail capture, where the
+# gesture is consumed and no OSC is sent at all.
+for i in range(N):
+    note = i % 8
+    out.send_message([0x90, note, 127])
+    time.sleep(0.05)
+    out.send_message([0x80, note, 0])
+    time.sleep(0.6)
+print(f"sent {N} synthetic pad presses")
+time.sleep(1.0)

--- a/tests/test_looper_session.py
+++ b/tests/test_looper_session.py
@@ -144,3 +144,57 @@ raise SystemExit(ls.run_session(["--bench-only"]))
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class LatencyTapTests(unittest.TestCase):
+    """Criterion 42 — the instrument must see the sends a pad actually makes."""
+
+    @staticmethod
+    def _tap_module():
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "latency_tap_for_test", REPO / "scripts" / "sooperlooper" / "latency_tap.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_tap_pairs_a_pending_pad_with_the_next_hit(self) -> None:
+        import time as _time
+
+        mod = self._tap_module()
+
+        class _Inner:
+            def __init__(self) -> None:
+                self.sent: list[str] = []
+
+            def send_message(self, path: str, args) -> None:
+                self.sent.append(path)
+
+        inner = _Inner()
+        pending: list[float] = [_time.monotonic()]
+        out: list[float] = []
+        client = mod.LatencyTapClient(inner, pending, out)
+        client.send_message("/sl/0/hit", ["trigger"])
+        self.assertEqual(len(out), 1)
+        self.assertGreaterEqual(out[0], 0.0)
+        self.assertEqual(inner.sent, ["/sl/0/hit"])
+        client.send_message("/sl/0/set", ["x"])
+        self.assertEqual(len(out), 1, "non-/hit sends must not consume a sample")
+
+    def test_footswitches_are_handed_the_tapped_client(self) -> None:
+        """The bug this exists for: hooking _send measured nothing.
+
+        build_footswitches(osc=...) hands the raw client to every footswitch, which
+        sends /hit through it directly. A hook in the bench's _send helper never sees
+        a pad. Measured on the appliance 2026-08-19: 267 presses, zero samples.
+        """
+        text = (REPO / "scripts" / "sooperlooper-apc-bench.py").read_text(encoding="utf-8")
+        tap = text.index("LatencyTapClient(osc,")
+        build = text.index("by_note, footswitches = build_footswitches(")
+        self.assertLess(tap, build, "the client must be wrapped before footswitches bind it")
+        send_body = text.split("def _send(path: str, a: list) -> None:", 1)[1].split("\n\n", 1)[0]
+        self.assertNotIn(
+            "midi_osc_pending", send_body, "pairing belongs on the client, not in _send"
+        )

--- a/tests/test_looper_session.py
+++ b/tests/test_looper_session.py
@@ -15,11 +15,20 @@ INSTALL_UNITS = REPO / "scripts" / "install-units.sh"
 
 
 def _disabled_units() -> list[str]:
+    """Entries in install-units.sh DISABLED.
+
+    Strip comments BEFORE finding the closing paren. Splitting the raw text on the
+    first ")" truncates at any parenthesis inside a comment — on 2026-08-19 a commit
+    hash in a caveat comment silently cut the list short, so every entry after it
+    stopped being checked and the tests still passed.
+    """
     text = INSTALL_UNITS.read_text(encoding="utf-8")
-    block = text.split("DISABLED=(", 1)[1].split(")", 1)[0]
+    body = text.split("DISABLED=(", 1)[1]
     names = []
-    for raw in block.splitlines():
+    for raw in body.splitlines():
         line = raw.split("#", 1)[0].strip()
+        if line.startswith(")"):
+            break
         if line:
             names.append(line)
     return names

--- a/tests/test_looper_session.py
+++ b/tests/test_looper_session.py
@@ -198,3 +198,43 @@ class LatencyTapTests(unittest.TestCase):
         self.assertNotIn(
             "midi_osc_pending", send_body, "pairing belongs on the client, not in _send"
         )
+
+
+class BenchArgvPassthroughTests(unittest.TestCase):
+    def test_empty_passthrough_is_a_list_not_none(self) -> None:
+        """argparse falls back to sys.argv on None, so the bench re-parsed our flags.
+
+        `--bench-only` with no other argument exited 2 with
+        "unrecognized arguments: --bench-only" on the appliance 2026-08-19.
+        """
+        text = LOOPER_SESSION.read_text(encoding="utf-8")
+        self.assertIn("run_bench(bench_argv, osc_session=session)", text)
+        self.assertNotIn("bench_argv or None", text)
+
+    def test_bench_only_reaches_the_bench_with_empty_argv(self) -> None:
+        sooper = REPO / "scripts" / "sooperlooper"
+        body = f"""
+import sys
+sys.path.insert(0, "{sooper}")
+sys.path.insert(0, "{REPO}")
+sys.argv = ["looper-session.py", "--bench-only"]
+import looper_session as ls
+ls.start_hud_thread = lambda *a, **k: (_ for _ in ()).throw(AssertionError("hud started"))
+class _FakeBench:
+    @staticmethod
+    def run_bench(argv=None, *, osc_session=None):
+        assert argv == [], f"bench got {{argv!r}}, expected []"
+        print("argv-ok")
+        return 0
+ls._load_bench_module = lambda: _FakeBench
+class _FakeSession:
+    def start(self):
+        return self
+ls.SlOscSession = _FakeSession
+raise SystemExit(ls.run_session(["--bench-only"]))
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", body], capture_output=True, text=True, cwd=REPO
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("argv-ok", result.stdout)

--- a/tests/test_session_publisher.py
+++ b/tests/test_session_publisher.py
@@ -1,0 +1,74 @@
+"""Snapshot publisher — work order task 5 (unblocked by the task 4 liveness spike)."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+PUBLISHER = REPO / "scripts" / "session-snapshot-publisher.py"
+UNIT = REPO / "config" / "mpe-session-publisher.service"
+
+
+class SessionPublisherTests(unittest.TestCase):
+    def test_publisher_exists_and_is_executable(self) -> None:
+        self.assertTrue(PUBLISHER.is_file())
+        self.assertTrue(PUBLISHER.stat().st_mode & 0o111)
+
+    def test_publishes_a_snapshot_with_an_allocated_seq(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = Path(tmp)
+            for expected in (1, 2):
+                proc = subprocess.run(
+                    [sys.executable, str(PUBLISHER), "--once", "--run-dir", str(run)],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+                snap = json.loads((run / "session.snapshot.json").read_text(encoding="utf-8"))
+                self.assertEqual(snap["seq"], expected)
+
+    def test_rejects_a_non_positive_interval(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(PUBLISHER), "--interval", "0"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(proc.returncode, 2, proc.stdout)
+
+    def test_builds_in_process_never_by_reinvoking_the_module_cli(self) -> None:
+        """418 ms per CLI invocation vs 42 ms in-process — 360 ms of it interpreter start."""
+        text = PUBLISHER.read_text(encoding="utf-8")
+        self.assertIn("from patch_browser.session_snapshot import", text)
+        self.assertNotIn("session_snapshot.py", text.split('"""', 2)[-1])
+
+    def test_unit_is_installed_but_not_enabled_by_default(self) -> None:
+        """A new always-on poll is an operator decision, not a deploy side effect."""
+        self.assertTrue(UNIT.is_file())
+        install = (REPO / "scripts" / "install-units.sh").read_text(encoding="utf-8")
+        enabled = install.split("ENABLED=(", 1)[1].split(")", 1)[0]
+        disabled = install.split("DISABLED=(", 1)[1].split("\n)", 1)[0]
+        self.assertNotIn("mpe-session-publisher", enabled)
+        self.assertIn("mpe-session-publisher", disabled)
+
+    def test_unit_keeps_the_publisher_off_the_realtime_plane(self) -> None:
+        text = UNIT.read_text(encoding="utf-8")
+        self.assertIn("CPUSchedulingPolicy=other", text)
+        self.assertEqual(re.findall(r"^LimitRTPRIO=", text, re.M), [])
+        self.assertIn("Nice=", text)
+
+    def test_unit_cites_the_measurement_behind_its_interval(self) -> None:
+        """Cadence is a measured decision here; the number must travel with the unit."""
+        text = UNIT.read_text(encoding="utf-8")
+        self.assertIn("systemd-liveness-cost-2026-08-19.md", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_snapshot.py
+++ b/tests/test_session_snapshot.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import tempfile
 import time
 import unittest
+from unittest import mock
 from pathlib import Path
 
+from patch_browser import session_snapshot
 from patch_browser.session_snapshot import (
     SCHEMA_VERSION,
     STALE_THRESHOLD_S,
@@ -285,6 +288,124 @@ class SnapshotServicesTests(unittest.TestCase):
                 unit_active=lambda _u: True,
             )
             self.assertNotIn("services", snap)
+
+
+class SnapshotLivenessCostTests(unittest.TestCase):
+    """Work order task 4 — batched liveness, and cached fields carry their age."""
+
+    def setUp(self) -> None:
+        session_snapshot._reset_probe_cache()
+
+    tearDown = setUp
+
+    def test_enabled_ttl_is_longer_than_active_ttl(self) -> None:
+        """`enabled` is configuration; sampling it at publish rate was the bug."""
+        self.assertGreater(
+            session_snapshot.ENABLED_PROBE_TTL_S,
+            session_snapshot.SERVICES_PROBE_TTL_S,
+        )
+
+    def test_batched_fork_parses_one_line_per_unit(self) -> None:
+        units = ("a", "b", "c")
+        completed = subprocess.CompletedProcess([], 0, "active\ninactive\nactivating\n", "")
+        with mock.patch.object(session_snapshot.subprocess, "run", return_value=completed):
+            self.assertEqual(
+                session_snapshot._fork_active_states(units),
+                {"a": True, "b": False, "c": None},
+            )
+
+    def test_batched_fork_refuses_a_short_answer(self) -> None:
+        """Fewer lines than units means the mapping is unknown, not partially true."""
+        completed = subprocess.CompletedProcess([], 0, "active\n", "")
+        with mock.patch.object(session_snapshot.subprocess, "run", return_value=completed):
+            self.assertEqual(
+                session_snapshot._fork_active_states(("a", "b")),
+                {"a": None, "b": None},
+            )
+
+    def test_falls_back_to_one_fork_when_dbus_is_unusable(self) -> None:
+        with mock.patch.object(session_snapshot, "_dbus_active_states", return_value=None):
+            with mock.patch.object(
+                session_snapshot, "_fork_active_states", return_value={"a": True}
+            ) as forked:
+                states, source = session_snapshot.batched_active_states(("a",))
+        self.assertEqual((states, source), ({"a": True}, "fork"))
+        forked.assert_called_once()
+
+    def test_dbus_result_is_used_without_forking(self) -> None:
+        with mock.patch.object(
+            session_snapshot, "_dbus_active_states", return_value={"a": False}
+        ):
+            with mock.patch.object(session_snapshot, "_fork_active_states") as forked:
+                states, source = session_snapshot.batched_active_states(("a",))
+        self.assertEqual((states, source), ({"a": False}, "dbus"))
+        forked.assert_not_called()
+
+    def test_cached_fields_carry_their_age(self) -> None:
+        """A cached judgement must be able to say how old it is."""
+        units = session_snapshot.STATUS_SERVICE_UNITS
+        with mock.patch.object(
+            session_snapshot,
+            "batched_active_states",
+            return_value=({u: True for u in units}, "dbus"),
+        ):
+            with mock.patch.object(
+                session_snapshot,
+                "batched_enabled_states",
+                return_value=({u: "enabled" for u in units}, "dbus"),
+            ):
+                services = session_snapshot.build_services()
+        self.assertTrue(services)
+        for unit, entry in services.items():
+            self.assertEqual(entry["active_source"], "dbus", unit)
+            self.assertEqual(entry["enabled_source"], "dbus", unit)
+            self.assertIn("active_age_s", entry, unit)
+            self.assertIn("enabled_age_s", entry, unit)
+            self.assertGreaterEqual(entry["active_age_s"], 0.0)
+
+    def test_active_probe_is_batched_not_per_unit(self) -> None:
+        """The 202 ms -> 7 ms win is the batching; one call for every unit."""
+        units = session_snapshot.STATUS_SERVICE_UNITS
+        with mock.patch.object(
+            session_snapshot,
+            "batched_active_states",
+            return_value=({u: True for u in units}, "dbus"),
+        ) as batched:
+            with mock.patch.object(
+                session_snapshot,
+                "batched_enabled_states",
+                return_value=({u: "enabled" for u in units}, "dbus"),
+            ):
+                session_snapshot.build_services()
+        batched.assert_called_once()
+
+    def test_enabled_probe_is_batched_not_per_unit(self) -> None:
+        """220 ms of per-unit is-enabled forks was the rest of the cold-build cost."""
+        units = session_snapshot.STATUS_SERVICE_UNITS
+        with mock.patch.object(
+            session_snapshot,
+            "batched_active_states",
+            return_value=({u: True for u in units}, "dbus"),
+        ):
+            with mock.patch.object(
+                session_snapshot,
+                "batched_enabled_states",
+                return_value=({u: "enabled" for u in units}, "dbus"),
+            ) as batched:
+                session_snapshot.build_services()
+        batched.assert_called_once()
+
+    def test_units_absent_from_dbus_reply_read_as_not_found(self) -> None:
+        """A unit with no unit file must be skipped, not rendered inactive."""
+        with mock.patch.object(session_snapshot, "_dbus_manager") as mgr:
+            mgr.return_value.ListUnitFilesByPatterns.return_value = [
+                ("/lib/systemd/system/mpe-jackd.service", "enabled"),
+            ]
+            states = session_snapshot._dbus_enabled_states(("mpe-jackd", "ghost-unit"))
+        self.assertEqual(states, {"mpe-jackd": "enabled", "ghost-unit": "not-found"})
+
+    def test_probe_age_is_none_before_the_probe_runs(self) -> None:
+        self.assertIsNone(session_snapshot._probe_age_s("active:batch"))
 
 
 if __name__ == "__main__":

--- a/tests/test_systemd_units.py
+++ b/tests/test_systemd_units.py
@@ -234,10 +234,20 @@ class SingleUnitSourceTests(unittest.TestCase):
 
     def test_retired_looper_client_units_disabled(self) -> None:
         """Phase 3M: merged units must land in DISABLED so upgrade does not double-run."""
+        # Comments are stripped before the closing paren is found: a ")" inside a
+        # comment used to truncate this list, so entries after it went unchecked.
         install = INSTALL_UNITS.read_text(encoding="utf-8")
-        disabled_block = install.split("DISABLED=(", 1)[1].split(")", 1)[0]
-        for name in ("mpe-apc-bench", "sl-hud-monitor"):
-            self.assertIn(name, disabled_block, f"{name} must be in install-units DISABLED")
+        body = install.split("DISABLED=(", 1)[1]
+        entries = []
+        for raw in body.splitlines():
+            line = raw.split("#", 1)[0].strip()
+            if line.startswith(")"):
+                break
+            if line:
+                entries.append(line)
+        for name in ("mpe-apc-bench", "sl-hud-monitor", "mpe-sooperlooper",
+                     "mpe-looper-session", "sl-watchdog", "mpe-session-publisher"):
+            self.assertIn(name, entries, f"{name} must be in install-units DISABLED")
 
     def test_retired_mpe_bench_is_gone_everywhere(self) -> None:
         """It could no longer free the APC — mpe-looper-session.service holds it now."""


### PR DESCRIPTION
Work-order tasks 4, 5 and 6, plus the spec status columns.

## Task 4 — liveness spike: 11.5% → 0.53% of a core

`build_snapshot()` was 57.3 ms, 55.9 ms of it `systemctl` forks. Measured on the appliance, 11 units:

| approach | 11 units | at 2 Hz |
|---|---:|---:|
| fork per unit | 201.93 ms | 40% of a core |
| one batched fork | 46.45 ms | 9.3% |
| **`ListUnitsByNames` over D-Bus** | **6.98 ms** | **1.4%** |

The finding that mattered was the other half: `enabled` costs 31–43 ms *whatever the transport*, because systemd walks the enablement symlink tree on disk. Nothing makes that cheap — and nothing needs to, because `enabled` is configuration, not runtime. Sampling a configuration fact at publish rate was the actual mistake.

`active` batched on a 5 s TTL, `enabled` on 30 s, D-Bus with a single-fork fallback. **Cold build 424 → 42 ms, warm 57 → 1.4 ms, amortised 0.53% at 2 Hz.** Criterion 7 passes.

Per the work order's condition on caching, every service entry now carries `active_age_s`, `enabled_age_s` and which transport answered.

**A trap worth reading:** the first cut batched both probes, tested green, and did not move the cold build at all — `build_snapshot()` was constructing the per-unit defaults and injecting them into `build_services()`, so the batch was built and then bypassed, 22 forks deep. The tests asserted the batch was *called*, which was true and irrelevant. Profiling on the Pi caught it.

## Task 5 — snapshot publisher, 1 Hz, installed but not enabled

In-process `build_snapshot()`; never the module CLI on a timer (418 ms vs 42 ms). 1 Hz rather than 2 — nothing in the snapshot changes faster than a second except `loop_pos`, which the HUD owns.

**Not enabled.** The cost clears criterion 7 with room, but it is a new always-on poll on an instrument whose scarcest resource is CPU. `sudo systemctl enable --now mpe-session-publisher` when you want it.

## Task 6 — the looper numbers are refuted

n=3 × 60 s per condition, cumulative, 1024 × 3, deterministic load:

| condition | xruns/60 s | DSP median | Δ |
|---|---:|---:|---:|
| A — all off | 0, 0, 0 | 19.14% | — |
| B — `mpe-sooperlooper` | 0, 0, 0 | 24.64% | **+5.50** |
| C — `+ mpe-looper-session` | 0, 0, 0 | 24.79% | +0.15 |
| D — `+ sl-watchdog` | 0, 0, 0 | 25.09% | +0.30 |

The whole cost is the engine, at 5.5 points — not the 30-point catastrophe the void numbers implied. The merged session and the watchdog are free, which answers criterion 47 from the other side.

**Zero xruns everywhere means this establishes cost, not safety.** At 1024 with a 19% baseline there is too much headroom for any condition to fail.

**The 512 run is void by my own error** — two scripts overlapped and the first one's cleanup stopped the looper units mid-measurement of the second. Caught by sample counts. Documented with a clean re-run procedure.

Appliance left as found: 1024 × 3, looper stack disabled and inactive.

## Also

- Spec: every phase table now carries a **Status column**, because the spec could not previously express what is currently true — Phase 3M's code has landed and four of its criteria have never been run.
- Fixes a false green: two tests parsed `install-units.sh` `DISABLED` by splitting on the first `)`, which truncates at a parenthesis inside a comment. A commit hash in a caveat comment was already cutting the list short, so the looper units were not actually being checked.

## Tests

998 pass. `test_uac2_stall_watchdog.test_session_mode_stops_bridge_on_close` is a pre-existing timing flake, unrelated — it also flakes on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)