### PR TITLE
docs: status, the fork-loop pattern, and a ranked experiment plan

### DIFF
--- a/Documents/specs/low-latency-512-256-spec.md
+++ b/Documents/specs/low-latency-512-256-spec.md
@@ -326,3 +326,130 @@ measurement in this document addresses.
   line without checking and it was false.
 - `Documents/specs/session-control-plane-spec.md` updated if the default buffer size
   changes.
+
+---
+
+# Status and experiment plan — 2026-08-20
+
+## Where the appliance is
+
+**Shipped and verified.** `irqaffinity=0,1` on the kernel cmdline; `CPUAffinity=2 3` on
+`mpe-jackd`, `surge-xt-cli`, `mpe-sooperlooper`. Survives reboot; no helper loop. All
+three processes confirmed on cores 2-3 after a cold boot.
+
+**Measured at 512x3, n=15 per condition, xruns per 60 s:**
+
+| condition | before any of this | now | clean runs |
+|---|---:|---:|---|
+| A — synth only | 4.20 | **0.13** | 14/15 |
+| B — + sooperlooper | — | 2.27 | 2/15 |
+| C — + session (post journal fix) | 4.20 | **2.53** | 1/15 |
+| D — + watchdog (post reboot) | 10.00 | **5.40** | 0/15 |
+
+**512 is usable without the looper and not shippable with it.** 1024 remains the default.
+
+## What has actually been fixed, and the pattern
+
+Three causes found so far, each hidden behind the one before it:
+
+1. **Interrupt pile-up on CPU0.** GICv2 targets the lowest core in each IRQ's mask and
+   nothing had ever moved them. Fixed by cmdline + `CPUAffinity`. A: 4.20 -> 0.13.
+2. **The session forking `journalctl` twice a second** to count xruns for the HUD.
+   Fixed in `221cd39`. C: 4.20 -> 2.53, and the burst signature vanished (sd 3.47 -> 1.55).
+3. **`sl-watchdog` forking on a 10 s loop** — found 2026-08-20, **not yet fixed**.
+
+**The pattern is the finding.** Every fix makes the next layer visible, and every layer so
+far has been the same bug: a fork in a periodic loop. The ladder measured the watchdog at
++0.33 ("negligible") while the session's fork was still making everything noisy; with that
+gone, the watchdog is +2.87 and the burst signature is back (D sd 3.5, max 14).
+
+Do not trust a small ladder step measured while a noisier layer is still present.
+
+## Open cause: sl-watchdog's fork loop
+
+`scripts/sooperlooper/sl-watchdog.py`, `INTERVAL_S = 10`, forks per cycle:
+
+- `jack_lsp -c` — **registers and unregisters a JACK client, forcing two graph reorders**
+- a second `subprocess.run`
+- `pgrep -x sooperlooper` and `pgrep -f src/sooperlooper`
+- conditionally `bash <script> connect`
+
+Six cycles per 60 s run. This is the same probe previously identified as the real xrun
+source at 35/min (`docs/measurements/crackle-root-cause-2026-08-18.md`), and the same
+doctrine violation as causes 2 and 3: **no forks in periodic loops on the appliance**
+(`Documents/DECISIONS.md`).
+
+**Do not chase "does sooperlooper process all sixteen loops every period" yet.** Condition
+B is sooperlooper with *zero loops recorded*, so its +2.13 cannot be per-loop work, and
+DSP does not move between conditions. The likelier explanations are (a) crowding — three
+audio processes shoehorned onto two cores by our own `CPUAffinity` — and (b) the fixed
+cost of one more client in JACK's serial process chain. E1 below distinguishes them for
+the price of one reboot.
+
+## Audio device — measured constraints
+
+```
+Sound Blaster Play! 3   12M (full speed)   Endpoint 0x01 OUT (ADAPTIVE)
+APC MINI                12M (full speed)   same internal hub
+```
+
+- **Full speed = 1 ms USB frames**, against 125 us microframes on a high-speed device.
+  At 256 frames (5.33 ms) that is ~5 USB frames per audio period. Near the floor of what
+  the transport can express, and set by the dongle, not the Pi.
+- **ADAPTIVE sync**: no feedback endpoint. The device slaves to whatever rate the host
+  delivers and absorbs clock drift internally. Every serious interface is asynchronous.
+- **The APC shares the bus.** Both are full-speed behind the same internal hub. **This
+  cannot be separated on a Pi 4** — all four ports feed one USB 2 hub, and Bus 002 carries
+  only SuperSpeed. Do not spend an experiment on port arrangement.
+
+**`nrpacks` is not available and needs no experiment.** It was removed from
+`snd-usb-audio` around kernel 5.17 and replaced by `lowlatency`, which is already `Y`.
+
+**256 is unlikely on this device** regardless of software. If the audio interface changes,
+every measurement above must be retaken — so make that decision before tuning further.
+
+An I2S **codec** HAT (not a bare DAC — the Sound Blaster carries the mic in as well as aux
+out) removes the host controller entirely and is cheaper than a USB interface.
+
+## Experiment plan, ranked by information per unit of cost
+
+### E1 — three cores instead of two. **Do first.**
+
+Our own `CPUAffinity=2 3` puts `jackd`, `surge-xt-cli` and `sooperlooper` on two cores.
+Two processes on two cores was comfortable; three may simply be crowding — which would
+mean sooperlooper's +2.13 is our configuration, not its code.
+
+`irqaffinity=0` on the cmdline, audio pinned to cores 1-3. Measure A and D, n=15, 512.
+
+If the gap collapses, 512 ships with the looper on. One line, one reboot, one hour.
+Needs Mitch for the reboot.
+
+### E2 — fix the sl-watchdog fork loop, then re-measure D.
+
+Same fix shape as `221cd39`: persistent readers instead of per-cycle forks, and nothing
+that registers a JACK client on a timer. Expect D to fall toward C. Needs no reboot.
+
+### E3 — the loop-count curve. **Highest product value.**
+
+0, 4, 8, 16 loops recorded and playing, at 512 and 1024. **Every measurement in this
+entire investigation has used an idle looper**; the instrument under real use is
+unmeasured. Answers directly whether a latency/loop-count tier is a real spec or whether
+there is one number. Needs no reboot.
+
+### E4 — long soak, 512 condition A.
+
+0.13/min is one event every ~8 minutes, so 15 one-minute runs cannot distinguish it from
+zero. One 8 h unattended run turns "very good" into a number that can go on a spec sheet.
+
+### E5 — the audio-device decision.
+
+A choice, not an experiment, but it gates 256 and invalidates every number above.
+
+### Dropped
+
+- **Step 3** (`threadirqs` + RT priority on `irq/30`) and **Step 4** (full core isolation):
+  they target scheduler jitter, and the audio thread has **91% margin at its worst
+  recorded moment** (max period deviation 917 us against a 10,667 us period).
+- **Step 6 (PREEMPT_RT):** dead. Floor is 209-320 us against 5,333 us at 256.
+- **USB port rearrangement:** impossible on Pi 4, see above.
+- **`nrpacks`:** does not exist on this kernel.

