### PR TITLE
fix: xrun counters were structurally blind; exp: E1 three cores

### DIFF
--- a/config/mpe-jackd.service
+++ b/config/mpe-jackd.service
@@ -45,7 +45,7 @@ StandardOutput=journal
 StandardError=journal
 
 # --- Audio cores (measured 2026-08-20) ---------------------------------------
-# Pin the audio path to cores 2-3, which take no interrupts.
+# Pin the audio path to cores 1-3, which take no interrupts.
 #
 # The BCM2711's GIC-400 (GICv2) has no usable 1-of-N interrupt distribution, so
 # Linux targets the lowest core in each IRQ's mask -- and with the default mask
@@ -54,7 +54,7 @@ StandardError=journal
 # sound card's xhci IRQ, mmc0, the codec and HDMI all landed on CPU0, and JACK's
 # RT thread was running there too.
 #
-# `irqaffinity=0,1` on the kernel cmdline confines interrupts to cores 0-1;
+# `irqaffinity=0` on the kernel cmdline confines interrupts to core 0;
 # this line puts the audio path on the cores that are left. IRQ 30 itself
 # cannot be moved -- BRCM-PCI-MSI does not implement set_affinity (EPERM) --
 # but that does not matter once audio never runs on CPU0.
@@ -63,12 +63,19 @@ StandardError=journal
 #   before: mean 4.20 xruns/60s, 0/5 runs clean
 #   after:  mean 0.13 xruns/60s, 14/15 runs clean   (t = -4.47)
 #
+# E1 2026-08-20: widened from `2 3` to `1 2 3`. With two cores, condition A ran
+# two processes (jackd, surge) and B/C/D ran three (+ sooperlooper) -- and the
+# ONLY significant step in the whole ladder was exactly that 2->3 transition
+# (+2.13, t=4.73). Crowding by our own pinning is therefore the leading
+# explanation for sooperlooper's cost, ahead of anything in its code. Paired
+# with irqaffinity=0 so cores 1-3 stay interrupt-free.
+#
 # sooperlooper is included because it is a JACK graph client -- its callback
 # runs in the process chain, so leaving it on cores 0-1 puts graph work back
 # next to the interrupts.
 #
 # docs/measurements/low-latency-step0-step1-2026-08-19.md
-CPUAffinity=2 3
+CPUAffinity=1 2 3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/mpe-sooperlooper.service
+++ b/config/mpe-sooperlooper.service
@@ -34,7 +34,7 @@ StandardOutput=journal
 StandardError=journal
 
 # --- Audio cores (measured 2026-08-20) ---------------------------------------
-# Pin the audio path to cores 2-3, which take no interrupts.
+# Pin the audio path to cores 1-3, which take no interrupts.
 #
 # The BCM2711's GIC-400 (GICv2) has no usable 1-of-N interrupt distribution, so
 # Linux targets the lowest core in each IRQ's mask -- and with the default mask
@@ -43,7 +43,7 @@ StandardError=journal
 # sound card's xhci IRQ, mmc0, the codec and HDMI all landed on CPU0, and JACK's
 # RT thread was running there too.
 #
-# `irqaffinity=0,1` on the kernel cmdline confines interrupts to cores 0-1;
+# `irqaffinity=0` on the kernel cmdline confines interrupts to core 0;
 # this line puts the audio path on the cores that are left. IRQ 30 itself
 # cannot be moved -- BRCM-PCI-MSI does not implement set_affinity (EPERM) --
 # but that does not matter once audio never runs on CPU0.
@@ -52,12 +52,19 @@ StandardError=journal
 #   before: mean 4.20 xruns/60s, 0/5 runs clean
 #   after:  mean 0.13 xruns/60s, 14/15 runs clean   (t = -4.47)
 #
+# E1 2026-08-20: widened from `2 3` to `1 2 3`. With two cores, condition A ran
+# two processes (jackd, surge) and B/C/D ran three (+ sooperlooper) -- and the
+# ONLY significant step in the whole ladder was exactly that 2->3 transition
+# (+2.13, t=4.73). Crowding by our own pinning is therefore the leading
+# explanation for sooperlooper's cost, ahead of anything in its code. Paired
+# with irqaffinity=0 so cores 1-3 stay interrupt-free.
+#
 # sooperlooper is included because it is a JACK graph client -- its callback
 # runs in the process chain, so leaving it on cores 0-1 puts graph work back
 # next to the interrupts.
 #
 # docs/measurements/low-latency-step0-step1-2026-08-19.md
