### PR TITLE
fix: cyclictest wrapper reported success on failure, then failure on success

### DIFF
--- a/Documents/specs/low-latency-512-256-spec.md
+++ b/Documents/specs/low-latency-512-256-spec.md
@@ -129,8 +129,11 @@ records per run:
 Also land `cyclictest` as a hardware floor:
 
 ```sh
-cyclictest -m -t1 -p 80 -n -i 200 -l 300000
+cyclictest -m -t1 -p 80 -i 200 -l 300000
 ```
+
+(`-n` was removed in rt-tests 2.6 — `clock_nanosleep` is now the default and `-x` opts out
+to POSIX timers. Passing it makes cyclictest print usage and exit non-zero.)
 
 Worst-case wakeup latency bounds everything. If it is 3 ms, then 256 frames (5.3 ms
 period) is arithmetically impossible on this kernel and Step 5 becomes mandatory rather

--- a/scripts/measure-cyclictest-floor.sh
+++ b/scripts/measure-cyclictest-floor.sh
@@ -55,13 +55,18 @@ fi
 
 # A real run reports per-thread "T: 0 (...) P:80 ... Min: N Act: N Avg: N Max: N".
 # Usage text, a permissions failure, or a truncated run will not match.
-if ! printf '%s' "$RAW" | grep -qE 'Min:[[:space:]]*[0-9]+.*Max:[[:space:]]*[0-9]+'; then
+# NOTE: a here-string, not `printf ... | grep -q`. With pipefail set, grep -q exits on
+# the first match, the writer takes SIGPIPE (141), and pipefail reports that as the
+# pipeline's status -- so a SUCCESSFUL match reads as failure. It only bites once the
+# output is big enough that the writer has not finished first: a 44 KB run passed, the
+# real 875 KB run did not.
+if ! grep -qE 'Min:[[:space:]]*[0-9]+.*Max:[[:space:]]*[0-9]+' <<<"$RAW"; then
     echo "ERROR: cyclictest produced no Min/Max latency line — nothing logged" >&2
     printf '%s\n' "$RAW" | head -5 >&2
     exit 1
 fi
 
-MAXUS="$(printf '%s' "$RAW" | grep -oE 'Max:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1)"
+MAXUS="$(grep -oE 'Max:[[:space:]]*[0-9]+' <<<"$RAW" | grep -oE '[0-9]+' | sort -n | tail -1)"
 
 {
     echo "=== cyclictest floor label=${LABEL} $(date -Is) ==="

--- a/scripts/measure-cyclictest-floor.sh
+++ b/scripts/measure-cyclictest-floor.sh
@@ -8,7 +8,10 @@
 #   ./scripts/measure-cyclictest-floor.sh [--output FILE] [--label TAG]
 #
 # Default command (from spec):
-#   cyclictest -m -t1 -p 80 -n -i 200 -l 300000
+#   cyclictest -m -t1 -p 80 -i 200 -l 300000
+#
+# NOTE: rt-tests 2.6 removed -n (clock_nanosleep is the default; -x opts out to
+# POSIX timers). Passing -n makes cyclictest print usage and exit non-zero.
 
 set -uo pipefail
 
@@ -36,6 +39,30 @@ if ! command -v cyclictest >/dev/null 2>&1; then
     exit 1
 fi
 
+# Run FIRST, validate, and only then append. A previous version piped cyclictest
+# straight into the log: when -n became invalid in rt-tests 2.6, it wrote the
+# tool's usage text into the measurement file, printed a success message and
+# exited 0. Per docs/measurements/README.md, a reading must not look the same
+# broken or fine.
+RAW="$(cyclictest -m -t1 -p 80 -i 200 -l 300000 2>&1)"
+RC=$?
+
+if [ "$RC" -ne 0 ]; then
+    echo "ERROR: cyclictest exited $RC — nothing logged" >&2
+    printf '%s\n' "$RAW" | head -5 >&2
+    exit 1
+fi
+
+# A real run reports per-thread "T: 0 (...) P:80 ... Min: N Act: N Avg: N Max: N".
+# Usage text, a permissions failure, or a truncated run will not match.
+if ! printf '%s' "$RAW" | grep -qE 'Min:[[:space:]]*[0-9]+.*Max:[[:space:]]*[0-9]+'; then
+    echo "ERROR: cyclictest produced no Min/Max latency line — nothing logged" >&2
+    printf '%s\n' "$RAW" | head -5 >&2
+    exit 1
+fi
+
+MAXUS="$(printf '%s' "$RAW" | grep -oE 'Max:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1)"
+
 {
     echo "=== cyclictest floor label=${LABEL} $(date -Is) ==="
     echo "SENTINEL cyclictest-start"
@@ -46,10 +73,11 @@ fi
     uname -r
     tr '\0' ' ' < /proc/cmdline 2>/dev/null || true
     echo
-    cyclictest -m -t1 -p 80 -n -i 200 -l 300000
+    printf '%s\n' "$RAW"
+    echo "WORST_CASE_USEC=${MAXUS}"
     echo "SENTINEL cyclictest-end"
     echo
 } >>"$OUTPUT"
 
-echo "Appended cyclictest floor to $OUTPUT"
+echo "Appended cyclictest floor to $OUTPUT (worst case ${MAXUS} us)"
 echo "SENTINEL cyclictest-logged"


### PR DESCRIPTION
Two bugs in `measure-cyclictest-floor.sh`, found while taking the Step 0 floor measurement.

## 1. Reported success on total failure

`rt-tests` 2.6 removed `-n` (`clock_nanosleep` is now the default; `-x` opts out to POSIX timers), so the spec's command made cyclictest print usage and exit non-zero. The wrapper piped it straight into the log inside a `{ }` block, so it wrote the tool's **help text** into `~/latency-cyclictest.log`, printed "Appended cyclictest floor", emitted its success sentinel, and exited 0.

That is precisely what `docs/measurements/README.md` exists to prevent: a reading that looks the same broken or fine. The poisoned log was indistinguishable from a real measurement.

Now runs cyclictest first, checks the exit code, and requires a `Min:`/`Max:` line before writing anything. Either check failing exits 1 and logs nothing.

## 2. Then rejected valid output

The guard used `printf '%s' "$RAW" | grep -qE ...`. `grep -q` exits on first match, the writer takes SIGPIPE (141), and `set -o pipefail` propagates that as the pipeline status — so a **successful match read as failure**.

Length-dependent, which is why it survived testing: a 44 KB (15k-loop) run passed because `printf` finished before `grep` bailed; the real 875 KB (300k-loop) run failed every time. Both checks now use here-strings.

`measure-latency-run.sh` audited for the same pattern — its three `grep -q` calls all read from files, so they are unaffected.

## Result

Floor recorded on the stock kernel, idle:

```
C: 300000  Min: 3  Avg: 5  Max: 209        WORST_CASE_USEC=209
```

Across runs the worst case was 291 µs. A 256-frame period is 5,333 µs, so scheduler wakeup latency is ~5% of the budget — **256 is not blocked by jitter on the stock kernel**, which weakens the case for Step 6 (PREEMPT_RT). Needs a re-take under audio load before being relied on.

Also adds `WORST_CASE_USEC=` to the log so the gating number is greppable, and corrects the command in the spec.