--- a/docs/STORAGE-ROBUSTNESS.md
+++ b/docs/STORAGE-ROBUSTNESS.md
@@ -1,0 +1,199 @@
+# Storage robustness — consumer product design
+
+**Purpose:** define how MPE survives sudden power loss without SD corruption becoming a bricking event. This is the product-side complement to [`RESTORE.md`](RESTORE.md) (manual rebuild) and [`SHUTDOWN.md`](SHUTDOWN.md) (graceful shutdown).
+
+*Last updated: 2026-08-20 (America/Toronto)*
+
+> **Status: design — not implemented.** The live appliance still runs a full mutable Raspberry Pi OS on ext4. Atomic write helpers and tmpfs runtime state exist; immutable OS, A/B slots, and a dedicated state partition do not.
+
+---
+
+## Problem
+
+Removable SD + ext4 + sudden power cut can corrupt metadata or leave half-written files. On a general-purpose Linux desktop that is annoying. On a consumer instrument it is unacceptable if the outcome is:
+
+- will not boot
+- black panel with no recovery path
+- requires Mitch (or a laptop) to fix
+
+The card is inherently corruptible. The product requirement is that corruption is **non-fatal**.
+
+---
+
+## Requirement reframe
+
+| Outcome | Acceptable? |
+|---------|-------------|
+| Power cut during play → reboot → sound in under a minute | ✅ |
+| Lose the loop currently recording | ✅ (expected) |
+| Revert one prefs file to last good snapshot | ✅ |
+| Touch calibration lost unless backed up | ⚠️ painful but bootable |
+| OS root or home tree corrupted → no boot | ❌ |
+
+**Design goal:** power loss may lose **in-flight work**; it must not lose **bootability**.
+
+This aligns with Decision C in [`racknerd-pi-access-spec.md`](racknerd-pi-access-spec.md): the appliance can be treated as expendable only if recovery is fast and proven. That spec also names **immutable-release architecture** (build → artifact → atomic activation) as the work that retires the current restore-gap table.
+
+---
+
+## Current state (2026-08-20)
+
+### Already mitigates single-file tears
+
+| Mechanism | Where | Effect |
+|-----------|-------|--------|
+| Runtime engine/HUD state on **tmpfs** | `/run/mpe` (`RuntimeDirectoryPreserve=yes` on units) | Power loss clears volatile state; does not corrupt root |
+| Atomic KEY=value writes | `mpe_state_write_atomic()` in `scripts/lib/audio-engine.sh` | Partial engine state files unlikely |
+| Atomic JSON writes + fsync | `patch_browser/json_store.py` | Favorites, normalization, pressure maps resist truncate-on-write |
+| Bounded shutdown + external splash | [`SHUTDOWN.md`](SHUTDOWN.md) | Graceful path reduces dirty unmount; does not help cable-yank |
+| Corrupt Surge defaults backup | `scripts/surge-watchdog.sh` | Falls back instead of SEGV on bad XML |
+
+### Still exposed on power cut
+
+| Risk | Why it hurts |
+|------|--------------|
+| **Full mutable root** | systemd journal, `/var`, apt, logs write constantly during play |
+| **User state in `$HOME`** | `~/.patch_browser_*.json`, `~/.local/share/Surge XT/`, calibration logs |
+| **Looper WAV capture** | Large, long-duration writes mid-record are the worst case for half-written files |
+| **Restore unrehearsed** | [`RESTORE.md`](RESTORE.md) has never been executed end to end — "expendable SD" is still asserted |
+
+---
+
+## Consumer stack — four layers
+
+### Layer 1 — Stop writing the OS during normal play
+
+**Read-only root** is the largest software lever. Standard embedded Linux layout:
+
+| Partition | Mount at runtime | Contents |
+|-----------|------------------|----------|
+| **system A** (and **B**) | read-only | Kernel, units, application, Surge binary, patch library (immutable image) |
+| **state** | read-write, small | User prefs, calibration, optional session exports only |
+| **overlay / volatile** | tmpfs | `/var/log`, `/tmp`, disposable caches |
+
+Boot succeeds because the OS image is not mid-write. Power cut may lose today's log line; it should not tear ext4 on `/`.
+
+Pi paths: `overlayroot` / raspi-config read-only overlay, custom image, or Buildroot/Yocto for full control.
+
+### Layer 2 — A/B firmware slots
+
+Two identical system partitions. Updates write the **inactive** slot, verify checksum or signature, flip bootloader preference, reboot. If fsck fails on slot A, boot slot B automatically.
+
+Same shape as the immutable-release pipeline already referenced in the racknerd spec: CI builds a signed artifact; activation is atomic; rollback is "boot the other slot."
+
+### Layer 3 — User data contract
+
+Classify writes by preciousness:
+
+| Data | Power-cut behaviour | Strategy |
+|------|---------------------|----------|
+| Engine/HUD snapshot | Gone | tmpfs — correct (`/run/mpe`) |
+| Favorites, normalization, pressure | One file may revert | Atomic JSON (done) + rolling `.bak` or append-only journal |
+| Touch calibration | Device-specific loss | Live under `/state`; export-to-USB path; version in backup repo |
+| Looper clip in progress | Lost take | Expected — do not fsync multi-MB WAV continuously; **commit on stop** (aligns with stop-then-weld) |
+| Surge user defaults | Can crash loader if corrupt | Factory read-only fallback + watchdog backup (partial today) |
+
+**Rule:** never truncate the only copy. Atomic rename protects one file; add a second generation for anything a customer would care about.
+
+### Layer 4 — Hardware (production BOM)
+
+Software cannot fully eliminate hard power loss on a rw state partition.
+
+| Option | Role |
+|--------|------|
+| **Hold-up power** | Supercap or small battery on PMIC power-fail: ~0.5–2 s to `sync`, stop services, unmount `/state` |
+| **eMMC / CM module** | Fewer connector failures than consumer microSD; better for gig vibration |
+| **Graceful shutdown UX** | Required courtesy, not sufficient alone — see [`SHUTDOWN.md`](SHUTDOWN.md), [`POWER_BUTTON_SETUP.md`](POWER_BUTTON_SETUP.md) |
+
+---
+
+## Recommended path for MPE
+
+Phased so bench/dev can continue on mutable SD until Phase 1 is ready to bake.
+
+### Phase 1 — "Won't brick" (software, no BOM change)
+
+1. **Immutable OS image from CI** — squashfs or ro root + tmpfs overlay for `/var`.
+2. **Dedicated `/state` partition** — symlink or bind-mount all precious `$HOME` state:
+   - `~/.patch_browser_*.json`
+   - `~/.local/share/Surge XT/`
+   - `~/surge-cli-calibration.log`, `~/.patch_browser_calibration_backups`
+3. **Volatile or redirected journal** during performance (`Storage=volatile` or tmpfs logs; persist only for support captures).
+4. **Boot health gate** — fsck `/state`; on failure mount empty factory tree or restore last `.bak`; **still boot to sound**.
+5. **Rehearse restore** — fill the rehearsal log in [`RESTORE.md`](RESTORE.md); until then treat expendable-SD as a hypothesis.
+
+### Phase 2 — "Updates don't kill it"
+
+6. **A/B system slots** + signed image + `mpe update` writing inactive slot then rebooting.
+7. **Factory reset** — flash known-good slot + wipe `/state` (optional USB export first).
+
+### Phase 3 — "Hardware-grade" (production units)
+
+8. Hold-up on 5 V input, or **CM4/eMMC** (or Pi 5 + industrial NVMe) for shipping BOM.
+9. Looper scratch on **tmpfs or RAM disk** during record; flush to `/state` only on **stop**.
+
+---
+
+## What not to rely on
+
+| Approach | Why insufficient |
+|----------|------------------|
+| Constant `sync` | Does not help between sync and unmount; adds latency spikes on an RT audio box |
+| "Users must shut down properly" | Necessary UX, not a safety property |
+| ext4 journaling alone | Helps metadata; does not save half-written large files or a corrupted writable `/` |
+| Backup-only ([`BACKUP_GUIDE.md`](BACKUP_GUIDE.md)) | Laptop-side backup does not fix a bricked appliance in the customer's room |
+
+---
+
+## Mapping to existing paths
+
+When `/state` lands, these move off the mutable root (today scattered under `/home/mitch`):
+
+| Today | File / directory |
+|-------|------------------|
+| Patch browser prefs | `~/.patch_browser_favorites.json`, `~/.patch_browser_normalization.json`, `~/.patch_browser_pressure.json`, `~/.patch_browser_ui.json`, `~/.patch_browser_last_patch.json` |
+| Looper HUD / clock | `~/.mpe_sl_hud_state.json`, `~/.mpe_midi_clock_state.json` |
+| Surge | `~/.local/share/Surge XT/SurgeXTUserDefaults.xml` |
+| Calibration | `~/surge-cli-calibration.log`, `~/.patch_browser_calibration_backups/` |
+| Appliance config | `/etc/mpe/mpe.env` (may stay separate or join `/state` — TBD) |
+
+Runtime-only (stay tmpfs — already correct):
+
+| Path | Notes |
+|------|-------|
+| `/run/mpe/*` | Engine, jack, surge, snapshot, maintenance flag |
+| Looper record scratch (Phase 3) | SooperLooper WAVs during capture — candidate for tmpfs until stop |
+
+---
+
+## Open questions
+
+1. **Image builder** — overlayroot on stock Pi OS vs custom image vs Buildroot (cost vs control).
+2. **`/etc/mpe/mpe.env`** — part of immutable image with overrides in `/state`, or fully in `/state`?
+3. **MPE-Library** — bake into ro system partition vs mount read-only from second partition?
+4. **Update channel** — USB stick vs network (Tailscale already on bench units; customer policy TBD).
+5. **Acceptance test** — scripted "yank power during X" matrix (idle, recording loop, writing favorites, OTA write).
+
+---
+
+## Related docs
+
+| Doc | Relationship |
+|-----|--------------|
+| [`RESTORE.md`](RESTORE.md) | Manual rebuild from blank SD — must stay valid; Phase 1 rehearsal is a gate |
+| [`SHUTDOWN.md`](SHUTDOWN.md) | Graceful shutdown — reduces but does not replace ro root |
+| [`PI-BOOT-RECOVERY.md`](PI-BOOT-RECOVERY.md) | Cmdline/config rollback when kernel still boots |
+| [`BACKUP_GUIDE.md`](BACKUP_GUIDE.md) | Developer/laptop backup — not customer-facing recovery |
+| [`racknerd-pi-access-spec.md`](racknerd-pi-access-spec.md) | Decision C + immutable-release callout |
+| [`Documents/specs/session-control-plane-spec.md`](../Documents/specs/session-control-plane-spec.md) | D6 — `/run/mpe` tmpfs snapshot design |
+| [`Documents/DECISIONS.md`](../Documents/DECISIONS.md) | Locked engineering decisions |
+
+---
+
+## Summary
+
+Consumer-grade MPE storage:
+
+> **Immutable OS (A/B) + small rw state partition + tmpfs for ephemeral + atomic writes for prefs + hold-up or eMMC on production hardware.**
+
+RT audio discipline (atomic writes, tmpfs runtime state) is largely in place. The product gap is **storage topology** — stop using the SD as a general-purpose Linux workstation — and **proven automatic recovery** (rehearsed restore, fallback boot).