-CPUAffinity=2 3
+CPUAffinity=1 2 3
 
 [Install]
 WantedBy=multi-user.target

--- a/config/surge-xt-cli.service
+++ b/config/surge-xt-cli.service
@@ -27,7 +27,7 @@ StandardOutput=journal
 StandardError=journal
 
 # --- Audio cores (measured 2026-08-20) ---------------------------------------
-# Pin the audio path to cores 2-3, which take no interrupts.
+# Pin the audio path to cores 1-3, which take no interrupts.
 #
 # The BCM2711's GIC-400 (GICv2) has no usable 1-of-N interrupt distribution, so
 # Linux targets the lowest core in each IRQ's mask -- and with the default mask
@@ -36,7 +36,7 @@ StandardError=journal
 # sound card's xhci IRQ, mmc0, the codec and HDMI all landed on CPU0, and JACK's
 # RT thread was running there too.
 #
-# `irqaffinity=0,1` on the kernel cmdline confines interrupts to cores 0-1;
+# `irqaffinity=0` on the kernel cmdline confines interrupts to core 0;
 # this line puts the audio path on the cores that are left. IRQ 30 itself
 # cannot be moved -- BRCM-PCI-MSI does not implement set_affinity (EPERM) --
 # but that does not matter once audio never runs on CPU0.
@@ -45,12 +45,19 @@ StandardError=journal
 #   before: mean 4.20 xruns/60s, 0/5 runs clean
 #   after:  mean 0.13 xruns/60s, 14/15 runs clean   (t = -4.47)
 #
+# E1 2026-08-20: widened from `2 3` to `1 2 3`. With two cores, condition A ran
+# two processes (jackd, surge) and B/C/D ran three (+ sooperlooper) -- and the
+# ONLY significant step in the whole ladder was exactly that 2->3 transition
+# (+2.13, t=4.73). Crowding by our own pinning is therefore the leading
+# explanation for sooperlooper's cost, ahead of anything in its code. Paired
+# with irqaffinity=0 so cores 1-3 stay interrupt-free.
+#
 # sooperlooper is included because it is a JACK graph client -- its callback
 # runs in the process chain, so leaving it on cores 0-1 puts graph work back
 # next to the interrupts.
 #
 # docs/measurements/low-latency-step0-step1-2026-08-19.md
-CPUAffinity=2 3
+CPUAffinity=1 2 3
 
 [Install]
 WantedBy=multi-user.target

--- a/patch_browser/looper_health.py
+++ b/patch_browser/looper_health.py
@@ -13,11 +13,13 @@ count from ``mpe-jackd`` journal lines.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import threading
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 _BUCKETS = 128
 
@@ -125,7 +127,7 @@ class JackGraphHealth:
         # Both probes are stateful and long-lived — one JACK client and one journal
         # cursor for the life of the monitor, not a fork per sample.
         self.cpu_reader = JackCpuLoadReader()
-        self.xrun_counter = JournalXrunCounter(self.started_at)
+        self.xrun_counter = MeterXrunCounter(self.started_at)
 
     def close(self) -> None:
         """Release held JACK and journal follower processes."""
@@ -260,108 +262,85 @@ class JackCpuLoadReader:
             pass
 
 
