### PR TITLE
Stop-then-weld looper: replace Tier 2 extend-recording

### DIFF
--- a/Documents/DECISIONS.md
+++ b/Documents/DECISIONS.md
@@ -6,6 +6,27 @@ Orientation canon: OM-Repo [`GROUNDING.md`](https://github.com/opsMachine/OM-Rep
 
 ---
 
+## 2026-08-19 — Tier 2 rejected; stop-then-weld is the only tail model
+
+**Decision:** Remove “extend Recording until release quiet” (Tier 2) and Option E
+(seam overdub) from product design. Every clip close — defining take and grid clips —
+uses the same **stop-then-weld** path:
+
+1. **Stop** — pad sends `record` stop; length fixes immediately (clip 0) or at the
+   quantised bar (grid clips).
+2. **Tail pass** — parallel record on scratch loop 15 while main loop plays at fixed N.
+3. **Weld once** — offline merge at wrap seam; no second copy of release already in the buffer.
+
+**Why:** Tier 2 duplicated release, did not stop on the pad, and was an AI compromise —
+not Mitch’s model. Ear-failed on Pi 2026-08-18–19.
+
+**Defaults:** `MPE_SL_TAIL_CAPTURE=1`, `MPE_SL_SEAM_WELD=1`. Set `MPE_SL_SEAM_WELD=0`
+for stop-only (no reload merge) while tuning latency.
+
+**Canon:** `Documents/specs/looper-loop-seam-spec.md` §Stop-then-weld.
+
+---
+
 ## 2026-08-18 — Anything that touches the audio path must be declared, including what you did not write
 
 **Three faults in one week, one shape.** Each was a component doing something

--- a/Documents/specs/looper-loop-seam-spec.md
+++ b/Documents/specs/looper-loop-seam-spec.md
@@ -87,52 +87,37 @@ unchanged (not worse). No change to loop length or grid BPM.
 
 ---
 
-### Tier 2 — Envelope-following close (clip 0 / defining take only)
+### ~~Tier 2~~ — REJECTED (do not ship)
 
-**Intent:** free-form first take **may grow** to include natural release; tempo
-is derived from final length anyway (`sl_grid_state.py`).
-
-**Behavior on pad-down while recording (defining take only):**
-
-1. Enter **`TAIL_CAPTURE`** bench state — **do not** send `record` stop yet.
-2. Continue **Recording** in SL (still `SL_STATE_RECORDING`).
-3. Poll `in_peak_meter` (OSC `/sl/{n}/get`) until peak &lt; `MPE_SL_TAIL_THRESH`
-   for `MPE_SL_TAIL_HOLD_MS` consecutive, or `MPE_SL_TAIL_MAX_MS` elapses.
-4. Send `record` stop → Playing; proceed with existing grid establish +
-   phase re-anchor.
-
-**Guardrails:**
-
-- Only when `grid.is_pending(loop)` / defining take (`loop_model.plan_gesture`
-  `arm_grid` path).
-- **Block** other gestures on **this** loop until capture ends or aborts.
-- Bank switch / pad release on **other** loops unaffected.
-- Long-press clear still cancels (existing hold path).
-
-**Acceptance (B2 / Mitch ear):** one-bar synth phrase, stop on downbeat —
-release audible through wrap; clip 0 `cycle_len` includes tail; derived BPM stable.
+**Status:** **Rejected 2026-08-19.** “Stay Recording until peak quiet” was an AI backup
+plan, not product design. It grew the clip after pad-down, duplicated release in the
+buffer, and did not stop on the pad. **No code path may reintroduce it.**
 
 ---
 
-### Tier 3 — Fixed-bar seam weld (grid clips 1+)
+### Stop-then-weld (all clips — defining + grid)
 
-**Intent:** loop length stays **one quantised cycle**; tail after the nominal
-stop is captured in parallel and merged at the seam only.
+**Intent:** pad fixes loop length **now**; release after the stop is captured **once**
+in parallel and merged at the wrap seam only.
 
-**Behavior on pad-down while recording (grid established, not defining):**
+**Behavior on pad-down while recording:**
 
-1. If quantised: wait for existing **WAIT_STOP / boundary** behaviour (unchanged).
-2. On transition to **Playing** (loop length fixed at N):
-   - Enter **`SEAM_WELD`** on this loop only.
-   - Start **parallel tail capture** (see spike below).
-3. While welding: loop plays; tail buffer fills from loop input (or SL overdub
-   scoped to seam — see spike).
-4. When envelope quiet or max ms: apply **seam merge** on `[N−M, N)` and
-   `[0, M)`; exit weld mode; SL returns to normal Playing.
+| Context | Stop timing | Tail pass |
+|---------|-------------|-----------|
+| **Defining take** (`grid.is_pending`) | Immediate `record` stop | Scratch + merge when PLAYING |
+| **Grid clip** (grid established) | Quantised boundary (existing WAIT_STOP) | Same, after PLAYING lands |
+
+**Steps (both contexts):**
+
+1. Send `record` stop (immediate or quantised — unchanged grid stop path).
+2. On **Playing** (length fixed at N): enter **`SEAM_WELD`** bench state on this loop.
+3. Record tail on **scratch loop 15** in parallel; poll `in_peak_meter` until quiet or max ms.
+4. If release was audible: **offline seam merge** on `[N−M, N)` ↔ `[0, M)`; reload main loop.
+5. Exit weld; apply deferred grid clock / phase re-anchor if any.
 
 **Guardrails (required — Mitch concern):**
 
-- **Single-loop lock:** while loop *i* is in `SEAM_WELD` or `TAIL_CAPTURE`, ignore
+- **Single-loop lock:** while loop *i* is in `SEAM_WELD`, ignore
   record/overdub/mute on *i* except explicit cancel (long-press clear).
 - **No overdub leak:** before any command on loop *j≠i*, ensure loop *i* is not
   in SL overdub/recording for tail — force `overdub` off or `undo` tail pass if
@@ -154,8 +139,8 @@ SooperLooper has **no** “weld tail here” OSC. Candidates to prove on bench:
 | **C. JACK-side tail tap** (`mpe-looper` or tap port) + offline merge | Full control | New audio path; CPU; not Phase 1. |
 | **D. SL substitute** at end of first playback cycle | One cycle replace | Playhead timing; tail may be gone before playhead reaches N. |
 
-**Decision rule:** Tier 3 code starts only after spike documents **one** viable
-path with ear pass on 1-bar grid clip. Until then, ship Tier 1 + Tier 2.
+**Implementation (2026-08-19):** Option B — scratch loop slot + offline merge
+(`sl_seam_weld.py`, `seam_merge.py`). Option E (seam overdub) rejected with Tier 2.
 
 ---
 
@@ -166,25 +151,20 @@ New states in `apc_footswitch.py` (per loop, orthogonal to `sl_state`):
 ```
 IDLE / RECORDING / PLAYING / …  (existing derive_state)
 
-TAIL_CAPTURE   — Tier 2; SL still Recording; waiting for silence
-SEAM_WELD      — Tier 3; SL Playing; tail scratch + merge pending
+SEAM_WELD      — fixed length; scratch tail + merge pending
 ```
 
 ```mermaid
 stateDiagram-v2
     [*] --> Recording: pad down (defining)
-    Recording --> TailCapture: pad down close (defining)
-    TailCapture --> Playing: silence or max ms → record stop
-    Recording --> WaitStop: pad down close (grid)
-    WaitStop --> Playing: quantize boundary
-    Playing --> SeamWeld: weld armed (grid, Tier 3)
+    Recording --> SeamWeld: pad down close (stop sent)
     SeamWeld --> Playing: merge done or abort
-    TailCapture --> Idle: long-press clear
-    SeamWeld --> Idle: long-press clear
+    Recording --> WaitStop: pad down close (grid, quantize)
+    WaitStop --> SeamWeld: boundary → Playing
+    SeamWeld --> Playing: merge done or abort
 ```
 
-LED hint (hypothesis): blink **amber** during `TAIL_CAPTURE` / `SEAM_WELD` so
-“still finishing take” is visible and fast switching is discouraged.
+LED hint: blink **amber** during `SEAM_WELD` (“still finishing take”).
 
 ---
 
@@ -196,8 +176,8 @@ LED hint (hypothesis): blink **amber** during `TAIL_CAPTURE` / `SEAM_WELD` so
 | `MPE_SL_TAIL_HOLD_MS` | `80` | Consecutive silence before close |
 | `MPE_SL_TAIL_MAX_MS` | `750` | Force close / abort weld |
 | `MPE_SL_SEAM_MERGE_SAMPLES` | `2048` | Crossfade width M at seam (Tier 3) |
-| `MPE_SL_TAIL_CAPTURE` | `1` | Master enable Tier 2; `0` = Tier 1 only |
-| `MPE_SL_SEAM_WELD` | `0` | Tier 3 off until spike passes |
+| `MPE_SL_TAIL_CAPTURE` | `1` | Master enable stop-then-weld; `0` = Tier 1 only |
+| `MPE_SL_SEAM_WELD` | `1` | Offline merge reload; `0` = stop + scratch poll, no merge |
 | `MPE_SL_INPUT_LATENCY` | *(unset)* | Override; else JACK autoset |
 | `MPE_SL_FADE_SAMPLES` | `256` | Existing global crossfade |
 

--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -161,18 +161,16 @@ MPE_MIDI_CLOCK_IN_PORT=RC-5
 # MPE_SL_GRID_ANCHOR_MAX_S=0.015
 # MPE_SL_GRID_ANCHOR_FALLBACK_CYCLES=1.1
 # MPE_SL_BENCH_LOOP_POS_MS=20     # loop_pos poll for phase re-anchor (default 20 ms)
-# Loop seam (looper-loop-seam-spec.md): tail capture on defining take close.
+# Loop seam (looper-loop-seam-spec.md): stop-then-weld on every clip close.
+# Pad fixes length immediately (defining) or at bar (grid); release captured on
+# scratch loop 15 and merged once at the wrap seam — not by extending Recording.
 # MPE_SL_TAIL_CAPTURE=1
-# MPE_SL_TAIL_MODE=extend        # default — Tier 2 grow clip; seam = Option E (experimental)
 # MPE_SL_TAIL_THRESH=0.02
 # MPE_SL_TAIL_HOLD_MS=80
 # MPE_SL_TAIL_MAX_MS=4000
-# MPE_SL_TAIL_SEAM_RATIO=0.85
-# MPE_SL_TAIL_SEAM_END_MS=500
-# MPE_SL_TAIL_MIN_OVERDUB_MS=150
 # MPE_SL_TAIL_PEAK_MS=25
-# Tier 3 seam weld (scratch loop + offline merge at wrap) — default OFF until spike passes:
-# MPE_SL_SEAM_WELD=0
+# Offline seam merge (default on; set 0 for stop-only, no reload):
+# MPE_SL_SEAM_WELD=1
 # MPE_SL_SCRATCH_LOOP=15
 # MPE_SL_SEAM_MERGE_SAMPLES=2048
 # MPE_SL_AUTOSET_LATENCY=1

--- a/docs/measurements/README.md
+++ b/docs/measurements/README.md
@@ -35,6 +35,6 @@ design under JACK and reports a false negative on a healthy appliance.
 ## Completed runs
 
 - [`looper-p0-latency-calibration.md`](looper-p0-latency-calibration.md) — P0 input_latency ear procedure (do before seam tuning)
-- [`seam-weld-spike-2026-08-18.md`](seam-weld-spike-2026-08-18.md) — Tier 3 Option B ear-failed; defining take reverted to Tier 2
+- [`seam-weld-spike-2026-08-18.md`](seam-weld-spike-2026-08-18.md) — Option B/E/Tier 2 archaeology; stop-then-weld is current (2026-08-19)
 - [`sooperlooper-eval-2026-08-14.md`](sooperlooper-eval-2026-08-14.md) — Session A
   **continue**, Session B **inconclusive** (Pi bench, branch `docs/sooperlooper-eval`).

--- a/docs/measurements/looper-p0-latency-calibration.md
+++ b/docs/measurements/looper-p0-latency-calibration.md
@@ -25,8 +25,8 @@ That applies to **record stop** as well as record start. Tier 2 (stay Recording 
 | Check | Command |
 |-------|---------|
 | Bench + engine up | `mpe looper sl-bench status` · `mpe status` |
-| Tier 2 deployed | Bench log on defining close: `recording release into loop until quiet` |
-| Seam weld off | `MPE_SL_SEAM_WELD=0` (default) |
+| Tier 2 deployed | Bench log on defining close: `stop now — weld release at seam` |
+| Seam weld | `MPE_SL_SEAM_WELD=1` (default) |
 | Quiet room / headphones | Normal playing level — see `AGENTS.md` audio safety |
 
 Read current engine values:

--- a/docs/measurements/seam-weld-spike-2026-08-18.md
+++ b/docs/measurements/seam-weld-spike-2026-08-18.md
@@ -1,8 +1,15 @@
 # Tier 3 seam weld spike — 2026-08-18
 
-**Verdict (2026-08-18 ear):** **Option B failed defining take** — tail often missing, HUD showed bar 2 from scratch loop, `load_loop` jumped to loop start. **Defining take reverted to Tier 2** (stay Recording until release quiet, then stop). Tier 3 code remains behind `MPE_SL_SEAM_WELD=1` for future grid-clip experiments; **default is now `0`.**
+**Verdict (superseded 2026-08-19):** Option B + Option E + Tier 2 extend were all rejected.
+**Product path:** stop-then-weld on `yolo/looper-poll-tail-fix` — pad fixes length,
+scratch loop 15 + offline merge (`MPE_SL_SEAM_WELD=1` default). See
+`Documents/DECISIONS.md` §2026-08-19.
 
-**Spec:** `Documents/specs/looper-loop-seam-spec.md` Tier 3 spike (P2).
+**Historical (2026-08-18 ear):** Option B failed defining take; Tier 2 was tried as
+default and also rejected (double tail, clip does not end on pad). Details below
+are kept for archaeology only.
+
+**Spec:** `Documents/specs/looper-loop-seam-spec.md` stop-then-weld.
 
 ---
 

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -20,6 +20,7 @@ from apc_footswitch import (  # noqa: E402
     apply_view,
     build_footswitches,
     footswitches_by_loop,
+    poll_footswitches,
     reset_all_loops,
     stop_all_loops,
 )
@@ -337,9 +338,7 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
             engine_event_watch.poll()
 
     def poll_holds() -> None:
-        for fs in footswitches:
-            fs.poll_hold()
-            fs.poll_led()
+        poll_footswitches(footswitches)
 
     def tick_faders() -> None:
         """Ramp smoothed wet toward targets between CC events."""

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -250,8 +250,7 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
     state_listener.start()
     state_listener.register(osc, num_loops=num_loops)
     state_listener.wire_tail_capture(footswitches)
-    seam_worker: SeamWeldWorker | None = None
-    if SEAM_WELD_ENABLED and TAIL_CAPTURE_ENABLED:
+    if TAIL_CAPTURE_ENABLED:
         seam_worker = SeamWeldWorker(_send)
         for fs in footswitches:
             fs.set_seam_weld_hooks(
@@ -268,13 +267,18 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
                     loop, SCRATCH_LOOP, done=done
                 ),
             )
+        weld_note = (
+            "on"
+            if SEAM_WELD_ENABLED
+            else "off (MPE_SL_SEAM_WELD=0 — stop only, no merge reload)"
+        )
         print(
-            f"bench: Tier 3 seam weld on (scratch loop {SCRATCH_LOOP})",
+            f"bench: stop-then-weld {weld_note} (scratch loop {SCRATCH_LOOP})",
             flush=True,
         )
-    if not TAIL_CAPTURE_ENABLED:
+    else:
         print(
-            "bench: MPE_SL_TAIL_CAPTURE off — defining-take tail capture disabled",
+            "bench: MPE_SL_TAIL_CAPTURE off — tail weld disabled",
             flush=True,
         )
 

--- a/scripts/sooperlooper/apc_footswitch.py
+++ b/scripts/sooperlooper/apc_footswitch.py
@@ -82,6 +82,19 @@ def log(msg: str) -> None:
     print(f"[{time.strftime('%H:%M:%S')}.{int(time.time() % 1 * 1000):03d}] {msg}", flush=True)
 
 
+def poll_footswitches(footswitches: list[LoopFootswitch]) -> None:
+    """Periodic bench poll — holds, LED transitions, tail capture completion.
+
+    Tail capture only finishes inside ``poll_tail_capture()`` (peak quiet / max
+    timeouts). If this is not called every idle tick, defining-take stop leaves
+    ``_tail_capture`` set forever and the pad keeps the green/red animation.
+    """
+    for fs in footswitches:
+        fs.poll_hold()
+        fs.poll_led()
+        fs.poll_tail_capture()
+
+
 def _osc_send(osc, path: str, args: list) -> None:
     osc.send_message(path, args)
 
@@ -1035,6 +1048,7 @@ def reset_all_loops(
         fs.awaiting_quantize = False
         fs._stop_queued = False
         fs._cancel_tail_capture()
+        fs._led_transition = None
         fs._expect(STATE_IDLE)
         fs._sync_led()
     for row, col in all_clip_pads():
@@ -1073,7 +1087,10 @@ def stop_all_loops(
         log(f"grid position reset to zero ({grid.bpm:.3f} BPM)")
     for fs in footswitches:
         fs.awaiting_quantize = False
-        if fs.sl_state != SL_STATE_OFF or fs._tail_capture:
+        # OFF_MUTED (20) is idle/empty after global mute — not a clip to stop.
+        # Treating it like active set pending=stopped on every empty pad (yellow
+        # blink storm on the second Stop All in a session). Pi log 2026-08-19.
+        if fs.sl_state not in (SL_STATE_OFF, SL_STATE_OFF_MUTED) or fs._tail_capture:
             fs._expect(STATE_STOPPED)
         fs._sync_led()
     print(f"-> stop all: paused {num_loops} loops", flush=True)

--- a/scripts/sooperlooper/apc_footswitch.py
+++ b/scripts/sooperlooper/apc_footswitch.py
@@ -29,21 +29,13 @@ from loop_model import (
 )
 from sl_grid_state import GridState, derive_tempo
 from sl_grid_sync import (
-    DEFAULT_FADE_SAMPLES,
     GRID_ANCHOR_FALLBACK_CYCLES,
     GRID_ANCHOR_MAX_S,
     TAIL_CAPTURE_ENABLED,
     TAIL_HOLD_S,
     TAIL_MAX_S,
     TAIL_ABSOLUTE_MAX_S,
-    TAIL_MIN_OVERDUB_S,
-    TAIL_SEAM_END_MAX_S,
-    TAIL_SEAM_RATIO,
-    TAIL_SEAM_MODE,
     TAIL_THRESH,
-    TAIL_WELD_FADE_SAMPLES,
-    TAIL_WELD_INPUT_GAIN,
-    TAIL_WELD_RESTORE_INPUT_GAIN,
     detect_loop_wrap,
     should_defer_phase_anchor,
 )
@@ -155,11 +147,7 @@ class LoopFootswitch:
         self._in_peak_seen = False
         self._tail_saw_loud = False
         self._tail_stop_sent = False
-        self._tail_seam_mode = False
-        self._seam_overdub_active = False
-        self._seam_overdub_started_at = 0.0
-        self._tail_release_quiet = False
-        self._tail_release_quiet_since: float | None = None
+        self._tail_deferred = False
         self._scratch_active = False
         self._tail_ending = False
         self._merge_pending = False
@@ -233,51 +221,6 @@ class LoopFootswitch:
         if self._tail_capture and self._in_peak >= TAIL_THRESH:
             self._tail_saw_loud = True
 
-    def _in_seam_zone(self) -> bool:
-        if self.loop_len <= 0.0 or not self._loop_pos_seen:
-            return False
-        return self.loop_pos >= self.loop_len * TAIL_SEAM_RATIO
-
-    def _set_loop_control(self, name: str, value: float) -> None:
-        if self._osc is None:
-            return
-        self._osc.send_message(self._path("set"), [name, float(value)])
-
-    def _start_seam_overdub(self) -> None:
-        if self._seam_overdub_active:
-            return
-        log(
-            f"loop {self.loop}: seam overdub on "
-            f"(pos={self.loop_pos:.3f}s / {self.loop_len:.3f}s, "
-            f"gain={TAIL_WELD_INPUT_GAIN})"
-        )
-        self._set_loop_control("input_gain", TAIL_WELD_INPUT_GAIN)
-        self._set_loop_control("fade_samples", float(TAIL_WELD_FADE_SAMPLES))
-        self._hit("overdub")
-        self._seam_overdub_active = True
-        self._seam_overdub_started_at = time.monotonic()
-        # Release must be loud *during* the overdub pass — not from the main take.
-        self._tail_saw_loud = False
-        self._in_peak_seen = False
-        self._tail_silence_since = None
-        self._tail_release_quiet = False
-        self._tail_release_quiet_since = None
-
-    def _stop_seam_overdub(self) -> None:
-        if not self._seam_overdub_active:
-            return
-        self._hit("overdub")
-        self._set_loop_control("input_gain", TAIL_WELD_RESTORE_INPUT_GAIN)
-        self._set_loop_control("fade_samples", float(DEFAULT_FADE_SAMPLES))
-        self._seam_overdub_active = False
-        log(f"loop {self.loop}: seam overdub off")
-
-    def _reset_seam_overdub_state(self) -> None:
-        self._seam_overdub_active = False
-        self._seam_overdub_started_at = 0.0
-        self._tail_release_quiet = False
-        self._tail_release_quiet_since = None
-
     def _stop_scratch_capture(self) -> None:
         if not self._scratch_active:
             return
@@ -310,7 +253,6 @@ class LoopFootswitch:
     def _cancel_tail_capture(self) -> None:
         if self._tail_capture and self._on_tail_capture_end is not None:
             self._on_tail_capture_end(self.loop)
-        self._stop_seam_overdub()
         self._stop_scratch_capture()
         self._tail_ending = False
         self._merge_pending = False
@@ -320,8 +262,7 @@ class LoopFootswitch:
         self._tail_silence_since = None
         self._tail_saw_loud = False
         self._tail_stop_sent = False
-        self._tail_seam_mode = False
-        self._reset_seam_overdub_state()
+        self._tail_deferred = False
         if had_deferred:
             self._flush_deferred_grid_side_effects()
 
@@ -345,23 +286,12 @@ class LoopFootswitch:
     def _finish_tail_capture(self, reason: str) -> None:
         if not self._tail_capture:
             return
-        peak = self._in_peak
-        saw_loud = self._tail_saw_loud
-        elapsed = (
-            time.monotonic() - self._tail_capture_since
-            if self._tail_capture_since
-            else 0.0
-        )
-        stop_sent = self._tail_stop_sent
-        seam_mode = self._tail_seam_mode
         self._tail_capture = False
         self._tail_capture_since = 0.0
         self._tail_silence_since = None
         self._tail_saw_loud = False
         self._tail_stop_sent = False
-        self._tail_seam_mode = False
-        self._stop_seam_overdub()
-        self._reset_seam_overdub_state()
+        self._tail_deferred = False
         self._scratch_active = False
         self._tail_ending = False
         self._merge_pending = False
@@ -370,16 +300,7 @@ class LoopFootswitch:
         self._pad_down = False
         self._pad_down_at = 0.0
         self._hold_fired = False
-        if not stop_sent:
-            log(
-                f"loop {self.loop}: tail capture done ({reason}) — "
-                f"sending record stop (peak={peak:.4f}, "
-                f"saw_loud={saw_loud}, elapsed={elapsed:.2f}s)"
-            )
-            self._hit("record")
-            self._expect(STATE_PLAYING)
-        else:
-            log(f"loop {self.loop}: seam weld done ({reason})")
+        log(f"loop {self.loop}: seam weld done ({reason})")
         self._flush_deferred_grid_side_effects()
         self._sync_led()
         self._mark_action()
@@ -450,54 +371,21 @@ class LoopFootswitch:
         return self.sl_state in ACTIVE_PLAY
 
     def poll_tail_capture(self) -> None:
-        """Tier 2: extend recording until release fades. Option E: seam overdub.
-        Tier 3: scratch + merge."""
+        """Stop-then-weld: fixed loop length + parallel scratch + offline merge."""
         if not self._tail_capture:
             return
         now = time.monotonic()
         elapsed = now - self._tail_capture_since
         if elapsed >= TAIL_ABSOLUTE_MAX_S:
-            if self._tail_stop_sent:
-                if self._tail_seam_mode:
-                    self._stop_seam_overdub()
-                    self._finish_tail_capture(f"absolute max {TAIL_ABSOLUTE_MAX_S:.2f}s")
-                else:
-                    self._end_tail_capture(f"absolute max {TAIL_ABSOLUTE_MAX_S:.2f}s")
-            else:
-                self._finish_tail_capture(f"absolute max {TAIL_ABSOLUTE_MAX_S:.2f}s")
+            self._end_tail_capture(f"absolute max {TAIL_ABSOLUTE_MAX_S:.2f}s")
             return
         if self._in_peak_seen and self._in_peak >= TAIL_THRESH:
             self._tail_saw_loud = True
             self._tail_silence_since = None
-            self._tail_release_quiet = False
-            self._tail_release_quiet_since = None
 
-        if self._tail_seam_mode and self._tail_stop_sent:
-            self._poll_seam_tail(now, elapsed)
+        if self._tail_deferred and not self._tail_playback_ready():
             return
 
-        if not self._tail_stop_sent:
-            # Tier 2 — main loop still recording; release is captured in-place.
-            if self._tail_ending:
-                return
-            if self._in_peak_seen and self._in_peak >= TAIL_THRESH:
-                return
-            if not self._in_peak_seen or not self._tail_saw_loud:
-                if elapsed >= TAIL_MAX_S:
-                    self._finish_tail_capture(
-                        f"max {TAIL_MAX_S:.2f}s (no release peak)"
-                    )
-                return
-            if self._tail_silence_since is None:
-                self._tail_silence_since = now
-                return
-            if (now - self._tail_silence_since) >= TAIL_HOLD_S:
-                self._finish_tail_capture(
-                    f"peak<{TAIL_THRESH} for {TAIL_HOLD_S * 1000:.0f}ms"
-                )
-            return
-
-        # Tier 3 — fixed length + parallel scratch capture + offline merge.
         if not self._scratch_active:
             self._maybe_start_scratch()
             if not self._scratch_active and elapsed >= TAIL_MAX_S:
@@ -519,67 +407,6 @@ class LoopFootswitch:
         if (now - self._tail_silence_since) >= TAIL_HOLD_S:
             self._end_tail_capture(
                 f"peak<{TAIL_THRESH} for {TAIL_HOLD_S * 1000:.0f}ms"
-            )
-
-    def _poll_seam_tail(self, now: float, elapsed: float) -> None:
-        """Option E — fixed bar; overdub release only near the wrap seam."""
-        if self._tail_ending or self._merge_pending:
-            return
-        if not self._tail_playback_ready():
-            return
-        if self.loop_len <= 0.0:
-            return
-
-        if not self._seam_overdub_active:
-            if elapsed >= TAIL_MAX_S:
-                self._finish_tail_capture(f"max {TAIL_MAX_S:.2f}s (no seam overdub)")
-                return
-            if self._in_seam_zone():
-                self._start_seam_overdub()
-            return
-
-        overdub_elapsed = now - self._seam_overdub_started_at
-        if self._in_peak_seen and self._in_peak >= TAIL_THRESH:
-            return
-        if not self._in_peak_seen or not self._tail_saw_loud:
-            if elapsed >= TAIL_MAX_S:
-                self._stop_seam_overdub()
-                self._finish_tail_capture(f"max {TAIL_MAX_S:.2f}s (no release peak)")
-            return
-
-        if not self._tail_release_quiet:
-            if self._tail_silence_since is None:
-                self._tail_silence_since = now
-                return
-            if (now - self._tail_silence_since) >= TAIL_HOLD_S:
-                self._tail_release_quiet = True
-                self._tail_release_quiet_since = now
-                log(
-                    f"loop {self.loop}: release quiet — waiting for wrap "
-                    f"(pos={self.loop_pos:.3f}s)"
-                )
-            return
-
-        quiet_wait = (
-            now - self._tail_release_quiet_since
-            if self._tail_release_quiet_since is not None
-            else 0.0
-        )
-        ready_to_stop = (
-            self._in_seam_zone()
-            and overdub_elapsed >= TAIL_MIN_OVERDUB_S
-        )
-        if ready_to_stop:
-            self._stop_seam_overdub()
-            self._finish_tail_capture(
-                f"seam weld at wrap (peak<{TAIL_THRESH}, "
-                f"overdub={overdub_elapsed * 1000:.0f}ms)"
-            )
-            return
-        if quiet_wait >= TAIL_SEAM_END_MAX_S:
-            self._stop_seam_overdub()
-            self._finish_tail_capture(
-                f"seam end timeout {TAIL_SEAM_END_MAX_S * 1000:.0f}ms"
             )
 
     def sync_from_sl(self, sl_state: int) -> bool:
@@ -752,7 +579,6 @@ class LoopFootswitch:
             self.sl_state,
             pending=self._pending,
             tail_capture=self._tail_capture,
-            tail_seam_weld=self._tail_seam_mode and self._tail_stop_sent,
         )
 
     def _sync_led(self) -> None:
@@ -839,7 +665,6 @@ class LoopFootswitch:
             is_defining=self.grid is not None and self.grid.is_pending(self.loop),
             quantized=self.quantized,
             tail_capture_enabled=TAIL_CAPTURE_ENABLED,
-            tail_seam_mode=TAIL_SEAM_MODE,
         )
         if not (plan.commands or plan.queue_stop or plan.arm_grid or plan.begin_tail_capture):
             return
@@ -855,36 +680,22 @@ class LoopFootswitch:
             self._in_peak_seen = False
             self._tail_saw_loud = False
             self._scratch_active = False
-            self._tail_seam_mode = TAIL_SEAM_MODE and bool(plan.commands)
-            if self._tail_seam_mode:
-                log(
-                    f"loop {self.loop}: defining take — stop at bar, "
-                    f"seam overdub release at wrap"
-                )
+            self._tail_deferred = plan.tail_deferred
+            self._tail_stop_sent = True
+            if plan.commands:
                 for cmd in plan.commands:
                     self._hit(cmd)
-                self._tail_stop_sent = True
-                self._expect(STATE_PLAYING)
             elif self.sl_state in ACTIVE_RECORD:
-                log(
-                    f"loop {self.loop}: defining take — recording release "
-                    f"into loop until quiet"
-                )
-                self._tail_stop_sent = False
-                self._expect(STATE_RECORDING)
-            elif self.sl_state in (SL_STATE_PLAYING, SL_STATE_OFF_MUTED):
-                if self._on_prepare_scratch is not None:
-                    self._on_prepare_scratch(self.loop)
-                self._tail_stop_sent = True
-                self._expect(STATE_PLAYING)
-            else:
-                self._tail_stop_sent = False
+                self._hit("record")
+            if self._on_prepare_scratch is not None:
+                self._on_prepare_scratch(self.loop)
+            self._expect(STATE_PLAYING)
             if self._on_tail_capture_begin is not None:
                 self._on_tail_capture_begin(self.loop)
             self._sync_led()
             self._mark_action()
             log(
-                f"loop {self.loop}: -> {edge} done (tail capture, "
+                f"loop {self.loop}: -> {edge} done (stop-then-weld, "
                 f"state={self.state}, sl_state={self.sl_state})"
             )
             return

--- a/scripts/sooperlooper/led_table.py
+++ b/scripts/sooperlooper/led_table.py
@@ -75,7 +75,6 @@ def led_for(
     *,
     pending: str | None = None,
     tail_capture: bool = False,
-    tail_seam_weld: bool = False,
 ) -> tuple[int, ...]:
     """Pad colour, as a blink sequence. Length 1 means hold it steady.
 
@@ -87,12 +86,9 @@ def led_for(
     what let a poll clear the flag while the launch was still pending, leaving
     the pad blinking green forever after it had already landed.
     """
-    if tail_capture and tail_seam_weld:
-        # Option E: loop is Playing/Overdubbing while release is welded at the seam.
-        return (LED_YELLOW_BLINK,)
     if tail_capture:
-        # Tier 2: SL is still Recording while release is captured in-place.
-        return RECORD_TO_PLAY
+        # Stop-then-weld: loop length fixed; scratch tail + merge still running.
+        return (LED_YELLOW_BLINK,)
     if sl_state == SL_STATE_WAIT_STOP:
         return RECORD_TO_PLAY
     if sl_state == SL_STATE_WAIT_START:

--- a/scripts/sooperlooper/loop_model.py
+++ b/scripts/sooperlooper/loop_model.py
@@ -105,6 +105,8 @@ class Plan:
     queue_stop: bool = False
     begin_quantize_wait: bool = False
     begin_tail_capture: bool = False
+    # True when scratch tail waits for quantize boundary + PLAYING (grid clips).
+    tail_deferred: bool = False
     note: str = ""
 
 
@@ -117,7 +119,6 @@ def plan_gesture(
     is_defining: bool,
     quantized: bool,
     tail_capture_enabled: bool = False,
-    tail_seam_mode: bool = False,
 ) -> Plan:
     """The whole gesture vocabulary, split by which physical edge fired.
 
@@ -153,21 +154,13 @@ def plan_gesture(
             # recording, which is what a player tapping again means.
             return Plan(commands=("record",))
         if is_defining and tail_capture_enabled:
-            # Defining take: always tail-capture on stop, even when OSC lags and
-            # reports OffMuted (20) or WAIT_START instead of Recording (2).
-            # queue_stop here never fires — it waits for sl=2 and strands the
-            # pad on red blink forever (Pi log 2026-08-18).
-            if tail_seam_mode:
-                return Plan(
-                    begin_tail_capture=True,
-                    commands=("record",),
-                    expect=STATE_PLAYING,
-                    note="seam overdub — stop now, weld release at wrap",
-                )
+            # Defining take: stop immediately, then weld release at the wrap seam.
+            # Works even when OSC lags (OffMuted / WAIT_START) — never queue_stop.
             return Plan(
                 begin_tail_capture=True,
+                commands=("record",) if sl_state == SL_STATE_RECORDING else (),
                 expect=STATE_PLAYING,
-                note="tail capture — record release until quiet, then stop",
+                note="stop now — weld release at seam",
             )
         if sl_state != SL_STATE_RECORDING:
             # Armed, or asked-for-but-unconfirmed. Either way the engine may be
@@ -181,6 +174,19 @@ def plan_gesture(
                 note="stop queued — will record exactly one cycle",
             )
         wait = quantized and not is_defining
+        if tail_capture_enabled and grid_established and not is_defining:
+            return Plan(
+                commands=("record",),
+                expect=None if wait else STATE_PLAYING,
+                begin_quantize_wait=wait,
+                begin_tail_capture=True,
+                tail_deferred=wait,
+                note=(
+                    "stop at bar — weld release at seam"
+                    if wait
+                    else "stop — weld release at seam"
+                ),
+            )
         return Plan(
             commands=("record",),
             expect=None if wait else STATE_PLAYING,
@@ -216,7 +222,6 @@ def plan_tap(
     is_defining: bool,
     quantized: bool,
     tail_capture_enabled: bool = False,
-    tail_seam_mode: bool = False,
 ) -> Plan:
     """Legacy entry: both edges on release. Prefer plan_gesture in the bench."""
     down = plan_gesture(
@@ -227,7 +232,6 @@ def plan_tap(
         is_defining=is_defining,
         quantized=quantized,
         tail_capture_enabled=tail_capture_enabled,
-        tail_seam_mode=tail_seam_mode,
     )
     if down.commands or down.queue_stop or down.arm_grid or down.begin_tail_capture:
         return down
@@ -239,5 +243,4 @@ def plan_tap(
         is_defining=is_defining,
         quantized=quantized,
         tail_capture_enabled=tail_capture_enabled,
-        tail_seam_mode=tail_seam_mode,
     )

--- a/scripts/sooperlooper/sl_grid_sync.py
+++ b/scripts/sooperlooper/sl_grid_sync.py
@@ -25,17 +25,14 @@ DEFAULT_FADE_SAMPLES = int(os.environ.get("MPE_SL_FADE_SAMPLES", "256"))
 DEFAULT_BPM = float(os.environ.get("MPE_LOOPER_BPM", "120"))
 DEFAULT_CLOCK = os.environ.get("MPE_SL_GRID_CLOCK", "internal").strip().lower()
 
-# Tail capture on defining take close — looper-loop-seam-spec.md Tier 2 / Option E.
+# Stop-then-weld: pad fixes loop length; parallel scratch + offline merge at seam.
+# Tier 2 (extend recording until quiet) rejected 2026-08-19 — see DECISIONS.md.
 TAIL_CAPTURE_ENABLED = os.environ.get("MPE_SL_TAIL_CAPTURE", "1").strip().lower() not in (
     "0",
     "off",
     "false",
     "",
 )
-# extend = Tier 2 (grow clip 0 until release quiet) — default, ear-validated.
-# seam = Option E (fixed bar + seam overdub) — experimental; opt-in only.
-TAIL_MODE = os.environ.get("MPE_SL_TAIL_MODE", "extend").strip().lower()
-TAIL_SEAM_MODE = TAIL_MODE in ("seam", "e", "overdub", "option_e")
 TAIL_THRESH = float(os.environ.get("MPE_SL_TAIL_THRESH", "0.02"))
 TAIL_HOLD_S = float(os.environ.get("MPE_SL_TAIL_HOLD_MS", "80")) / 1000.0
 TAIL_MAX_S = float(os.environ.get("MPE_SL_TAIL_MAX_MS", "4000")) / 1000.0

--- a/scripts/sooperlooper/sl_seam_weld.py
+++ b/scripts/sooperlooper/sl_seam_weld.py
@@ -12,7 +12,7 @@ from seam_merge import merge_tail_at_seam
 
 SCRATCH_LOOP = int(os.environ.get("MPE_SL_SCRATCH_LOOP", "15"))
 SEAM_MERGE_SAMPLES = int(os.environ.get("MPE_SL_SEAM_MERGE_SAMPLES", "2048"))
-SEAM_WELD_ENABLED = os.environ.get("MPE_SL_SEAM_WELD", "0").strip().lower() not in (
+SEAM_WELD_ENABLED = os.environ.get("MPE_SL_SEAM_WELD", "1").strip().lower() not in (
     "",
     "0",
     "off",

--- a/tests/test_apc_bench.py
+++ b/tests/test_apc_bench.py
@@ -3,9 +3,10 @@
 import conftest  # noqa: F401 — bare sooperlooper imports (apc_grid, …)
 
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock
 
-from scripts.sooperlooper.apc_footswitch import apply_view, build_footswitches
+from scripts.sooperlooper.apc_footswitch import apply_view, build_footswitches, poll_footswitches
 from scripts.sooperlooper.apc_grid import GridView, pad_note
 
 
@@ -105,6 +106,21 @@ class ApcBenchFootswitchTests(unittest.TestCase):
         osc.reset_mock()
         took_over.on_pad_up()
         osc.send_message.assert_not_called()
+
+    def test_poll_footswitches_is_wired_in_bench_idle_loop(self) -> None:
+        """Tail capture must be polled from the live bench, not only in unit tests."""
+        source = (
+            Path(__file__).resolve().parent.parent / "scripts" / "sooperlooper-apc-bench.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("poll_footswitches(footswitches)", source)
+        self.assertNotIn("fs.poll_tail_capture()", source)
+
+    def test_poll_footswitches_delegates_to_tail_capture(self) -> None:
+        fs = MagicMock()
+        poll_footswitches([fs])
+        fs.poll_hold.assert_called_once()
+        fs.poll_led.assert_called_once()
+        fs.poll_tail_capture.assert_called_once()
 
 
 class ViewAgreementTests(unittest.TestCase):

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -66,21 +66,22 @@ class ApcFootswitchTests(unittest.TestCase):
         osc = MagicMock()
         fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
         fs.bind(osc, MagicMock(), 36)
-        fs.on_pad_down()
-        fs.on_pad_up()
-        fs.sync_from_sl(SL_STATE_RECORDING)
-        fs.on_pad_down()
-        fs.on_pad_up()  # stop-record -> waits for a boundary
-        fs.sync_from_sl(SL_STATE_WAIT_STOP)
-        self.assertTrue(fs.awaiting_quantize)
-        self.assertTrue(fs._waiting_for_quantize())
+        with patch.object(footswitch_mod, "TAIL_CAPTURE_ENABLED", False):
+            fs.on_pad_down()
+            fs.on_pad_up()
+            fs.sync_from_sl(SL_STATE_RECORDING)
+            fs.on_pad_down()
+            fs.on_pad_up()  # stop on pad down -> waits for a boundary
+            fs.sync_from_sl(SL_STATE_WAIT_STOP)
+            self.assertTrue(fs.awaiting_quantize)
+            self.assertTrue(fs._waiting_for_quantize())
 
-        fs._wait_since -= footswitch_mod.QUANTIZE_WAIT_TIMEOUT_S + 1.0
-        self.assertFalse(fs._waiting_for_quantize())
-        self.assertFalse(fs.awaiting_quantize)
+            fs._wait_since -= footswitch_mod.QUANTIZE_WAIT_TIMEOUT_S + 1.0
+            self.assertFalse(fs._waiting_for_quantize())
+            self.assertFalse(fs.awaiting_quantize)
 
-        fs.on_pad_down()
-        fs.on_pad_up()
+            fs.on_pad_down()
+            fs.on_pad_up()
         hits = [c.args[1] for c in osc.send_message.call_args_list if c.args[0] == "/sl/0/hit"]
         self.assertEqual(len(hits), 3)
 
@@ -286,6 +287,7 @@ class GridEstablishmentTests(unittest.TestCase):
         # be armed, where `record` lands as CANCEL.
         fs.sync_from_sl(SL_STATE_RECORDING)
         fs.on_pad_down()
+        fs.sync_from_sl(SL_STATE_WAIT_STOP)
         self.assertTrue(fs.awaiting_quantize, "quantized clip must wait for the bar")
         self.assertTrue(fs._tail_capture)
         self.assertTrue(fs._tail_deferred)

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -11,6 +11,7 @@ from scripts.sooperlooper.apc_footswitch import LoopFootswitch, build_footswitch
 from scripts.sooperlooper.sl_loop_states import (
     SL_STATE_MUTE,
     SL_STATE_OFF,
+    SL_STATE_OFF_MUTED,
     SL_STATE_PAUSED,
     SL_STATE_PLAYING,
     SL_STATE_RECORDING,
@@ -790,6 +791,19 @@ class StopAllIsImmediateTests(unittest.TestCase):
         hits = [v for path, v in sent if path == "/sl/-1/hit"]
         self.assertEqual(hits, ["mute_on", "pause_on"])
 
+    def test_stop_all_skips_pending_on_off_muted_empty_loops(self) -> None:
+        """Global mute leaves empties at sl=20; must not get pending=stopped."""
+        from scripts.sooperlooper.apc_footswitch import stop_all_loops
+        from scripts.sooperlooper.led_table import led_for
+
+        osc = MagicMock()
+        empty = LoopFootswitch(loop=1, hold_ms=1000.0, debounce_ms=0.0)
+        empty.bind(MagicMock(), MagicMock(), 37)
+        empty.sync_from_sl(SL_STATE_OFF_MUTED)
+        stop_all_loops(osc, num_loops=2, footswitches=[empty])
+        self.assertIsNone(empty._pending)
+        self.assertEqual(led_for(SL_STATE_OFF_MUTED), (0,))
+
     def test_per_clip_stop_is_still_quantized(self) -> None:
         """Only Stop All is immediate — a single pad stop still waits."""
         from scripts.sooperlooper.apc_footswitch import LoopFootswitch
@@ -800,6 +814,21 @@ class StopAllIsImmediateTests(unittest.TestCase):
         fs.on_pad_down(); fs.on_pad_up()
         paths = [c.args[0] for c in fs._osc.send_message.call_args_list]
         self.assertNotIn("/sl/1/set", paths, "must not touch mute_quantized")
+
+
+class PollFootswitchesTests(unittest.TestCase):
+    def test_poll_footswitches_runs_tail_capture(self) -> None:
+        from scripts.sooperlooper.apc_footswitch import poll_footswitches
+        from scripts.sooperlooper.sl_grid_sync import TAIL_MAX_S
+
+        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
+        fs.bind(MagicMock(), MagicMock(), 36)
+        fs._tail_capture = True
+        fs._tail_capture_since = time.monotonic() - TAIL_MAX_S - 0.01
+        fs.sync_from_sl(SL_STATE_RECORDING)
+        poll_footswitches([fs])
+        self.assertFalse(fs._tail_capture)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_apc_footswitch.py
+++ b/tests/test_apc_footswitch.py
@@ -108,13 +108,6 @@ class ApcFootswitchTests(unittest.TestCase):
 class GridEstablishmentTests(unittest.TestCase):
     """First take defines the tempo, then the grid stands alone."""
 
-    def setUp(self) -> None:
-        self._tail_mode_patch = patch.object(footswitch_mod, "TAIL_SEAM_MODE", False)
-        self._tail_mode_patch.start()
-
-    def tearDown(self) -> None:
-        self._tail_mode_patch.stop()
-
     def _fs(self, loop, grid, established_cb=None, reanchor_cb=None):
         from scripts.sooperlooper.apc_footswitch import LoopFootswitch
 
@@ -167,13 +160,13 @@ class GridEstablishmentTests(unittest.TestCase):
         seen = []
         grid = GridState()
         fs = self._fs(0, grid, lambda bpm, bars: seen.append((bpm, bars)))
+        self._wire_seam_hooks(fs)
 
         self._start_defining_take(fs)
         self.assertTrue(grid.is_pending(0))
         fs.on_pad_down()
-        fs.on_pad_up()  # tail capture — stay recording until release fades
         self.assertTrue(fs._tail_capture)
-        self.assertFalse(fs._tail_stop_sent)
+        self.assertTrue(fs._tail_stop_sent)
         self.assertFalse(fs.awaiting_quantize)
 
         hits = [
@@ -181,22 +174,16 @@ class GridEstablishmentTests(unittest.TestCase):
             for c in fs._osc.send_message.call_args_list
             if c.args[0] == "/sl/0/hit"
         ]
-        self.assertEqual(hits.count("record"), 1, "start only — stop waits for quiet tail")
+        self.assertEqual(hits, ["record", "record"], "start then immediate stop")
 
+        fs.sync_from_sl(SL_STATE_PLAYING)
+        fs.sync_loop_len(2.0)
+        fs.sync_loop_pos(0.0)
+        fs._maybe_start_scratch()
         fs.sync_in_peak(0.5)
         fs.sync_in_peak(0.0)
         fs._tail_silence_since = TAIL_HOLD_S * -2 + time.monotonic()
         fs.poll_tail_capture()
-        hits = [
-            c.args[1]
-            for c in fs._osc.send_message.call_args_list
-            if c.args[0] == "/sl/0/hit"
-        ]
-        self.assertEqual(hits.count("record"), 2, "record stop after release fades")
-
-        fs.sync_loop_len(2.0)
-        fs.sync_loop_pos(0.0)
-        fs.sync_from_sl(SL_STATE_PLAYING)
 
         self.assertTrue(grid.established)
         self.assertEqual(seen, [(120.0, 1)])
@@ -298,18 +285,13 @@ class GridEstablishmentTests(unittest.TestCase):
         # stop — tapping again before that arrives means the engine may still
         # be armed, where `record` lands as CANCEL.
         fs.sync_from_sl(SL_STATE_RECORDING)
-        fs.on_pad_down(); fs.on_pad_up()
+        fs.on_pad_down()
         self.assertTrue(fs.awaiting_quantize, "quantized clip must wait for the bar")
+        self.assertTrue(fs._tail_capture)
+        self.assertTrue(fs._tail_deferred)
 
 
 class TailCaptureTests(unittest.TestCase):
-    def setUp(self) -> None:
-        self._tail_mode_patch = patch.object(footswitch_mod, "TAIL_SEAM_MODE", False)
-        self._tail_mode_patch.start()
-
-    def tearDown(self) -> None:
-        self._tail_mode_patch.stop()
-
     def test_pad_down_during_tail_aborts_without_merge(self) -> None:
         fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=200.0)
         fs.bind(MagicMock(), MagicMock(), 36)
@@ -329,18 +311,15 @@ class TailCaptureTests(unittest.TestCase):
         self.assertFalse(fs._tail_capture)
         self.assertEqual(merged, [])
 
-    def test_tail_led_matches_wait_stop_pattern(self) -> None:
-        from scripts.sooperlooper.led_table import RECORD_TO_PLAY, LED_YELLOW_BLINK, led_for
+    def test_tail_led_amber_during_weld(self) -> None:
+        from scripts.sooperlooper.led_table import LED_YELLOW_BLINK, led_for
 
         fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
         fs.bind(MagicMock(), MagicMock(), 36)
-        fs.sync_from_sl(SL_STATE_RECORDING)
+        fs.sync_from_sl(SL_STATE_PLAYING)
         fs._tail_capture = True
-        self.assertEqual(fs._led_target(), RECORD_TO_PLAY)
-        self.assertEqual(led_for(SL_STATE_RECORDING, tail_capture=True), RECORD_TO_PLAY)
-        fs._tail_seam_mode = True
-        fs._tail_stop_sent = True
         self.assertEqual(fs._led_target(), (LED_YELLOW_BLINK,))
+        self.assertEqual(led_for(SL_STATE_PLAYING, tail_capture=True), (LED_YELLOW_BLINK,))
 
     def test_tail_max_timeout_closes_capture(self) -> None:
         from scripts.sooperlooper.sl_grid_sync import TAIL_MAX_S
@@ -385,7 +364,7 @@ class TailCaptureTests(unittest.TestCase):
                 if c.args[0] == "/sl/0/hit"]
         self.assertEqual(hits, [], "gesture after auto-close should be debounced")
 
-    def test_defining_stop_stays_recording_until_quiet(self) -> None:
+    def test_defining_stop_sends_immediate_record_stop(self) -> None:
         from scripts.sooperlooper.sl_grid_state import GridState
 
         grid = GridState()
@@ -395,34 +374,14 @@ class TailCaptureTests(unittest.TestCase):
         fs.on_pad_up()
         fs.sync_from_sl(SL_STATE_RECORDING)
         fs.on_pad_down()
-        fs.on_pad_up()
         hits = [
             c.args[1]
             for c in fs._osc.send_message.call_args_list
             if c.args[0] == "/sl/0/hit"
         ]
-        self.assertEqual(hits, ["record"], "no immediate stop — tail extends recording")
-        self.assertFalse(fs._tail_stop_sent)
+        self.assertEqual(hits, ["record", "record"], "stop on pad — length fixed now")
+        self.assertTrue(fs._tail_stop_sent)
         self.assertTrue(fs._tail_capture)
-
-    def test_tier2_tail_max_timeout_sends_stop(self) -> None:
-        from scripts.sooperlooper.sl_grid_sync import TAIL_MAX_S
-
-        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
-        fs.bind(MagicMock(), MagicMock(), 36)
-        fs._tail_capture = True
-        fs._tail_stop_sent = False
-        fs.sync_from_sl(SL_STATE_RECORDING)
-        fs._tail_capture_since = time.monotonic() - TAIL_MAX_S - 0.01
-        fs._in_peak_seen = False
-        fs.poll_tail_capture()
-        self.assertFalse(fs._tail_capture)
-        hits = [
-            c.args[1]
-            for c in fs._osc.send_message.call_args_list
-            if c.args[0] == "/sl/0/hit"
-        ]
-        self.assertEqual(hits, ["record"])
 
     def test_tail_max_timeout_without_peak_reading(self) -> None:
         from scripts.sooperlooper.sl_grid_sync import TAIL_MAX_S
@@ -556,86 +515,6 @@ class TailCaptureTests(unittest.TestCase):
         stop_all_loops(MagicMock(), num_loops=1, footswitches=[fs])
         self.assertFalse(fs._tail_capture)
         self.assertEqual(ended, [0])
-
-
-class SeamTailTests(unittest.TestCase):
-    """Option E — fixed bar + seam-position overdub."""
-
-    def setUp(self) -> None:
-        self._tail_mode_patch = patch.object(footswitch_mod, "TAIL_SEAM_MODE", True)
-        self._tail_mode_patch.start()
-
-    def tearDown(self) -> None:
-        self._tail_mode_patch.stop()
-
-    def test_defining_close_sends_immediate_stop(self) -> None:
-        from scripts.sooperlooper.sl_grid_state import GridState
-
-        grid = GridState()
-        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0, grid=grid)
-        fs.bind(MagicMock(), MagicMock(), 36)
-        fs.on_pad_down()
-        fs.on_pad_up()
-        fs.sync_from_sl(SL_STATE_RECORDING)
-        fs.on_pad_down()
-        fs.on_pad_up()
-        hits = [
-            c.args[1]
-            for c in fs._osc.send_message.call_args_list
-            if c.args[0] == "/sl/0/hit"
-        ]
-        self.assertEqual(hits, ["record", "record"], "start then immediate stop")
-        self.assertTrue(fs._tail_capture)
-        self.assertTrue(fs._tail_seam_mode)
-        self.assertTrue(fs._tail_stop_sent)
-
-    def test_seam_overdub_starts_in_seam_zone(self) -> None:
-        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
-        fs.bind(MagicMock(), MagicMock(), 36)
-        fs._tail_capture = True
-        fs._tail_seam_mode = True
-        fs._tail_stop_sent = True
-        fs._tail_capture_since = time.monotonic()
-        fs.sync_from_sl(SL_STATE_PLAYING)
-        fs.sync_loop_len(2.0)
-        fs.sync_loop_pos(1.75)
-        fs.poll_tail_capture()
-        hits = [
-            c.args[1]
-            for c in fs._osc.send_message.call_args_list
-            if c.args[0] == "/sl/0/hit"
-        ]
-        self.assertIn("overdub", hits)
-        self.assertTrue(fs._seam_overdub_active)
-
-    def test_seam_overdub_ends_at_wrap_after_quiet(self) -> None:
-        from scripts.sooperlooper.sl_grid_sync import TAIL_HOLD_S, TAIL_MIN_OVERDUB_S
-
-        fs = LoopFootswitch(loop=0, hold_ms=1000.0, debounce_ms=0.0)
-        fs.bind(MagicMock(), MagicMock(), 36)
-        fs._tail_capture = True
-        fs._tail_seam_mode = True
-        fs._tail_stop_sent = True
-        fs._tail_capture_since = time.monotonic()
-        fs.sync_from_sl(SL_STATE_PLAYING)
-        fs.sync_loop_len(2.0)
-        fs.sync_loop_pos(1.75)
-        fs._start_seam_overdub()
-        fs._seam_overdub_started_at = time.monotonic() - TAIL_MIN_OVERDUB_S - 0.01
-        fs._tail_saw_loud = True
-        fs._in_peak_seen = True
-        fs.sync_in_peak(0.0)
-        fs._tail_silence_since = TAIL_HOLD_S * -2 + time.monotonic()
-        fs.poll_tail_capture()
-        self.assertTrue(fs._tail_release_quiet)
-        fs.poll_tail_capture()
-        self.assertFalse(fs._tail_capture)
-        hits = [
-            c.args[1]
-            for c in fs._osc.send_message.call_args_list
-            if c.args[0] == "/sl/0/hit"
-        ]
-        self.assertEqual(hits.count("overdub"), 2, "on then off")
 
 
 class DoubleTapRecordsOneCycleTests(unittest.TestCase):

--- a/tests/test_footswitch_against_engine.py
+++ b/tests/test_footswitch_against_engine.py
@@ -64,12 +64,16 @@ class FootswitchOnEngineTests(unittest.TestCase):
         engine.poll(fs)
         self.assertEqual(self._led(midi), LED_RED)
 
-        self._tap(fs)                    # stop-record: queued to the bar
+        fs.on_pad_down()                 # stop on pad down; weld tail still running
         engine.poll(fs)
         self.assertNotEqual(self._led(midi), LED_GREEN,
                             "nothing has landed yet — green would be a lie")
 
-        engine.boundary()                # the take lands
+        engine.boundary()                # the take lands; weld still running
+        engine.poll(fs)
+        self.assertNotEqual(self._led(midi), LED_GREEN,
+                            "stop-then-weld: amber until the tail merge finishes")
+        fs._finish_tail_capture("test")
         engine.poll(fs)
         self.assertEqual(self._led(midi), LED_GREEN)
         self.assertEqual(engine.state[0], SL_STATE_PLAYING)

--- a/tests/test_loop_model.py
+++ b/tests/test_loop_model.py
@@ -126,28 +126,30 @@ class PlanTapTests(unittest.TestCase):
         self.assertFalse(p.begin_quantize_wait)
         self.assertEqual(p.expect, STATE_PLAYING)
 
-    def test_defining_take_stop_uses_tail_capture_when_enabled(self) -> None:
+    def test_defining_take_stop_uses_stop_then_weld_when_enabled(self) -> None:
         p = self._gesture(
             "down",
             SL_STATE_RECORDING,
             is_defining=True,
             tail_capture_enabled=True,
-            tail_seam_mode=False,
-        )
-        self.assertTrue(p.begin_tail_capture)
-        self.assertEqual(p.commands, ())
-
-    def test_defining_take_seam_mode_stops_immediately(self) -> None:
-        p = self._gesture(
-            "down",
-            SL_STATE_RECORDING,
-            is_defining=True,
-            tail_capture_enabled=True,
-            tail_seam_mode=True,
         )
         self.assertTrue(p.begin_tail_capture)
         self.assertEqual(p.commands, ("record",))
         self.assertEqual(p.expect, STATE_PLAYING)
+        self.assertFalse(p.tail_deferred)
+
+    def test_grid_clip_stop_arms_deferred_tail_weld(self) -> None:
+        p = self._gesture(
+            "down",
+            SL_STATE_RECORDING,
+            grid_established=True,
+            is_defining=False,
+            tail_capture_enabled=True,
+        )
+        self.assertTrue(p.begin_tail_capture)
+        self.assertTrue(p.begin_quantize_wait)
+        self.assertTrue(p.tail_deferred)
+        self.assertEqual(p.commands, ("record",))
 
     def test_defining_take_stop_off_muted_enters_tail_not_queue_stop(self) -> None:
         """Pi reported sl=20 (OffMuted) while pending=recording — was queue_stop deadlock."""
@@ -209,10 +211,12 @@ class LedTableTests(unittest.TestCase):
     def test_queued_to_record_is_ableton_standard(self) -> None:
         self.assertEqual(led_for(SL_STATE_WAIT_START), (LED_RED_BLINK,))
 
-    def test_tail_capture_led_matches_wait_stop(self) -> None:
+    def test_tail_capture_led_is_amber_while_weld_pending(self) -> None:
+        from scripts.sooperlooper.led_table import LED_YELLOW_BLINK
+
         self.assertEqual(
-            led_for(SL_STATE_RECORDING, tail_capture=True),
-            RECORD_TO_PLAY,
+            led_for(SL_STATE_PLAYING, tail_capture=True),
+            (LED_YELLOW_BLINK,),
         )
 
     def test_recording_queued_to_play_shows_both_colours(self) -> None:


### PR DESCRIPTION
## Summary
- **Stop-then-weld** replaces Tier 2 extend-recording and Option E seam overdub for defining + grid clips
- Immediate `record` stop on pad; parallel scratch loop 15 + offline merge at wrap
- Poll tail capture from bench idle loop; Stop All OFF_MUTED fix; reset LED transition
- `MPE_SL_SEAM_WELD=1` default; docs/spec/DECISIONS updated

## Test plan
- [x] `mpe test looper` — 39 tests pass
- [ ] Pi ear test after deploy (Mitch)

Made with [Cursor](https://cursor.com)