--- a/docs/measurements/postjournal-512-C-2026-08-20.md
+++ b/docs/measurements/postjournal-512-C-2026-08-20.md
@@ -53,21 +53,33 @@ is not quoted while measuring a known bug.
 
 ---
 
-## Post-reboot — affinity persistence + D @ n=15 (2026-08-20)
+## Post-E2 — watchdog meter probe + D @ n=15 (2026-08-20)
 
-**Reboot test passed:** `irqaffinity=0,1` in cmdline; `CPUAffinity=2-3` on
-`mpe-jackd`, `surge-xt-cli`, `mpe-sooperlooper`; live `taskset` on jackd/surge
-**2,3**; no `repin-audio` loop.
+**Fix (commit `d203089`):** `sl-watchdog.py` reads `looper_client=` / `looper_playback=`
+from `/run/mpe/meter.state` (5 Hz, no fork). `mpe-peak-meter` publishes those fields.
+`jack_lsp` is fallback only when the meter is off or stale. `engine_running()` scans
+`/proc/*/comm` instead of `pgrep`.
 
-Log: `~/latency-postreboot-512-D.log`
+Log: `~/latency-measure.log` (harness) · per-run probes `/tmp/latency-D-run*-178725*.xruns`
 
 | run | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 |
 |---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| xruns | 5 | 9 | 3 | 7 | 5 | 7 | 1 | 3 | 1 | 14 | 3 | 5 | 6 | 3 | 9 |