-class JournalXrunCounter:
-    """Incremental xrun count from the ``mpe-jackd`` journal.
+METER_STATE_FILE = Path(os.environ.get("MPE_METER_STATE", "/run/mpe/meter.state"))
+# The meter writes at 5 Hz; three missed writes is generous and still catches a
+# dead meter well inside one measurement window.
+METER_STALE_AFTER_S = float(os.environ.get("MPE_METER_STALE_AFTER_S", "3.0"))
 
-    Holds one ``journalctl -f`` process for the life of the monitor. ``poll()`` reads
-    an in-memory total — no fork per HUD tick. The old form forked ``journalctl`` every
-    0.5 s (even with ``--after-cursor``), hitting SD-backed journal I/O on CPU0.
+
+class MeterXrunCounter:
+    """Cumulative xrun count read from the peak meter's state file.
+
+    Replaces JournalXrunCounter (2026-08-20). That class followed the
+    ``mpe-jackd`` journal and counted lines containing "xrun" -- but that journal
+    carries **no xrun lines at all** on this appliance: three hours of it during
+    runs that measured 3-7 xruns/min contained zero. It therefore reported 0
+    forever, in the component whose entire job is to notice. sl-watchdog had the
+    same hole from the other side, tailing /tmp/sooperlooper.log for "got xrun"
+    when that file does not exist.
+
+    ``/run/mpe/meter.state`` is where the real count lives -- written by
+    mpe-peak-meter from JACK's xrun callback, and the same source
+    scripts/measure-latency-run.sh has always used for its RESULT lines.
+
+    tmpfs, so poll() is a small read with no fork and no thread.
+
+    Returns None -- never a silently wrong 0 -- when the file is missing,
+    unparseable, or stale, so callers can tell "no xruns" from "cannot see".
     """
 
-    def __init__(self, started_at: float, *, unit: str = "mpe-jackd.service") -> None:
+    def __init__(
+        self,
+        started_at: float,
+        *,
+        path: Path | None = None,
+        stale_after_s: float = METER_STALE_AFTER_S,
+    ) -> None:
         self.started_at = started_at
-        self.unit = unit
-        self._lock = threading.Lock()
+        self.path = Path(path) if path is not None else METER_STATE_FILE
+        self.stale_after_s = stale_after_s
+        self._baseline: int | None = None
         self._total = 0
-        self._unavailable = False
-        self._anchored = False
-        self._proc: subprocess.Popen | None = None
-        self._thread: threading.Thread | None = None
-        self._last_spawn_attempt = 0.0
-        self._spawn()
 
-    def _since_argv(self) -> list[str]:
-        since = datetime.fromtimestamp(self.started_at, tz=timezone.utc).astimezone()
-        return [
-            "journalctl",
-            "-u",
-            self.unit,
-            "-f",
-            "--since",
-            since.isoformat(),
-            "--no-pager",
-        ]
-
-    def _spawn(self, now: float | None = None) -> bool:
-        if self._unavailable:
-            return False
-        if now is None:
-            now = time.monotonic()
-        if now - self._last_spawn_attempt < JACK_CPU_RESPAWN_BACKOFF_S:
-            return False
-        self._last_spawn_attempt = now
+    def _read(self) -> tuple[int, float] | None:
+        """(xruns, updated_epoch) from the meter file, or None if unusable."""
         try:
-            proc = subprocess.Popen(
-                self._since_argv(),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                text=True,
-                bufsize=1,
-            )
-        except (FileNotFoundError, OSError):
-            self._unavailable = True
-            return False
-        self._proc = proc
-        self._thread = threading.Thread(
-            target=self._drain,
-            args=(proc,),
-            daemon=True,
-            name="JournalXrunFollower",
-        )
-        self._thread.start()
-        return True
-
-    def _count_line(self, line: str) -> None:
-        if "xrun" not in line.lower():
-            return
-        with self._lock:
-            self._total += 1
-
-    def _drain(self, proc: subprocess.Popen) -> None:
-        stream = proc.stdout
-        if stream is None:
-            return
-        for line in stream:
-            self._anchored = True
-            self._count_line(line)
-
-    def _alive(self) -> bool:
-        return self._proc is not None and self._proc.poll() is None
+            raw = self.path.read_text(encoding="utf-8")
+        except (FileNotFoundError, PermissionError, OSError):
+            return None
+        xruns: int | None = None
+        updated: float | None = None
+        for line in raw.splitlines():
+            key, _, value = line.partition("=")
+            try:
+                if key == "xruns":
+                    xruns = int(value)
+                elif key == "updated":
+                    updated = float(value)
+            except ValueError:
+                return None
+        if xruns is None or updated is None:
+            return None
+        return xruns, updated
 
     def poll(self) -> int | None:
-        """Cumulative xruns since *started_at*, or None if the journal is unreadable."""
-        if self._unavailable:
+        """Cumulative xruns since the first successful read, or None if unseeable."""
+        sample = self._read()
+        if sample is None:
             return None
-        if not self._alive():
-            self.close()
-            self._spawn()
-            if not self._alive():
-                return None
-        if not self._anchored:
-            # Follower running but no lines yet — journal empty or still catching up.
-            return 0
-        with self._lock:
-            return self._total
+        xruns, updated = sample
+        # A meter that has stopped writing looks identical to a quiet one. It is
+        # not: report None so the caller raises a problem instead of "healthy".
+        if self.stale_after_s > 0 and (time.time() - updated) > self.stale_after_s:
+            return None
+        if self._baseline is None or xruns < self._baseline:
+            # First read, or the meter restarted and its counter went backwards.
+            self._baseline = xruns
+        self._total = xruns - self._baseline
+        return self._total
 
     def close(self) -> None:
-        proc, self._proc = self._proc, None
-        if proc is None:
-            return
-        try:
-            proc.kill()
-            proc.wait(timeout=2.0)
-        except (subprocess.TimeoutExpired, OSError):
-            pass
+        """No-op. Kept so callers need not care which counter they hold."""
 
 
 def read_jack_cpu_load_pct(*, timeout_s: float = 1.0) -> float | None:
@@ -393,7 +372,7 @@ def read_jack_cpu_load_pct(*, timeout_s: float = 1.0) -> float | None:
 def jackd_journal_xruns_since(started_at: float) -> int | None:
     """One-shot journal xrun count — diagnostics only.
 