+| xruns | 3 | **0** | 3 | 2 | 6 | 6 | **0** | 1 | 4 | 1 | 7 | **0** | 5 | 6 | 3 |
 
-**Mean 5.4** · sd ~3.5 · **0/15 clean** · max 14.
+**Mean 3.13** · sd ~2.4 · **3/15 clean** · max 7.
 
-This run is **contaminated by the watchdog fork loop** (see above) — not the merge-candidate
-full-stack number. Still ~half pre-fix ladder D (10.0).
+### vs post-reboot D (watchdog fork loop, same affinity)
+
+| | mean | max | clean |
+|---|---:|---:|---:|
+| post-reboot (pre-E2) | 5.4 | 14 | 0/15 |
+| post-E2 watchdog fix | **3.13** | **7** | 3/15 |
+
+Watchdog layer cost drops from implied **+2.87** (5.4 − 2.53) to **+0.60** (3.13 − 2.53).
+Burst tail largely gone (max 14→7). **E2 merge gate cleared** — D is no longer measuring a
+known periodic fork in the watchdog.
+
+512×3 exit criterion (0 xruns × 5×60 s in D) still not met; next steps per spec: **E1**
+(three cores), **E3** (loop-count curve).
 
 *Last updated: 2026-08-20 (America/Toronto)*

--- a/docs/measurements/postjournal-512-C-2026-08-20.md
+++ b/docs/measurements/postjournal-512-C-2026-08-20.md
@@ -35,11 +35,21 @@ burst source.
 | sooperlooper (A→B) | +2.13 (t≈4.7) | +2.13 — unchanged |
 | session (B→C) | +1.93 (t≈2.0) | **+0.27 (t≈0.45)** — not distinguishable from zero |
 
-Session contribution collapsed; **remaining gap at 512 is sooperlooper** (+2.13, steady,
-not bursty). Next suspect: SL processing all eight loops every period regardless of
-recording state.
+Session contribution collapsed. **Do not merge on D yet** — the post-reboot D number
+(5.4) does not reconcile with C (2.53): implied watchdog step is +2.87, not the ladder's
++0.33. Burst signature returned (sd 1.55→3.5, max 6→14) — same shape as the session fork.
 
-512 exit criterion (D = 0×n) unchanged.
+**Finding:** `sl-watchdog.py` forks ~4 subprocesses per 10 s cycle, including `jack_lsp -c`
+(two graph reorders per call). ~6 cycles per 60 s run. Same doctrine violation as session
+`journalctl` and the old `jack_lsp` probe (35/min). Ladder called watchdog "negligible"
+while session noise drowned it — see spec § ladder warning.
+
+**Remaining after E2 (watchdog fix):** sooperlooper +2.13 (A→B, zero loops recorded — not
+per-loop work). E1 (three cores) separates crowding vs serial-chain cost. Hold off on
+eight-loop hypothesis until E2 clears the watchdog layer.
+
+512 exit criterion (D = 0×n) unchanged. **Merge `feat/audio-core-affinity` after E2** so D
+is not quoted while measuring a known bug.
 
 ---
 
@@ -57,10 +67,7 @@ Log: `~/latency-postreboot-512-D.log`
 
 **Mean 5.4** · sd ~3.5 · **0/15 clean** · max 14.
 
-Higher than the ~2.6–2.9 estimate (B + session + watchdog); run 10 (14 xruns) is the
-main outlier. Still ~half pre-fix ladder D (10.0). **512 not shippable** — remaining
-stack cost is sooperlooper-dominated (+2.13 A→B, steady).
-
-*Last updated: 2026-08-20 (America/Toronto)*
+This run is **contaminated by the watchdog fork loop** (see above) — not the merge-candidate
+full-stack number. Still ~half pre-fix ladder D (10.0).
 
 *Last updated: 2026-08-20 (America/Toronto)*

--- a/native/mpe-peak-meter/mpe-peak-meter.c
+++ b/native/mpe-peak-meter/mpe-peak-meter.c
@@ -40,6 +40,8 @@ static volatile sig_atomic_t g_running = 1;
 static volatile sig_atomic_t g_jack_shutdown = 0;
 static _Atomic float g_period_peak = 0.0f;
 static atomic_int g_surge_wired = 0;
+static atomic_int g_looper_client = 0;
+static atomic_int g_looper_playback = 0;
 static _Atomic unsigned long g_xrun_count = 0;
 static char g_run_dir[RUN_DIR_MAX + 1] = "/run/mpe";
 static char g_surge_client[128];
@@ -107,7 +109,46 @@ static int env_truthy(const char *value)
             strcasecmp(value, "yes") == 0 || strcasecmp(value, "on") == 0);
 }
 
-static void write_meter_state(float peak_linear, int surge_wired, unsigned long xruns)
+static int looper_client_visible(void)
+{
+    const char **ports = jack_get_ports(g_client, "mpe-looper:*", NULL, 0);
+    if (ports == NULL) {
+        return 0;
+    }
+    int found = 0;
+    for (int i = 0; ports[i] != NULL; i++) {
+        if (strncmp(ports[i], "mpe-looper:", 11) == 0) {
+            found = 1;
+            break;
+        }
+    }
+    jack_free(ports);
+    return found;
+}
+
+static int looper_playback_wired(void)
+{
+    jack_port_t *pb = jack_port_by_name(g_client, "system:playback_1");
+    if (pb == NULL) {
+        return 0;
+    }
+    const char **connections = jack_port_get_all_connections(g_client, pb);
+    if (connections == NULL) {
+        return 0;
+    }
+    int ok = 0;
+    for (int i = 0; connections[i] != NULL; i++) {
+        if (strncmp(connections[i], "mpe-looper:common_out", 21) == 0) {
+            ok = 1;
+            break;
+        }
+    }
+    jack_free(connections);
+    return ok;
+}
+
+static void write_meter_state(float peak_linear, int surge_wired, int looper_client,
+                              int looper_playback, unsigned long xruns)
 {
     char path[RUN_DIR_MAX + 32];
     char tmp[sizeof(path) + 32];
@@ -127,7 +168,11 @@ static void write_meter_state(float peak_linear, int surge_wired, unsigned long 
     fprintf(fh, "peak_linear=%.9g\n", peak_linear);
     /* wired= reflects Surge XT:out_{1,2} only; looper taps are best-effort. */
     fprintf(fh, "wired=%d\n", surge_wired ? 1 : 0);
+    /* jack_online=1 whenever this process is on the graph (watchdog graph probe). */
+    fprintf(fh, "jack_online=%d\n", 1);
     fprintf(fh, "online=%d\n", surge_wired ? 1 : 0);
+    fprintf(fh, "looper_client=%d\n", looper_client ? 1 : 0);
+    fprintf(fh, "looper_playback=%d\n", looper_playback ? 1 : 0);
     fprintf(fh, "source=jack\n");
     fprintf(fh, "xruns=%lu\n", xruns);
     fprintf(fh, "updated=%ld\n", (long)time(NULL));
@@ -182,6 +227,8 @@ static int ensure_wiring(void)
         }
     }
     atomic_store_explicit(&g_surge_wired, surge_ok, memory_order_relaxed);
+    atomic_store_explicit(&g_looper_client, looper_client_visible(), memory_order_relaxed);
+    atomic_store_explicit(&g_looper_playback, looper_playback_wired(), memory_order_relaxed);
     return surge_ok;
 }
 
@@ -198,11 +245,13 @@ static void *writer_thread(void *arg)
             held_peak *= PEAK_DECAY;
         }
         int surge_wired = atomic_load_explicit(&g_surge_wired, memory_order_relaxed);
+        int looper_client = atomic_load_explicit(&g_looper_client, memory_order_relaxed);
+        int looper_playback = atomic_load_explicit(&g_looper_playback, memory_order_relaxed);
         unsigned long xruns = atomic_load_explicit(&g_xrun_count, memory_order_relaxed);
-        write_meter_state(held_peak, surge_wired, xruns);
+        write_meter_state(held_peak, surge_wired, looper_client, looper_playback, xruns);
         usleep(WRITER_INTERVAL_US);
     }
-    write_meter_state(0.0f, 0, atomic_load_explicit(&g_xrun_count, memory_order_relaxed));
+    write_meter_state(0.0f, 0, 0, 0, atomic_load_explicit(&g_xrun_count, memory_order_relaxed));
     return NULL;
 }
 

--- a/patch_browser/audio_engine.py
+++ b/patch_browser/audio_engine.py
@@ -26,6 +26,7 @@ RECONCILE_STATE_FILE = Path("/run/mpe/engine-reconcile.state")
 JACK_STATE_FILE = Path("/run/mpe/jack.state")
 METER_STATE_FILE = Path("/run/mpe/meter.state")
 ENGINE_STATE_MAX_BYTES = 4096
+METER_STATE_MAX_AGE_S = float(__import__("os").environ.get("MPE_METER_STATE_MAX_AGE_S", "5"))
 
 COOLDOWN_SEC = 30
 # 15s was sized for an ALSA-contention hazard (Surge holding the tier device on
@@ -183,6 +184,66 @@ def read_engine_state(path: Path | None = None) -> dict[str, str]:
 def read_meter_state(path: Path | None = None) -> dict[str, str]:
     """Parse ``meter.state`` from the compiled peak meter process."""
     return read_engine_state(path or METER_STATE_FILE)
+
+
+def meter_state_age_s(state: dict[str, str], *, now: float | None = None) -> float | None:
+    """Seconds since meter.state ``updated=`` epoch, or None if unusable."""
+    updated = state.get("updated")
+    if not updated:
+        return None
+    try:
+        ts = float(updated)
+    except ValueError:
+        return None
+    anchor = __import__("time").time() if now is None else now
+    age = anchor - ts
+    if age < 0:
+        return None
+    return age
+
+
+def meter_state_fresh(state: dict[str, str], *, now: float | None = None,
+                      max_age_s: float = METER_STATE_MAX_AGE_S) -> bool:
+    age = meter_state_age_s(state, now=now)
+    return age is not None and age <= max_age_s
+
+
+def _meter_flag(state: dict[str, str], key: str) -> bool | None:
+    value = state.get(key)
+    if value in {"0", "1"}:
+        return value == "1"
+    return None
+
+
+def jack_reachable_via_meter(*, path: Path | None = None,
+                             now: float | None = None) -> bool | None:
+    """True when the peak meter is on a live JACK graph. None → caller must fall back."""
+    state = read_meter_state(path)
+    if not meter_state_fresh(state, now=now):
+        return None
+    online = _meter_flag(state, "jack_online")
+    if online is not None:
+        return online
+    # Older meters only published online= tied to Surge wiring.
+    return _meter_flag(state, "online")
+
+
+def looper_client_via_meter(*, path: Path | None = None,
+                            now: float | None = None) -> bool | None:
+    """True when ``mpe-looper:*`` ports are on the graph. None → fall back."""
+    state = read_meter_state(path)
+    if not meter_state_fresh(state, now=now):
+        return None
+    return _meter_flag(state, "looper_client")
+
+
+def looper_playback_via_meter(*, path: Path | None = None,
+                              now: float | None = None) -> bool | None:
+    """True when ``common_out`` feeds ``system:playback``. None → fall back."""
+    state = read_meter_state(path)
+    if not meter_state_fresh(state, now=now):
+        return None
+    return _meter_flag(state, "looper_playback")
 
 
 def engine_hud_should_show(state: dict[str, str] | None) -> bool:

--- a/scripts/sooperlooper/sl-watchdog.py
+++ b/scripts/sooperlooper/sl-watchdog.py
@@ -44,6 +44,14 @@ import sys
 import threading
 import time
 from pathlib import Path
+from typing import NamedTuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from patch_browser.audio_engine import (  # noqa: E402
+    jack_reachable_via_meter,
+    looper_client_via_meter,
+    looper_playback_via_meter,
+)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from sl_probe import (  # noqa: E402
@@ -144,10 +152,9 @@ class Osc:
 def jack_graph() -> str | None:
     """Raw `jack_lsp -c` output, or None if JACK itself is unreachable.
 
-    None and "" are different answers and must not be conflated: None means we
-    could not ask, "" means we asked and the graph is empty. Treating the
-    second as the first is how this watchdog reported a healthy appliance with
-    nothing connected to the speakers.
+    Fallback only: registers a JACK client and can reorder the graph. The hot
+    path reads ``/run/mpe/meter.state`` from the long-lived ``mpe-peak-meter``
+    process instead (E2, 2026-08-20).
     """
     try:
         proc = subprocess.run(["jack_lsp", "-c"], capture_output=True,
@@ -155,6 +162,50 @@ def jack_graph() -> str | None:
     except Exception:
         return None
     return proc.stdout if proc.returncode == 0 else None
+
+
+class GraphSnapshot(NamedTuple):
+    """Graph visibility without spawning jack_lsp on the healthy path."""
+
+    jack_reachable: bool | None
+    looper_client: bool | None
+    looper_playback: bool | None
+    source: str
+
+
+def read_graph_snapshot(*, now: float | None = None) -> GraphSnapshot:
+    """Prefer meter.state; fall back to jack_lsp when the meter is off or stale."""
+    t = time.time() if now is None else now
+    jack = jack_reachable_via_meter(now=t)
+    looper = looper_client_via_meter(now=t)
+    playback = looper_playback_via_meter(now=t)
+    if jack is not None and looper is not None and playback is not None:
+        return GraphSnapshot(jack, looper, playback, "meter")
+
+    graph = jack_graph()
+    if graph is None:
+        return GraphSnapshot(None, None, None, "none")
+    return GraphSnapshot(
+        True,
+        jack_client_visible(graph),
+        any(s.startswith(f"{JACK_CLIENT}:common_out") for s in playback_sources(graph)),
+        "jack_lsp",
+    )
+
+
+def wait_for_playback_via_meter(*, timeout_s: float = 4.0,
+                                poll_s: float = 0.2) -> bool | None:
+    """After wire-jack-graph.sh, poll meter.state instead of jack_lsp."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        wired = looper_playback_via_meter()
+        if wired is True:
+            return True
+        if wired is False:
+            time.sleep(poll_s)
+            continue
+        return None
+    return looper_playback_via_meter() is True
 
 
 def playback_sources(graph: str) -> set[str]:
@@ -282,15 +333,22 @@ def engine_running() -> bool | None:
     running at boot alarms ORPHAN every 10 s forever and teaches its operator
     to ignore it — at which point the alarm that matters is also ignored.
 
-    `pgrep -x` matches restart-sooperlooper.sh's own liveness test, so the two
-    agree on what "running" means.
+    Scans ``/proc/*/comm`` — no fork, unlike ``pgrep``.
     """
     try:
-        proc = subprocess.run(["pgrep", "-x", "sooperlooper"],
-                              capture_output=True, text=True, timeout=5)
-    except Exception:
+        proc_root = Path("/proc")
+        for entry in proc_root.iterdir():
+            if not entry.name.isdigit():
+                continue
+            try:
+                comm = (entry / "comm").read_text(errors="replace").strip()
+            except OSError:
+                continue
+            if comm == "sooperlooper":
+                return True
+        return False
+    except OSError:
         return None
-    return proc.returncode == 0
 
 
 def capture_wedge_diagnostics() -> dict:
@@ -399,7 +457,8 @@ def main(argv: list[str] | None = None) -> int:
         # Check this FIRST. An orphan looks exactly like a wedge to the OSC
         # probe below, and every JACK repair against it is futile — so
         # diagnosing in the other order names the wrong component.
-        graph = jack_graph()
+        snap = read_graph_snapshot(now=cycle_t)
+        CURRENT_METRICS["graph_source"] = snap.source
         orphan = False
         stopped = False
         # None means we could not ask (pgrep missing or timed out). That is not
@@ -407,10 +466,10 @@ def main(argv: list[str] | None = None) -> int:
         # alarm below asserts a live process, and asserting it unverified is the
         # failure mode this whole file exists to avoid. Alarm anyway — loud on
         # the control path — but say which of the two we actually established.
-        running = None if graph is None else engine_running()
-        if graph is None:
-            problems.append("jack_lsp unavailable — JACK down or not reachable")
-        elif not jack_client_visible(graph) and running is False:
+        running = None if snap.jack_reachable is None else engine_running()
+        if snap.jack_reachable is None:
+            problems.append("JACK down or not reachable (meter stale and jack_lsp failed)")
+        elif snap.looper_client is False and running is False:
             # Not a fault. Nothing to repair, nothing to alarm — but say so
             # every cycle, because "watchdog up, engine deliberately down" and
             # "watchdog died" must not produce the same alarm file.
@@ -421,10 +480,10 @@ def main(argv: list[str] | None = None) -> int:
                 "action": "mpe looper sl-restart (safe: there are no loops to lose)",
             })
             alarm_written = True