-    NOT for polling: one fork per call. Use ``JournalXrunCounter`` on any repeating path.
+    NOT for polling: one fork per call. Use ``MeterXrunCounter`` on any repeating path.
     """
     since = datetime.fromtimestamp(started_at, tz=timezone.utc).astimezone()
     try:

--- a/scripts/sooperlooper/sl-watchdog.py
+++ b/scripts/sooperlooper/sl-watchdog.py
@@ -97,7 +97,10 @@ GOVERNOR_UNIT = os.environ.get("MPE_CPU_GOVERNOR_UNIT", "mpe-cpu-governor.servic
 # RATE IS ALWAYS REPORTED in the alarm file regardless of the threshold — a
 # number you can watch is the point; the alarm is only for the loud case.
 ENGINE_LOG = Path(os.environ.get("MPE_SL_ENGINE_LOG", "/tmp/sooperlooper.log"))
-XRUN_MARKER = os.environ.get("MPE_SL_XRUN_MARKER", "got xrun")
+METER_STATE_FILE = Path(os.environ.get("MPE_METER_STATE", "/run/mpe/meter.state"))
+# The meter writes at 5 Hz; three missed writes is generous and still catches a
+# dead meter well inside one watchdog cycle.
+METER_STALE_AFTER_S = float(os.environ.get("MPE_METER_STALE_AFTER_S", "3.0"))
 XRUN_ALARM_PER_MIN = float(os.environ.get("MPE_SL_XRUN_ALARM_PER_MIN", "30"))
 XRUN_WINDOW_S = float(os.environ.get("MPE_SL_XRUN_WINDOW_S", "60"))
 
@@ -268,45 +271,69 @@ def repair_governor() -> tuple[bool, str]:
 
 
 class XrunCounter:
-    """Counts new xrun markers in the engine log without re-reading it.
+    """Xruns per minute, read from the peak meter's state file.
 
-    The log grows without bound while the engine runs (161 KB and climbing when
-    this was written), and this polls every 10 s on the same box that is trying
-    to make audio — so it tracks a byte offset and reads only what is new.
+    Was: tail /tmp/sooperlooper.log for the marker "got xrun". **That file does
+    not exist on the appliance** (2026-08-20), so this counter reported 0 every
+    cycle regardless of what the audio path was doing -- while measured runs in
+    the same period were producing 3-7 xruns/min. The health monitor's central
+    metric read identically whether the instrument was clean or faulting, which
+    is precisely the failure shape docs/measurements/README.md exists to
+    prevent. patch_browser.looper_health had the same hole from the journal side.
 
-    Handles the log being rotated, truncated or replaced (inode change or a
-    shrink): that resets the offset rather than reporting a wild negative delta.
+    ``/run/mpe/meter.state`` carries the real count, written by mpe-peak-meter
+    from JACK's xrun callback -- the same source scripts/measure-latency-run.sh
+    has always used. tmpfs, so this is a small read: no fork, consistent with
+    the no-forks-in-periodic-loops doctrine in Documents/DECISIONS.md.
+
+    A missing or stale meter returns an error string rather than 0, so "cannot
+    see" is never reported as "clean".
     """
 
     def __init__(self, path: Path) -> None:
         self.path = path
-        self._offset = 0
-        self._inode: int | None = None
+        self._baseline: int | None = None
+        self._last_total: int | None = None
         self._events: list[tuple[float, int]] = []
 
-    def poll(self, when: float) -> tuple[int, str | None]:
-        """Read new bytes. Returns (new_marker_count, error_or_None)."""
+    def _read(self) -> tuple[int, float] | None:
         try:
-            st = self.path.stat()
-        except OSError as exc:
-            return 0, f"no engine log at {self.path} ({exc.__class__.__name__})"
-        if self._inode is not None and (st.st_ino != self._inode
-                                        or st.st_size < self._offset):
-            self._offset = 0
-        self._inode = st.st_ino
-        if st.st_size == self._offset:
+            raw = self.path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        xruns = updated = None
+        for line in raw.splitlines():
+            key, _, value = line.partition("=")
+            try:
+                if key == "xruns":
+                    xruns = int(value)
+                elif key == "updated":
+                    updated = float(value)
+            except ValueError:
+                return None
+        if xruns is None or updated is None:
+            return None
+        return xruns, updated
+
+    def poll(self, when: float) -> tuple[int, str | None]:
+        """New xruns since the last cycle. Returns (count, error_or_None)."""
+        sample = self._read()
+        if sample is None:
+            return 0, f"no usable meter state at {self.path}"
+        total, updated = sample
+        age = time.time() - updated
+        if age > METER_STALE_AFTER_S:
+            return 0, f"meter state stale ({age:.1f}s) — peak meter stopped?"
+        if self._baseline is None or total < self._baseline:
+            # First cycle, or the meter restarted and its counter went backwards.
+            self._baseline = total
+            self._last_total = total
             self._events.append((when, 0))
             return 0, None
-        try:
-            with self.path.open("r", errors="replace") as fh:
-                fh.seek(self._offset)
-                chunk = fh.read()
-                self._offset = fh.tell()
-        except OSError as exc:
-            return 0, f"cannot read engine log ({exc.__class__.__name__})"
-        count = chunk.count(XRUN_MARKER)
-        self._events.append((when, count))
-        return count, None
+        new = total - (self._last_total if self._last_total is not None else total)
+        self._last_total = total
+        self._events.append((when, max(0, new)))
+        return max(0, new), None
 
     def rate_per_min(self, when: float) -> float | None:
         """Xruns/min over the trailing window, or None until it has a span."""
@@ -398,7 +425,7 @@ def main(argv: list[str] | None = None) -> int:
     log(f"watching every {INTERVAL_S:.0f}s — repairs JACK graph, alarms on wedge")
     wedged_since: float | None = None
 
-    xruns = XrunCounter(ENGINE_LOG)
+    xruns = XrunCounter(METER_STATE_FILE)
     governor_repairs: list[float] = []
 
     while True:

--- a/tests/test_looper_health.py
+++ b/tests/test_looper_health.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import tempfile
+import shutil
+import time
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from patch_browser.looper_health import (
     JackCpuLoadReader,
     JackGraphHealth,
-    JournalXrunCounter,
+    MeterXrunCounter,
     LooperHealth,
     collect_jack_graph_health,
     jackd_journal_xruns_since,
@@ -95,76 +99,69 @@ class JackProbeTests(unittest.TestCase):
         self.assertEqual(jackd_journal_xruns_since(1_700_000_000.0), 1)
 
 
-class JournalXrunCounterTests(unittest.TestCase):
-    """One ``journalctl -f`` for the life of the monitor — no fork per poll."""
+class MeterXrunCounterTests(unittest.TestCase):
+    """Reads the meter's real count, and says None rather than a confident 0.
 
-    def test_spawns_follow_once_across_many_polls(self) -> None:
-        import io
-        import time
+    Replaced JournalXrunCounter, which followed the mpe-jackd journal for lines
+    containing "xrun". That journal carries none on this appliance, so it
+    reported 0 forever while runs measured 3-7 xruns/min.
+    """
 
-        spawns: list[list[str]] = []
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.state = self.tmp / "meter.state"
 
-        class FakeProc:
-            def __init__(self, argv: list[str]) -> None:
-                spawns.append(argv)
-                self.stdout = io.StringIO("jackd: xrun of at least 128 msecs\nfine\n")
-                self.killed = False
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
 
-            def poll(self):
-                return None
+    def _write(self, xruns: int, *, age_s: float = 0.0) -> None:
+        self.state.write_text(
+            f"peak_linear=0\nxruns={xruns}\nupdated={time.time() - age_s:.0f}\n",
+            encoding="utf-8",
+        )
 
-            def kill(self) -> None:
-                self.killed = True
+    def test_counts_from_a_baseline_so_prior_xruns_are_not_replayed(self) -> None:
+        self._write(7)
+        counter = MeterXrunCounter(0.0, path=self.state)
+        self.assertEqual(counter.poll(), 0, "first read establishes the baseline")
+        self._write(11)
+        self.assertEqual(counter.poll(), 4)
 
-            def wait(self, timeout=None):
-                return 0
+    def test_meter_restart_rebaselines_instead_of_going_negative(self) -> None:
+        self._write(40)
+        counter = MeterXrunCounter(0.0, path=self.state)
+        counter.poll()
+        self._write(2)  # meter restarted, counter reset
+        self.assertEqual(counter.poll(), 0)
+        self._write(5)
+        self.assertEqual(counter.poll(), 3)
 
-        counter = JournalXrunCounter(1_700_000_000.0)
-        with patch(
-            "patch_browser.looper_health.subprocess.Popen",
-            side_effect=lambda argv, **kw: FakeProc(argv),
-        ):
-            time.sleep(0.05)
-            self.assertEqual(counter.poll(), 1)
+    def test_stale_meter_reports_none_not_zero(self) -> None:
+        """A stopped meter and a clean instrument must not read the same."""
+        self._write(3, age_s=120.0)
+        counter = MeterXrunCounter(0.0, path=self.state)
+        self.assertIsNone(counter.poll())
+
+    def test_missing_file_reports_none_not_zero(self) -> None:
+        counter = MeterXrunCounter(0.0, path=self.tmp / "absent.state")
+        self.assertIsNone(counter.poll())
+
+    def test_unparseable_file_reports_none_not_zero(self) -> None:
+        self.state.write_text("xruns=not-a-number\nupdated=1\n", encoding="utf-8")
+        counter = MeterXrunCounter(0.0, path=self.state)
+        self.assertIsNone(counter.poll())
+
+    def test_poll_does_not_fork(self) -> None:
+        """The whole point: no subprocess on a periodic path."""
+        self._write(1)
+        counter = MeterXrunCounter(0.0, path=self.state)
+        with patch("patch_browser.looper_health.subprocess.Popen") as popen, patch(
+            "patch_browser.looper_health.subprocess.run"
+        ) as run:
             for _ in range(20):
-                self.assertEqual(counter.poll(), 1)
-            counter.close()
-
-        self.assertEqual(len(spawns), 1, f"respawned {len(spawns)}x — forks per tick")
-        self.assertIn("-f", spawns[0])
-        self.assertIn("--since", spawns[0])
-
-    def test_quiet_poll_keeps_running_total(self) -> None:
-        import io
-        import time
-
-        counter = JournalXrunCounter(1_700_000_000.0)
-        with patch(
-            "patch_browser.looper_health.subprocess.Popen",
-            side_effect=lambda argv, **kw: type(
-                "FakeProc",
-                (),
-                {
-                    "stdout": io.StringIO("jackd: xrun\n"),
-                    "poll": lambda self: None,
-                    "kill": lambda self: None,
-                    "wait": lambda self, timeout=None: 0,
-                },
-            )(),
-        ):
-            time.sleep(0.05)
-            self.assertEqual(counter.poll(), 1)
-            self.assertEqual(counter.poll(), 1)
-            counter.close()
-
-    def test_missing_journalctl_is_never_retried(self) -> None:
-        counter = JournalXrunCounter(1_700_000_000.0)
-        with patch(
-            "patch_browser.looper_health.subprocess.Popen", side_effect=FileNotFoundError
-        ) as popen:
-            self.assertIsNone(counter.poll())
-            self.assertIsNone(counter.poll())
-        self.assertEqual(popen.call_count, 1)
+                counter.poll()
+        self.assertEqual(popen.call_count, 0)
+        self.assertEqual(run.call_count, 0)
 
 
 class JackCpuLoadReaderTests(unittest.TestCase):

--- a/tests/test_sl_watchdog_host_health.py
+++ b/tests/test_sl_watchdog_host_health.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import importlib.util
 import json
 import tempfile
+import time
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 from unittest import mock
 
@@ -23,43 +25,73 @@ _spec.loader.exec_module(sl)
 
 
 class XrunCounterTests(unittest.TestCase):
+    """Reads /run/mpe/meter.state, the only place the real count lives.
+
+    Was: tail /tmp/sooperlooper.log for "got xrun". That file does not exist on
+    the appliance, so the watchdog's central metric read 0 every cycle while
+    measured runs produced 3-7 xruns/min — clean and faulting looked identical.
+    """
+
     def setUp(self) -> None:
         self.tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
-        self.log = self.tmp / "engine.log"
+        self.state = self.tmp / "meter.state"
 
-    def test_counts_only_new_bytes(self) -> None:
-        """A growing log must not be re-counted from the top every 10s."""
-        self.log.write_text("got xrun\ngot xrun\n")
-        c = sl.XrunCounter(self.log)
-        self.assertEqual((2, None), c.poll(100.0))
-        self.assertEqual((0, None), c.poll(110.0), "re-counted unchanged file")
-        with self.log.open("a") as fh:
-            fh.write("got xrun\n")
-        self.assertEqual((1, None), c.poll(120.0))
+    def _write(self, xruns: int, *, age_s: float = 0.0) -> None:
+        self.state.write_text(
+            f"xruns={xruns}\nupdated={time.time() - age_s:.0f}\n", encoding="utf-8"
+        )
 
-    def test_truncation_resets_offset(self) -> None:
-        """A rotated or truncated log must not report a negative/garbage delta."""
-        self.log.write_text("got xrun\n" * 5)
-        c = sl.XrunCounter(self.log)
+    def test_reports_new_xruns_per_cycle(self) -> None:
+        self._write(7)
+        c = sl.XrunCounter(self.state)
+        self.assertEqual((0, None), c.poll(100.0), "first cycle sets the baseline")
+        self._write(9)
+        self.assertEqual((2, None), c.poll(110.0))
+        self.assertEqual((0, None), c.poll(120.0), "unchanged meter is not re-counted")
+
+    def test_meter_restart_does_not_report_a_negative_delta(self) -> None:
+        self._write(40)
+        c = sl.XrunCounter(self.state)
         c.poll(100.0)
-        self.log.write_text("got xrun\n")  # truncate + one fresh event
-        self.assertEqual((1, None), c.poll(110.0))
+        self._write(2)  # meter restarted, counter reset
+        self.assertEqual((0, None), c.poll(110.0))
+        self._write(5)
+        self.assertEqual((3, None), c.poll(120.0))
 
-    def test_missing_log_is_reported_not_crashed(self) -> None:
-        c = sl.XrunCounter(self.tmp / "absent.log")
+    def test_missing_meter_is_reported_not_crashed(self) -> None:
+        c = sl.XrunCounter(self.tmp / "absent.state")
+        count, err = c.poll(100.0)
+        self.assertEqual(0, count)
+        self.assertIsNotNone(err, "a missing meter must not read as clean")
+
+    def test_stale_meter_is_an_error_not_a_clean_reading(self) -> None:
+        """A peak meter that has stopped writing must not look like silence."""
+        self._write(3, age_s=120.0)
+        c = sl.XrunCounter(self.state)
         count, err = c.poll(100.0)
         self.assertEqual(0, count)
         self.assertIsNotNone(err)
+        self.assertIn("stale", err)
 
     def test_rate_needs_a_span_then_reports_per_minute(self) -> None:
-        self.log.write_text("")
-        c = sl.XrunCounter(self.log)
+        self._write(0)
+        c = sl.XrunCounter(self.state)
         c.poll(0.0)
         self.assertIsNone(c.rate_per_min(0.0), "no rate from a single sample")
-        with self.log.open("a") as fh:
-            fh.write("got xrun\n" * 10)
+        self._write(10)
         c.poll(30.0)
         self.assertEqual(20.0, c.rate_per_min(30.0))  # 10 in 30s -> 20/min
+
+    def test_poll_does_not_fork(self) -> None:
+        self._write(1)
+        c = sl.XrunCounter(self.state)
+        with patch.object(sl.subprocess, "run") as run, patch.object(
+            sl.subprocess, "Popen"
+        ) as popen:
+            for _ in range(20):
+                c.poll(100.0)
+        self.assertEqual(run.call_count, 0)
+        self.assertEqual(popen.call_count, 0)
 
 
 class GovernorTests(unittest.TestCase):


### PR DESCRIPTION
Two changes. The first is a correctness fix that should probably land regardless of E1.

## 1. Both xrun counters were reading dead sources

The health monitor could not see the appliance's primary failure mode. Two counters, two different dead sources, both reporting a confident zero:

| counter | read from | reality |
|---|---|---|
| `JournalXrunCounter` (HUD) | `mpe-jackd` journal, lines containing "xrun" | **that journal has no xrun lines** — 3 h of it, spanning runs measured at 3–7 xruns/min, contained zero |
| `XrunCounter` (sl-watchdog) | `/tmp/sooperlooper.log`, marker `"got xrun"` | **that file does not exist** |

So `xruns_per_min` read 0 forever, and the watchdog believed the instrument was clean while it faulted several times a minute — a reading that looks the same broken or fine, inside the component whose entire job is to notice.

Neither was introduced by E2; E2 moved the *other* probes onto `meter.state` and left these two behind.

**Both now read `/run/mpe/meter.state`** — written by `mpe-peak-meter` from JACK's xrun callback, and the same source `measure-latency-run.sh` has always used. It's tmpfs, so polling is a small read with no fork and no follower thread (which also retires the `journalctl -f` process E2 introduced).

**Missing, stale, or unparseable meter returns `None`/an error, never 0**, so "cannot see" is never reported as "clean". Staleness is 3 s against a 5 Hz writer; a meter restart rebaselines rather than reporting a negative delta.

### Verified live on the Pi, not just in tests

```
source file: /run/mpe/meter.state
cycle 0 (baseline): (0, None)
t=10s new=1 err=None rate_per_min=6.0
t=20s new=2 err=None rate_per_min=9.0
t=30s new=0 err=None rate_per_min=6.0
t=40s new=0 err=None rate_per_min=4.5
t=50s new=1 err=None rate_per_min=4.8
```

Tests rewritten against the new behaviour, including explicit cases that a missing or stale meter does not read as zero and that neither `poll()` forks. **1011 pass** (was 3 failing).

## 2. E1 — widen the audio path from two cores to three

`CPUAffinity=2 3` → `CPUAffinity=1 2 3`, paired with `irqaffinity=0` on the cmdline (staged on the Pi, needs a reboot).

With two cores, condition A ran two processes and B/C/D ran three — and **the only significant step in the whole ladder was exactly that 2→3 transition** (+2.13, t=4.73; session +0.27 and watchdog +0.60 are both ns). That makes crowding by our own pinning the leading explanation for sooperlooper's cost, ahead of anything in its code.

Measure **A, B and D** at n=15. B is the point: minimal condition with three processes, no session or watchdog confound. If B's +2.13 collapses, the cost was our configuration and sooperlooper is exonerated; if it holds with a whole extra core free, it's structural and E3 becomes the next question.