-        elif not jack_client_visible(graph):
+        elif snap.looper_client is False:
             orphan = True
             _proc = ("process is up" if running
-                     else "process state UNKNOWN (pgrep failed)")
+                     else "process state UNKNOWN (proc scan failed)")
             problems.append(f"ORPHAN: {JACK_CLIENT} {_proc} but has no JACK "
                             f"client (jackd restarted under it?)")
             write_alarm("orphan", {
@@ -440,9 +499,9 @@ def main(argv: list[str] | None = None) -> int:
 
         # --- audio path: safe to repair -------------------------------------
         # Pointless while orphaned: the ports being connected do not exist.
-        if graph is not None and not orphan and not stopped:
-            srcs = playback_sources(graph)
-            if not any(s.startswith(f"{JACK_CLIENT}:common_out") for s in srcs):
+        if snap.jack_reachable and not orphan and not stopped:
+            playback_ok = snap.looper_playback is True
+            if snap.looper_playback is False:
                 problems.append("common_out not connected to system:playback")
                 if not args.no_repair:
                     script = REPO_ROOT / "scripts/sooperlooper/wire-jack-graph.sh"
@@ -450,10 +509,7 @@ def main(argv: list[str] | None = None) -> int:
                         proc = subprocess.run(["bash", str(script), "connect"],
                                               capture_output=True, text=True,
                                               timeout=60)
-                        after = jack_graph()
-                        if after is not None and any(
-                                s.startswith(f"{JACK_CLIENT}:common_out")
-                                for s in playback_sources(after)):
+                        if wait_for_playback_via_meter():
                             repaired.append("reconnected common_out -> playback")
                             problems.pop()
                         else:
@@ -468,6 +524,8 @@ def main(argv: list[str] | None = None) -> int:
                                     log(f"  wire-jack {stream}: {line}")
                     except Exception as exc:
                         log(f"repair failed: {exc}")
+            elif snap.looper_playback is None and not playback_ok:
+                problems.append("common_out playback wiring unknown (meter stale)")
 
         # --- control path: NEVER auto-repair (restart destroys takes) --------
         # Skipped while orphaned: it would report WEDGED, which is true but

--- a/tests/test_sl_watchdog_engine_down.py
+++ b/tests/test_sl_watchdog_engine_down.py
@@ -41,8 +41,9 @@ class EngineDownTests(unittest.TestCase):
         self.addCleanup(patcher.stop)
 
     def _run_once(self, *, engine_up: bool) -> dict:
-        with mock.patch.object(sl_watchdog, "jack_graph",
-                               return_value=GRAPH_WITHOUT_LOOPER), \
+        snap = sl_watchdog.GraphSnapshot(True, False, False, "meter")
+        with mock.patch.object(sl_watchdog, "read_graph_snapshot",
+                               return_value=snap), \
              mock.patch.object(sl_watchdog, "engine_running",
                                return_value=engine_up), \
              mock.patch.object(sl_watchdog, "Osc") as osc, \
@@ -67,13 +68,14 @@ class EngineDownTests(unittest.TestCase):
         self.assertEqual("orphan", alarm["state"])
 
     def test_unknown_process_state_alarms_without_asserting_it_is_up(self) -> None:
-        """pgrep failing is not evidence the process is alive.
+        """proc scan failing is not evidence the process is alive.
 
         Still alarms — loud on the control path — but the detail must not claim
         a live process we never confirmed.
         """
-        with mock.patch.object(sl_watchdog, "jack_graph",
-                               return_value=GRAPH_WITHOUT_LOOPER), \
+        snap = sl_watchdog.GraphSnapshot(True, False, False, "meter")
+        with mock.patch.object(sl_watchdog, "read_graph_snapshot",
+                               return_value=snap), \
              mock.patch.object(sl_watchdog, "engine_running", return_value=None), \
              mock.patch.object(sl_watchdog, "Osc") as osc, \
              mock.patch.object(sl_watchdog, "capture_wedge_diagnostics",
@@ -87,8 +89,9 @@ class EngineDownTests(unittest.TestCase):
 
     def test_engine_down_exits_clean(self) -> None:
         """`--once` is a health gate; a deliberately stopped looper isn't a fault."""
-        with mock.patch.object(sl_watchdog, "jack_graph",
-                               return_value=GRAPH_WITHOUT_LOOPER), \
+        snap = sl_watchdog.GraphSnapshot(True, False, False, "meter")
+        with mock.patch.object(sl_watchdog, "read_graph_snapshot",
+                               return_value=snap), \
              mock.patch.object(sl_watchdog, "engine_running", return_value=False), \
              mock.patch.object(sl_watchdog, "Osc") as osc:
             osc.return_value.start.return_value = mock.MagicMock()

--- a/tests/test_sl_watchdog_host_health.py
+++ b/tests/test_sl_watchdog_host_health.py
@@ -78,8 +78,9 @@ class GovernorTests(unittest.TestCase):
         self.gov.write_text(actual + "\n")
         graph = f"{sl.JACK_CLIENT}:common_out_1\n   system:playback_1\n" \
                 f"system:playback_1\n   {sl.JACK_CLIENT}:common_out_1\n"
+        snap = sl.GraphSnapshot(True, True, True, "meter")
         with mock.patch.object(sl, "GOVERNOR_TARGET", target), \
-             mock.patch.object(sl, "jack_graph", return_value=graph), \
+             mock.patch.object(sl, "read_graph_snapshot", return_value=snap), \
              mock.patch.object(sl, "engine_running", return_value=True), \
              mock.patch.object(sl, "repair_governor", return_value=repair) as rep, \
              mock.patch.object(sl, "Osc") as osc:
@@ -129,9 +130,10 @@ class GovernorTests(unittest.TestCase):
             if cycles["n"] >= 4:
                 raise KeyboardInterrupt
 
+        snap = sl.GraphSnapshot(True, True, True, "meter")
         with mock.patch.object(sl, "GOVERNOR_TARGET", "performance"), \
              mock.patch.object(sl, "GOVERNOR_FIGHT_LIMIT", 2), \
-             mock.patch.object(sl, "jack_graph", return_value=graph), \
+             mock.patch.object(sl, "read_graph_snapshot", return_value=snap), \
              mock.patch.object(sl, "engine_running", return_value=True), \
              mock.patch.object(sl, "repair_governor", return_value=(True, "ok")), \
              mock.patch.object(sl, "check_command_path",

--- a/tests/test_sl_watchdog_meter.py
+++ b/tests/test_sl_watchdog_meter.py
@@ -1,0 +1,88 @@
+"""sl-watchdog must not fork jack_lsp when meter.state can answer (E2)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "sl_watchdog_meter", REPO / "scripts/sooperlooper/sl-watchdog.py")
+sl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sl)
+
+
+def _fresh_meter(**flags: int) -> str:
+    body = {
+        "jack_online": 1,
+        "looper_client": 0,
+        "looper_playback": 0,
+        "updated": int(time.time()),
+        **flags,
+    }
+    return "\n".join(f"{k}={v}" for k, v in body.items()) + "\n"
+
+
+class MeterGraphSnapshotTests(unittest.TestCase):
+    def test_healthy_meter_avoids_jack_lsp(self) -> None:
+        snap = sl.GraphSnapshot(True, True, True, "meter")
+        with mock.patch.object(sl, "GOVERNOR_TARGET", ""), \
+             mock.patch.object(sl, "read_graph_snapshot", return_value=snap), \
+             mock.patch.object(sl, "jack_graph") as jg, \
+             mock.patch.object(sl, "engine_running", return_value=True), \
+             mock.patch.object(sl, "check_command_path", return_value=(sl.ALIVE, "ok")), \
+             mock.patch.object(sl, "Osc") as osc:
+            engine = mock.MagicMock()
+            engine.get.return_value = "play"
+            osc.return_value.start.return_value = engine
+            sl.main(["--once"])
+        jg.assert_not_called()
+
+    def test_read_graph_snapshot_prefers_meter(self) -> None:
+        now = time.time()
+        with mock.patch.object(sl, "jack_reachable_via_meter", return_value=True), \
+             mock.patch.object(sl, "looper_client_via_meter", return_value=True), \
+             mock.patch.object(sl, "looper_playback_via_meter", return_value=True), \
+             mock.patch.object(sl, "jack_graph") as jg:
+            snap = sl.read_graph_snapshot(now=now)
+        self.assertEqual("meter", snap.source)
+        jg.assert_not_called()
+
+    def test_stale_meter_falls_back_to_jack_lsp(self) -> None:
+        graph = "mpe-looper:common_out_1\n   system:playback_1\n"
+        with mock.patch.object(sl, "jack_reachable_via_meter", return_value=None), \
+             mock.patch.object(sl, "looper_client_via_meter", return_value=None), \
+             mock.patch.object(sl, "looper_playback_via_meter", return_value=None), \
+             mock.patch.object(sl, "jack_graph", return_value=graph):
+            snap = sl.read_graph_snapshot()
+        self.assertEqual("jack_lsp", snap.source)
+        self.assertTrue(snap.looper_client)
+
+
+class MeterMainLoopTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.alarm = Path(self.enterContext(tempfile.TemporaryDirectory())) / "alarm.json"
+        mock.patch.object(sl, "ALARM_FILE", self.alarm).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_engine_down_via_meter_without_jack_lsp(self) -> None:
+        snap = sl.GraphSnapshot(True, False, False, "meter")
+        with mock.patch.object(sl, "read_graph_snapshot", return_value=snap), \
+             mock.patch.object(sl, "jack_graph") as jg, \
+             mock.patch.object(sl, "engine_running", return_value=False), \
+             mock.patch.object(sl, "Osc") as osc:
+            osc.return_value.start.return_value = mock.MagicMock()
+            rc = sl.main(["--once"])
+        jg.assert_not_called()
+        alarm = json.loads(self.alarm.read_text())
+        self.assertEqual("engine-down", alarm["state"])
+        self.assertEqual(0, rc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Documents where the appliance stands after the reboot test, and corrects the reading of the post-reboot D result.

## Reboot test: passed

`irqaffinity=0,1` plus `CPUAffinity=2 3` survive a cold boot. All three audio processes verified on cores 2–3, no helper loop.

## The post-reboot D number does not reconcile — and that is the finding

D at n=15: mean **5.40**, sd 3.5, max 14, 0/15 clean. Well above the ~2.6–2.9 projection.

D − C would make the watchdog **+2.87**, where the ladder measured **+0.33 ("negligible")**. And the burst signature is back:

| | mean | sd | max |
|---|---:|---:|---:|
| C (post journal fix) | 2.53 | **1.55** | 6 |
| D (post reboot) | 5.40 | **3.5** | 14 |

**Cause: `sl-watchdog.py` runs a 10 s loop that forks at least four subprocesses per cycle** — including `jack_lsp -c`, which registers and unregisters a JACK client and so forces two graph reorders every time. Six cycles per 60 s run. Same probe previously identified as the real xrun source at 35/min, and the **third instance** of the same doctrine violation: no forks in periodic loops.

The ladder called it negligible only because the session's own `journalctl` fork was still drowning it. That is now written into the spec as a general warning: **a small ladder step measured while a noisier layer is still present cannot be trusted.**

## Warning off the wrong next lever

"Does sooperlooper process all sixteen loops every period" is unlikely to explain its +2.13 — condition B runs with **zero loops recorded**, and DSP does not move between conditions. The likelier causes are crowding (our own `CPUAffinity` puts three audio processes on two cores) or the fixed cost of one more client in JACK's serial chain. E1 distinguishes them.

## Audio device constraints, measured today

- Sound Blaster Play! 3 is **full speed (12M)** — 1 ms USB frames vs 125 µs microframes on a high-speed device — and **ADAPTIVE** sync, so no feedback endpoint.
- The **APC MINI shares the same full-speed bus**, and this cannot be separated on a Pi 4: all four ports feed one USB 2 hub.
- **`nrpacks` does not exist on this kernel** — removed ~5.17, replaced by `lowlatency`, already on. No experiment needed.

## Experiment plan, ranked

1. **E1 — three cores instead of two.** Tests our own pinning choice; could close the remaining gap. One line, one reboot.
2. **E2 — fix the watchdog fork loop**, re-measure D.
3. **E3 — the loop-count curve.** Every measurement so far used an idle looper; the instrument under real use is unmeasured.
4. **E4 — 8 h soak** at 512 condition A. 0.13/min cannot be distinguished from zero in 15 minutes.
5. **E5 — the audio-device decision.** Gates 256; invalidates every number above.

**Dropped with reasons:** Steps 3/4 (audio thread has 91% margin at its worst recorded moment), Step 6 PREEMPT_RT (floor 209–320 µs against 5,333 µs), USB port rearrangement (impossible on Pi 4), `nrpacks`.