### PR TITLE
feat(norm): patch normalization v2 port (cherry-pick from yolo/patch-norm-v2)

### DIFF
--- a/Documents/specs/patch-normalization-v2-spec.md
+++ b/Documents/specs/patch-normalization-v2-spec.md
@@ -1,9 +1,9 @@
 # Patch normalization v2 — calibration integrity + level UX
 
 **Issue:** [MPE-Sound-Module #5](https://github.com/MitchSchwartz/MPE-Sound-Module/issues/5) (follow-on)
-**Status:** Draft
+**Status:** Implemented (pending Pi soak)
 **Created:** 2026-08-17
-**Last updated:** 2026-08-17 (America/Toronto)
+**Last updated:** 2026-08-18 (America/Toronto)
 
 **Related:** [`docs/PATCH_NORMALIZATION.md`](../../docs/PATCH_NORMALIZATION.md) · [`docs/OUTPUT-METER.md`](../../docs/OUTPUT-METER.md) · [`docs/TOUCH_PATCH_BROWSER.md`](../../docs/TOUCH_PATCH_BROWSER.md) §Mixer faders
 

--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -58,6 +58,9 @@
 # Override with exact step: MPE_DAC_SPEAKER_RAW=64
 # MPE_DAC_VOLUME_DB=-12
 
+# Vol fader law (touch browser): console (IEC default) or linear-in-dB
+# MPE_VOL_FADER_LAW=console
+
 # --- Audio engine (Pi — JACK graph server) ---
 # JACK is the only audio engine (spec amended 2026-08-13 — ALSA removed
 # entirely, not just its automatic fallback). MPE_AUDIO_ENGINE is retired —

--- a/docs/PATCH_NORMALIZATION.md
+++ b/docs/PATCH_NORMALIZATION.md
@@ -4,9 +4,19 @@ Static loudness matching for Surge XT patches on the MPE appliance. Calibrate on
 
 **Issue:** [MPE-Sound-Module #5](https://github.com/MitchSchwartz/MPE-Sound-Module/issues/5)
 
-**v2 spec (cal integrity, Norm trim, meter/fader UX):** [`Documents/specs/patch-normalization-v2-spec.md`](../Documents/specs/patch-normalization-v2-spec.md) — Draft 2026-08-17. **DAC appliance default:** `MPE_DAC_VOLUME_DB=-12` (Speaker raw 64) as of same date.
+**v2 spec (cal integrity, Norm trim, meter/fader UX):** [`Documents/specs/patch-normalization-v2-spec.md`](../Documents/specs/patch-normalization-v2-spec.md) — Implemented 2026-08-18 (pending Pi soak). **DAC appliance default:** `MPE_DAC_VOLUME_DB=-12` (Speaker raw 64) as of same date.
 
 ## Design
+
+### v2 Norm trim (2026-08-18)
+
+- **Norm fader** adjusts `user_trim_db` — an offset from calibrated `gain_db` (−24…+12 dB). **0** = calibrated baseline; double-tap clears trim.
+- **Legacy `user_gain_db`** rows migrate on store load to `user_trim_db` (absolute → offset) and persist.
+- **Cal save gate:** post-gain closed-loop verify must report peak ≤ −2.8 dBTP or the patch is **not saved**.
+- **Audit:** `scripts/calibrate-patch-normalization.py --verify-only --favorites-only` replays at stored `gain_db` only.
+- **OUT meter** floor: −24 dBFS (was −48).
+- **Vol fader law:** `MPE_VOL_FADER_LAW=console|linear` in `/etc/mpe/mpe.env` (default **console**).
+
 
 | When | What |
 |------|------|

--- a/patch_browser/mixer_controls.py
+++ b/patch_browser/mixer_controls.py
@@ -171,7 +171,7 @@ class TailControl:
 
 
 class NormControl:
-    """Calibrated absolute value on a bipolar scale."""
+    """Per-patch trim offset from calibrated gain (v2 Norm fader)."""
 
     spec = MixerControlSpec("norm", "Norm", NORM_GAIN_DB_MIN, NORM_GAIN_DB_MAX)
 
@@ -191,11 +191,8 @@ class NormControl:
         patch = browser.detail_patch
         kw = sidecar_kwargs_from_patch(patch)
         name = patch["name"]
-        effective = store.get_effective_gain_db(name, **kw)
-        if effective is not None:
-            return max(self.spec.min_value, min(self.spec.max_value, effective))
-        default = store.get_slider_default_gain_db(name, **kw)
-        return max(self.spec.min_value, min(self.spec.max_value, default))
+        trim = store.get_user_trim_db(name, **kw)
+        return max(self.spec.min_value, min(self.spec.max_value, trim))
 
     def default(self, browser) -> float:
         if not browser.detail_patch:
@@ -213,12 +210,11 @@ class NormControl:
         kw = sidecar_kwargs_from_patch(patch)
         name = patch["name"]
         store = browser.loader.normalization
-        default = store.get_slider_default_gain_db(name, **kw)
         clamped = max(self.spec.min_value, min(self.spec.max_value, float(value)))
-        if abs(clamped - default) < 0.05:
-            store.clear_user_gain_db(name, persist=persist, **kw)
+        if abs(clamped) < 0.05:
+            store.clear_user_trim_db(name, persist=persist, **kw)
         else:
-            store.set_user_gain_db(name, clamped, persist=persist, **kw)
+            store.set_user_trim_db(name, clamped, persist=persist, **kw)
         loaded = browser.loaded_patch_info
         if (
             loaded
@@ -234,8 +230,7 @@ class NormControl:
         kw = sidecar_kwargs_from_patch(patch)
         name = patch["name"]
         store = browser.loader.normalization
-        store.clear_user_gain_db(name, **kw)
-        default = store.get_slider_default_gain_db(name, **kw)
+        store.clear_user_trim_db(name, **kw)
         loaded = browser.loaded_patch_info
         if (
             loaded
@@ -243,10 +238,7 @@ class NormControl:
             and store.refs_match(loaded, patch)
         ):
             browser.loader.refresh_patch_volume(name)
-        if store.get_calibrated_gain_db(name, **kw) is not None:
-            browser._toast(f"Level reset to {default:+.1f} dB", 1.5)
-        else:
-            browser._toast("Level reset to 0 dB", 1.5)
+        browser._toast("Norm trim reset to calibrated baseline", 1.5)
 
     def format(self, value: float) -> str:
         return f"{value:+.1f}"

--- a/patch_browser/patch_normalization.py
+++ b/patch_browser/patch_normalization.py
@@ -29,9 +29,25 @@ MAX_AMP_VOLUME_LINEAR = 1.5
 # (2026-08-01, see PATCH_NORMALIZATION.md).
 NORM_MAX_AMP_VOLUME_LINEAR = MAX_AMP_VOLUME_LINEAR
 
-# Per-patch manual level slider range (dB gain sent to Surge amp/volume).
-NORM_GAIN_DB_MIN = -12.0
-NORM_GAIN_DB_MAX = 24.0
+# v2 Norm fader: trim offset from calibrated gain_db (-24..+12 dB; 0 = cal baseline).
+NORM_TRIM_DB_MIN = -24.0
+NORM_TRIM_DB_MAX = 12.0
+
+# Legacy aliases -- NormControl uses trim range; keep names for import stability.
+NORM_GAIN_DB_MIN = NORM_TRIM_DB_MIN
+NORM_GAIN_DB_MAX = NORM_TRIM_DB_MAX
+
+# Closed-loop cal verify: post-gain peak must land at or below SAFE_PEAK + tolerance.
+POST_GAIN_VERIFY_PEAK_MAX_DBTP = SAFE_PEAK_DBTP + 0.2
+
+VOL_FADER_LAW_CONSOLE = "console"
+VOL_FADER_LAW_LINEAR = "linear"
+
+
+def post_gain_verify_passes(peak_dbtp: float) -> bool:
+    """True when closed-loop post-gain peak is finite and within v2 save gate."""
+    return math.isfinite(peak_dbtp) and peak_dbtp <= POST_GAIN_VERIFY_PEAK_MAX_DBTP
+
 
 
 def default_normalization_path() -> Path:
@@ -105,24 +121,34 @@ def _volume_fader_t(
     return max(0.0, min(1.0, (trim - fader_min) / span))
 
 
+def volume_fader_law() -> str:
+    """Vol fader taper — env ``MPE_VOL_FADER_LAW`` (``console`` default, or ``linear``)."""
+    raw = os.environ.get("MPE_VOL_FADER_LAW", VOL_FADER_LAW_CONSOLE).strip().lower()
+    if raw == VOL_FADER_LAW_LINEAR:
+        return VOL_FADER_LAW_LINEAR
+    return VOL_FADER_LAW_CONSOLE
+
+
 def volume_fader_trim_to_db(
     trim: float,
     *,
     fader_min: float,
     fader_max: float,
     floor_db: float = VOLUME_FADER_FLOOR_DB,
+    law: str | None = None,
 ) -> float | None:
     """Attenuation in dB relative to full patch level. None when fader is at mute.
 
-    Console (IEC 60268-17) taper, rescaled from the law's -70 dB bottom onto *floor_db*,
-    so the top half of travel covers 0..-20 dB instead of 0..-30 dB. Was
-    ``floor_db * (1 - t)`` — linear in dB, which made the fader fall off a cliff.
+    Console (IEC 60268-17) taper by default; ``linear`` spreads dB evenly over travel
+    (``MPE_VOL_FADER_LAW=linear``).
     """
     if trim <= fader_min:
         return None
     t = _volume_fader_t(trim, fader_min=fader_min, fader_max=fader_max)
     if t <= 0.0:
         return None
+    if (law or volume_fader_law()) == VOL_FADER_LAW_LINEAR:
+        return floor_db * (1.0 - t)
     return _iec_fader_db(t) * (floor_db / _IEC_FADER_BOTTOM_DB)
 
 
@@ -241,6 +267,29 @@ def _merge_patch_entry(
     return merged
 
 
+def clamp_user_trim_db(trim_db: float) -> float:
+    """Clamp Norm trim offset to the v2 fader range."""
+    return max(NORM_TRIM_DB_MIN, min(NORM_TRIM_DB_MAX, float(trim_db)))
+
+
+def _migrate_legacy_user_gain(entry: dict[str, Any]) -> dict[str, Any]:
+    """v1 ``user_gain_db`` (absolute) -> v2 ``user_trim_db`` (offset from gain_db)."""
+    if "user_gain_db" not in entry:
+        return entry
+    updated = dict(entry)
+    if "user_trim_db" not in updated:
+        user_gain = float(updated.pop("user_gain_db"))
+        gain_db = updated.get("gain_db")
+        if gain_db is not None:
+            trim = clamp_user_trim_db(user_gain - float(gain_db))
+        else:
+            trim = clamp_user_trim_db(user_gain)
+        updated["user_trim_db"] = round(trim, 3)
+    else:
+        updated.pop("user_gain_db", None)
+    return updated
+
+
 # Reserved key in user normalization JSON — master switch, not a patch stem.
 _GLOBAL_SETTINGS_KEY = "_global"
 
@@ -277,7 +326,15 @@ class PatchNormalizationStore(SidecarKeyMixin):
                 if isinstance(entry, dict):
                     merged[key] = _merge_patch_entry(merged.get(key), entry)
 
+        migrated = False
+        for key in list(merged.keys()):
+            new_entry = _migrate_legacy_user_gain(merged[key])
+            if new_entry != merged[key]:
+                merged[key] = new_entry
+                migrated = True
         self._data = merged
+        if migrated and self.path.exists():
+            self.save()
 
     def save(self) -> None:
         """Persist store atomically so cancel/interrupt mid-write cannot truncate JSON."""
@@ -401,6 +458,20 @@ class PatchNormalizationStore(SidecarKeyMixin):
             return None
         return float(gain)
 
+    def get_user_trim_db(
+        self,
+        patch_name: str,
+        *,
+        patch_path: str | None = None,
+        stable_key: str | None = None,
+    ) -> float:
+        entry = self.get_entry(
+            patch_name, patch_path=patch_path, stable_key=stable_key
+        )
+        if not entry or "user_trim_db" not in entry:
+            return 0.0
+        return float(entry["user_trim_db"])
+
     def get_effective_gain_db(
         self,
         patch_name: str,
@@ -408,17 +479,19 @@ class PatchNormalizationStore(SidecarKeyMixin):
         patch_path: str | None = None,
         stable_key: str | None = None,
     ) -> float | None:
-        """Runtime gain: user_gain_db when set, else calibrated gain_db."""
+        """Runtime gain: calibrated gain_db + user_trim_db offset (v2)."""
         entry = self.get_entry(
             patch_name, patch_path=patch_path, stable_key=stable_key
         )
         if not entry:
             return None
-        if "user_gain_db" in entry:
-            return float(entry["user_gain_db"])
-        return self.get_calibrated_gain_db(
-            patch_name, patch_path=patch_path, stable_key=stable_key
-        )
+        calibrated = entry.get("gain_db")
+        trim = entry.get("user_trim_db")
+        if calibrated is None and trim is None:
+            return None
+        base = float(calibrated) if calibrated is not None else 0.0
+        offset = float(trim) if trim is not None else 0.0
+        return base + offset
 
     def get_slider_default_gain_db(
         self,
@@ -427,13 +500,10 @@ class PatchNormalizationStore(SidecarKeyMixin):
         patch_path: str | None = None,
         stable_key: str | None = None,
     ) -> float:
-        """Slider double-tap reset — calibrated gain, or 0 dB when uncalibrated."""
-        calibrated = self.get_calibrated_gain_db(
-            patch_name, patch_path=patch_path, stable_key=stable_key
-        )
-        return calibrated if calibrated is not None else 0.0
+        """Norm fader double-tap reset — 0 dB trim (calibrated baseline)."""
+        return 0.0
 
-    def has_user_gain_override(
+    def has_user_trim_override(
         self,
         patch_name: str,
         *,
@@ -443,7 +513,45 @@ class PatchNormalizationStore(SidecarKeyMixin):
         entry = self.get_entry(
             patch_name, patch_path=patch_path, stable_key=stable_key
         )
-        return bool(entry and "user_gain_db" in entry)
+        return bool(entry and "user_trim_db" in entry)
+
+    def has_user_gain_override(
+        self,
+        patch_name: str,
+        *,
+        patch_path: str | None = None,
+        stable_key: str | None = None,
+    ) -> bool:
+        return self.has_user_trim_override(
+            patch_name, patch_path=patch_path, stable_key=stable_key
+        )
+
+    def set_user_trim_db(
+        self,
+        patch_name: str,
+        trim_db: float,
+        *,
+        persist: bool = True,
+        patch_path: str | None = None,
+        stable_key: str | None = None,
+    ) -> None:
+        """Set Norm trim offset from calibrated gain (defer persist=False while dragging)."""
+        key = self._storage_key(
+            patch_name, patch_path=patch_path, stable_key=stable_key
+        )
+        entry, matched = self._lookup(
+            patch_name, patch_path=patch_path, stable_key=stable_key
+        )
+        if not isinstance(entry, dict):
+            entry = {}
+        entry = self._ensure_calibration_fields(matched or key, entry)
+        entry["user_trim_db"] = round(clamp_user_trim_db(trim_db), 3)
+        entry.pop("user_gain_db", None)
+        if matched and matched != key:
+            self._data.pop(matched, None)
+        self._data[key] = entry
+        if persist:
+            self.save()
 
     def set_user_gain_db(
         self,
@@ -454,20 +562,48 @@ class PatchNormalizationStore(SidecarKeyMixin):
         patch_path: str | None = None,
         stable_key: str | None = None,
     ) -> None:
-        """Set manual per-patch level override (defer persist=False while dragging)."""
-        key = self._storage_key(
+        """Legacy v1 API — absolute gain_db converted to trim offset when calibrated."""
+        entry = self.get_entry(
             patch_name, patch_path=patch_path, stable_key=stable_key
         )
-        entry, matched = self._lookup(
+        calibrated = entry.get("gain_db") if entry else None
+        if calibrated is not None:
+            trim = float(gain_db) - float(calibrated)
+        else:
+            trim = float(gain_db)
+        self.set_user_trim_db(
+            patch_name,
+            trim,
+            persist=persist,
+            patch_path=patch_path,
+            stable_key=stable_key,
+        )
+
+    def clear_user_trim_db(
+        self,
+        patch_name: str,
+        *,
+        persist: bool = True,
+        patch_path: str | None = None,
+        stable_key: str | None = None,
+    ) -> None:
+        """Remove trim override; runtime reverts to calibrated gain_db only."""
+        entry, key = self._lookup(
             patch_name, patch_path=patch_path, stable_key=stable_key
         )
-        if not isinstance(entry, dict):
-            entry = {}
-        entry = self._ensure_calibration_fields(matched or key, entry)
-        entry["user_gain_db"] = round(float(gain_db), 3)
-        if matched and matched != key:
-            self._data.pop(matched, None)
-        self._data[key] = entry
+        if not entry or not key:
+            return
+        if "user_trim_db" not in entry and "user_gain_db" not in entry:
+            return
+        updated = dict(entry)
+        updated.pop("user_trim_db", None)
+        updated.pop("user_gain_db", None)
+        storage = self._storage_key(
+            patch_name, patch_path=patch_path, stable_key=stable_key
+        )
+        if key != storage:
+            self._data.pop(key, None)
+        self._data[storage] = updated
         if persist:
             self.save()
 
@@ -479,22 +615,12 @@ class PatchNormalizationStore(SidecarKeyMixin):
         patch_path: str | None = None,
         stable_key: str | None = None,
     ) -> None:
-        """Remove manual override; runtime reverts to calibrated gain_db."""
-        entry, key = self._lookup(
-            patch_name, patch_path=patch_path, stable_key=stable_key
+        self.clear_user_trim_db(
+            patch_name,
+            persist=persist,
+            patch_path=patch_path,
+            stable_key=stable_key,
         )
-        if not entry or "user_gain_db" not in entry or not key:
-            return
-        updated = dict(entry)
-        del updated["user_gain_db"]
-        storage = self._storage_key(
-            patch_name, patch_path=patch_path, stable_key=stable_key
-        )
-        if key != storage:
-            self._data.pop(key, None)
-        self._data[storage] = updated
-        if persist:
-            self.save()
 
     def get_gain_db(
         self,
@@ -534,6 +660,8 @@ class PatchNormalizationStore(SidecarKeyMixin):
         enabled: bool | None = None,
         calibrated_at: str | None = None,
         true_peak_dbtp: float | None = None,
+        post_gain_peak_dbtp: float | None = None,
+        cal_route: str | None = None,
         strike_lufs: float | None = None,
         sustain_lufs: float | None = None,
         patch_path: str | None = None,
@@ -561,12 +689,21 @@ class PatchNormalizationStore(SidecarKeyMixin):
         }
         if true_peak_dbtp is not None:
             entry["true_peak_dbtp"] = round(float(true_peak_dbtp), 2)
+        if post_gain_peak_dbtp is not None:
+            entry["post_gain_peak_dbtp"] = round(float(post_gain_peak_dbtp), 2)
+        if cal_route is not None:
+            entry["cal_route"] = cal_route
         if strike_lufs is not None:
             entry["strike_lufs"] = round(float(strike_lufs), 2)
         if sustain_lufs is not None:
             entry["sustain_lufs"] = round(float(sustain_lufs), 2)
-        if existing and "user_gain_db" in existing:
-            entry["user_gain_db"] = existing["user_gain_db"]
+        if existing:
+            if "user_trim_db" in existing:
+                entry["user_trim_db"] = existing["user_trim_db"]
+            elif "user_gain_db" in existing:
+                entry = _migrate_legacy_user_gain(
+                    {**entry, "user_gain_db": existing["user_gain_db"]}
+                )
         if matched and matched != key:
             self._data.pop(matched, None)
         self._data[key] = entry

--- a/patch_browser/peak_meter_math.py
+++ b/patch_browser/peak_meter_math.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 
 # Bar scale and color bands — single source for the OUT meter.
-PEAK_METER_FLOOR_DBFS = -48.0  # empty bar
+PEAK_METER_FLOOR_DBFS = -24.0  # empty bar
 PEAK_METER_CLIP_DBFS = 0.0  # full bar (digital clip / headroom reference)
 
 # Color bands tuned for normalized Surge output (SAFE_PEAK_DBTP = -3 in patch_normalization).

--- a/patch_browser/touch_browser_normalization.py
+++ b/patch_browser/touch_browser_normalization.py
@@ -71,7 +71,9 @@ class TouchBrowserNormalizationMixin:
         return bool(
             entry
             and (
-                entry.get("gain_db") is not None or entry.get("user_gain_db") is not None
+                entry.get("gain_db") is not None
+                or entry.get("user_trim_db") is not None
+                or entry.get("user_gain_db") is not None
             )
         )
 
@@ -90,11 +92,8 @@ class TouchBrowserNormalizationMixin:
         store = self.loader.normalization
         kw = self._detail_sidecar_kw()
         name = self.detail_patch["name"]
-        effective = store.get_effective_gain_db(name, **kw)
-        if effective is not None:
-            return max(NORM_GAIN_DB_MIN, min(NORM_GAIN_DB_MAX, effective))
-        default = store.get_slider_default_gain_db(name, **kw)
-        return max(NORM_GAIN_DB_MIN, min(NORM_GAIN_DB_MAX, default))
+        trim = store.get_user_trim_db(name, **kw)
+        return max(NORM_GAIN_DB_MIN, min(NORM_GAIN_DB_MAX, trim))
 
     def _apply_norm_gain_db(self, gain_db: float, *, persist: bool = True) -> None:
         if not self.detail_patch:
@@ -103,12 +102,11 @@ class TouchBrowserNormalizationMixin:
         kw = self._detail_sidecar_kw()
         name = patch["name"]
         store = self.loader.normalization
-        default = store.get_slider_default_gain_db(name, **kw)
         clamped = max(NORM_GAIN_DB_MIN, min(NORM_GAIN_DB_MAX, float(gain_db)))
-        if abs(clamped - default) < 0.05:
-            store.clear_user_gain_db(name, persist=persist, **kw)
+        if abs(clamped) < 0.05:
+            store.clear_user_trim_db(name, persist=persist, **kw)
         else:
-            store.set_user_gain_db(name, clamped, persist=persist, **kw)
+            store.set_user_trim_db(name, clamped, persist=persist, **kw)
         loaded = self.loaded_patch_info
         if loaded and self.loader.osc_enabled and store.refs_match(loaded, patch):
             self.loader.refresh_patch_volume(name)
@@ -120,13 +118,12 @@ class TouchBrowserNormalizationMixin:
         kw = self._detail_sidecar_kw()
         name = patch["name"]
         store = self.loader.normalization
-        store.clear_user_gain_db(name, **kw)
-        default = store.get_slider_default_gain_db(name, **kw)
+        store.clear_user_trim_db(name, **kw)
         loaded = self.loaded_patch_info
         if loaded and self.loader.osc_enabled and store.refs_match(loaded, patch):
             self.loader.refresh_patch_volume(name)
         if store.get_calibrated_gain_db(name, **kw) is not None:
-            self._toast(f"Level reset to {default:+.1f} dB", 1.5)
+            self._toast("Norm trim reset to calibrated baseline", 1.5)
         else:
             self._toast("Level reset to 0 dB", 1.5)
 

--- a/patch_browser/touch_browser_normalization.py
+++ b/patch_browser/touch_browser_normalization.py
@@ -18,7 +18,6 @@ from patch_browser.calibration_constants import (
 )
 from patch_browser.dsi_splash import SplashMode, draw_splash_frame
 from patch_browser.geometry import Rect
-from patch_browser.patch_normalization import NORM_GAIN_DB_MAX, NORM_GAIN_DB_MIN
 from patch_browser.patch_sidecar_key import sidecar_kwargs_from_patch
 from patch_browser.draw_primitives import draw_toggle_switch
 from patch_browser.touch_ui_constants import (
@@ -76,56 +75,6 @@ class TouchBrowserNormalizationMixin:
                 or entry.get("user_gain_db") is not None
             )
         )
-
-    def _show_norm_level_fader(self) -> bool:
-        """Second mixer column — only when Norm. is checked for this patch."""
-        if not self.detail_patch:
-            return False
-        store = self.loader.normalization
-        if not store.is_globally_enabled():
-            return False
-        return store.is_enabled(self.detail_patch["name"], **self._detail_sidecar_kw())
-
-    def _norm_gain_db_for_detail(self) -> float:
-        if not self.detail_patch:
-            return 0.0
-        store = self.loader.normalization
-        kw = self._detail_sidecar_kw()
-        name = self.detail_patch["name"]
-        trim = store.get_user_trim_db(name, **kw)
-        return max(NORM_GAIN_DB_MIN, min(NORM_GAIN_DB_MAX, trim))
-
-    def _apply_norm_gain_db(self, gain_db: float, *, persist: bool = True) -> None:
-        if not self.detail_patch:
-            return
-        patch = self.detail_patch
-        kw = self._detail_sidecar_kw()
-        name = patch["name"]
-        store = self.loader.normalization
-        clamped = max(NORM_GAIN_DB_MIN, min(NORM_GAIN_DB_MAX, float(gain_db)))
-        if abs(clamped) < 0.05:
-            store.clear_user_trim_db(name, persist=persist, **kw)
-        else:
-            store.set_user_trim_db(name, clamped, persist=persist, **kw)
-        loaded = self.loaded_patch_info
-        if loaded and self.loader.osc_enabled and store.refs_match(loaded, patch):
-            self.loader.refresh_patch_volume(name)
-
-    def _reset_norm_gain_to_calibrated(self) -> None:
-        if not self.detail_patch:
-            return
-        patch = self.detail_patch
-        kw = self._detail_sidecar_kw()
-        name = patch["name"]
-        store = self.loader.normalization
-        store.clear_user_trim_db(name, **kw)
-        loaded = self.loaded_patch_info
-        if loaded and self.loader.osc_enabled and store.refs_match(loaded, patch):
-            self.loader.refresh_patch_volume(name)
-        if store.get_calibrated_gain_db(name, **kw) is not None:
-            self._toast("Norm trim reset to calibrated baseline", 1.5)
-        else:
-            self._toast("Level reset to 0 dB", 1.5)
 
     def _normalization_patch_name(self) -> str | None:
         if not self.detail_patch:

--- a/scripts/calibrate-patch-normalization.py
+++ b/scripts/calibrate-patch-normalization.py
@@ -74,7 +74,9 @@ from patch_browser.calibration_teardown import (  # noqa: E402
     unload_snd_aloop_if_idle,
 )
 from patch_browser.patch_normalization import (  # noqa: E402
+    POST_GAIN_VERIFY_PEAK_MAX_DBTP,
     PatchNormalizationStore,
+    post_gain_verify_passes,
     SAFE_PEAK_DBTP,
     compute_gain_db,
     compute_gain_db_dual_anchor,
@@ -135,9 +137,18 @@ FAILURE_REPORT_PATH = Path("/tmp/calibration-last-failure.json")
 @dataclass
 class CalibrateResult:
     ok: bool
+    verify_failed: bool = False
     lufs_light: float | None = None
     lufs_strike: float | None = None
     lufs_sustain: float | None = None
+
+
+@dataclass
+class VerifyResult:
+    ok: bool
+    skipped: bool = False
+    peak_dbtp: float | None = None
+    reason: str = ""
 
 
 def _handle_interrupt(_signum: int, _frame: object | None) -> None:
@@ -163,6 +174,11 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=None,
         help="Output JSON path (default: MPE_NORMALIZATION_FILE or ~/.patch_browser_normalization.json)",
+    )
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Audit calibrated patches in scope: replay gesture at stored gain_db only",
     )
     parser.add_argument(
         "--dry-run",
@@ -786,13 +802,19 @@ def finalize_gain_with_closed_loop(
     for _ in range(CLOSED_LOOP_VERIFY_PASSES):
         apply_measurement_gain(loader, trial)
         time.sleep(0.35)
-        measured = measure_sustain_anchor_lufs(midi_out, audio_device)
-        if measured is None:
+        strike = measure_strike_anchor_lufs(midi_out, audio_device)
+        sustain = measure_sustain_anchor_lufs(midi_out, audio_device)
+        if strike is None or sustain is None:
             break
-        last_lufs, last_peak = measured
-        if last_peak <= SAFE_PEAK_DBTP + 0.5:
+        lufs_strike, peak_strike = strike
+        lufs_sustain, peak_sustain = sustain
+        last_lufs = lufs_sustain
+        last_peak = max(peak_strike, peak_sustain)
+        if post_gain_verify_passes(last_peak):
             return trial, last_lufs, last_peak
-        trial = compute_gain_db(last_lufs, last_peak)
+        trial = compute_gain_db_dual_anchor(
+            lufs_strike, peak_strike, lufs_sustain, peak_sustain
+        )
     return trial, last_lufs, last_peak
 
 
@@ -865,6 +887,37 @@ def measure_lufs(wav_path: Path) -> tuple[float, float]:
     return lufs, true_peak
 
 
+def verify_patch(
+    patch_path: Path,
+    loader: PatchLoader,
+    store: PatchNormalizationStore,
+    *,
+    audio_device: str,
+    midi_out: object,
+) -> VerifyResult:
+    name = patch_path.stem
+    entry = store.get_entry(name, patch_path=str(patch_path))
+    if not entry or entry.get("gain_db") is None:
+        return VerifyResult(ok=False, skipped=True, reason="not calibrated")
+    gain_db = float(entry["gain_db"])
+    if not loader.load_patch(str(patch_path), apply_normalization=False):
+        print(f"  [fail] OSC load failed: {name}", file=sys.stderr)
+        return VerifyResult(ok=False, reason="OSC load failed")
+    loader.user_volume_trim = 1.0
+    apply_measurement_gain(loader, gain_db)
+    time.sleep(PATCH_LOAD_SETTLE_SECONDS)
+    strike = measure_strike_anchor_lufs(midi_out, audio_device)
+    sustain = measure_sustain_anchor_lufs(midi_out, audio_device)
+    if strike is None or sustain is None:
+        print(f"  [fail] {name}: verify capture inaudible", file=sys.stderr)
+        return VerifyResult(ok=False, reason="verify capture inaudible")
+    _lufs_s, peak_strike = strike
+    _lufs_u, peak_sustain = sustain
+    peak = max(peak_strike, peak_sustain)
+    ok = post_gain_verify_passes(peak)
+    return VerifyResult(ok=ok, peak_dbtp=peak)
+
+
 def calibrate_patch(
     patch_path: Path,
     loader: PatchLoader,
@@ -875,6 +928,7 @@ def calibrate_patch(
     dry_run: bool,
     midi_out: object | None = None,
     touch_cal: bool = True,
+    cal_route: str = "soundblaster",
 ) -> CalibrateResult:
     name = patch_path.stem
     if dry_run:
@@ -946,10 +1000,25 @@ def calibrate_patch(
             file=sys.stderr,
         )
 
+    post_gain_peak: float | None = None
+    if mock_lufs is not None:
+        print(
+            f"  [fail] {name}: --mock-lufs cannot save cal entries (no post-gain verify)",
+            file=sys.stderr,
+        )
+        return CalibrateResult(ok=False)
     if mock_lufs is None and midi_out is not None:
         gain_db, verify_lufs, verify_peak = finalize_gain_with_closed_loop(
             loader, midi_out, audio_device, gain_db
         )
+        post_gain_peak = verify_peak
+        if not post_gain_verify_passes(verify_peak):
+            print(
+                f"  [fail] {name}: post-gain verify peak {verify_peak:.1f} dBTP "
+                f"exceeds {POST_GAIN_VERIFY_PEAK_MAX_DBTP:.1f} — not saved",
+                file=sys.stderr,
+            )
+            return CalibrateResult(ok=False, verify_failed=True)
         if math.isfinite(verify_lufs):
             lufs = verify_lufs
             true_peak = verify_peak
@@ -959,6 +1028,8 @@ def calibrate_patch(
         gain_db,
         lufs,
         true_peak_dbtp=true_peak,
+        post_gain_peak_dbtp=post_gain_peak,
+        cal_route=cal_route,
         strike_lufs=lufs_strike,
         sustain_lufs=lufs_sustain,
         patch_path=str(patch_path),
@@ -967,9 +1038,12 @@ def calibrate_patch(
     touch_note = ""
     if lufs_light is not None:
         touch_note = f", light {lufs_light:.1f} LUFS"
+    post_note = ""
+    if post_gain_peak is not None:
+        post_note = f", post-gain {post_gain_peak:.1f} dBTP"
     print(
         f"  [ok] {name}: strike {lufs_strike:.1f} / sustain {lufs_sustain:.1f} LUFS, "
-        f"peak {true_peak:.1f} dBTP -> gain {gain_db:+.2f} dB{touch_note}"
+        f"peak {true_peak:.1f} dBTP -> gain {gain_db:+.2f} dB{post_note}{touch_note}"
     )
     return CalibrateResult(
         ok=True,
@@ -1009,7 +1083,13 @@ def main() -> int:
     pressure_path = args.pressure_output or default_pressure_path()
     touch_cal = not args.no_touch_cal
     patch_records = patch_path_records(patch_paths)
-    if args.force or args.mock_lufs is not None:
+    if args.verify_only:
+        targets = [
+            p
+            for p in patch_paths
+            if store.get_calibrated_gain_db(p.stem, patch_path=str(p)) is not None
+        ]
+    elif args.force or args.mock_lufs is not None:
         targets = patch_paths
     else:
         missing_keys = set(store.list_missing(patch_records))
@@ -1053,7 +1133,22 @@ def main() -> int:
     )
 
     if not targets:
-        print("No patches need calibration (all entries present). Use --force to re-run.", file=sys.stderr)
+        if args.verify_only:
+            print("No calibrated patches in scope to verify.", file=sys.stderr)
+        else:
+            print(
+                "No patches need calibration (all entries present). Use --force to re-run.",
+                file=sys.stderr,
+            )
+        emit_progress(args, {"type": "done", "updated": 0, "exit_code": 0})
+        return 0
+
+    if args.verify_only and args.dry_run:
+        for path in targets:
+            entry = store.get_entry(path.stem, patch_path=str(path))
+            peak = entry.get("post_gain_peak_dbtp") if entry else None
+            label = f"post_gain_peak={peak}" if peak is not None else "stored cal"
+            print(f"  [would verify] {path.stem} ({label})")
         emit_progress(args, {"type": "done", "updated": 0, "exit_code": 0})
         return 0
 
@@ -1082,6 +1177,10 @@ def main() -> int:
     cal_surge_started = False
     updated = 0
     exit_code = 0
+    peak_verify_failed = 0
+    cal_attempted = 0
+    verify_failed_count = 0
+    cal_route = "loopback" if use_loopback else "soundblaster"
     last_patch_index = 0
     last_patch_name = ""
     needs_service_handoff = (use_loopback and args.mock_lufs is None) or standalone_restart
@@ -1145,6 +1244,54 @@ def main() -> int:
         try:
             if args.mock_lufs is None:
                 midi_out = open_midi_out(midi_port)
+            if args.verify_only:
+                if midi_out is None:
+                    msg = "Surge MIDI required for --verify-only"
+                    print(f"Error: {msg}", file=sys.stderr)
+                    emit_progress(args, {"type": "error", "message": msg})
+                    emit_progress(args, {"type": "done", "updated": 0, "exit_code": 1})
+                    return 1
+                for index, path in enumerate(targets, start=1):
+                    if _interrupted:
+                        break
+                    name = path.stem
+                    print(
+                        f"[{index}/{len(targets)}] verify {name}",
+                        file=sys.stderr if args.progress_json else sys.stdout,
+                    )
+                    result = verify_patch(
+                        path, loader, store, audio_device=audio_device, midi_out=midi_out
+                    )
+                    if result.skipped:
+                        print(f"  [skip] {name}: {result.reason}", file=sys.stderr)
+                        continue
+                    if result.ok:
+                        print(
+                            f"  [pass] {name}: post-gain peak {result.peak_dbtp:.1f} dBTP",
+                        )
+                    else:
+                        verify_failed_count += 1
+                        peak_label = (
+                            f"{result.peak_dbtp:.1f}"
+                            if result.peak_dbtp is not None
+                            else "?"
+                        )
+                        print(
+                            f"  [fail] {name}: post-gain peak {peak_label} dBTP "
+                            f"(max {POST_GAIN_VERIFY_PEAK_MAX_DBTP:.1f})",
+                            file=sys.stderr,
+                        )
+                exit_code = 1 if verify_failed_count else 0
+                emit_progress(
+                    args,
+                    {
+                        "type": "done",
+                        "updated": len(targets) - verify_failed_count,
+                        "exit_code": exit_code,
+                        "verify_failed": verify_failed_count,
+                    },
+                )
+                return exit_code
             for index, path in enumerate(targets, start=1):
                 if _interrupted:
                     print("Calibration interrupted — keeping partial progress.", file=sys.stderr)
@@ -1158,6 +1305,7 @@ def main() -> int:
                     {"type": "patch", "index": index, "total": len(targets), "name": name},
                 )
                 try:
+                    cal_attempted += 1
                     result = calibrate_patch(
                         path,
                         loader,
@@ -1167,7 +1315,10 @@ def main() -> int:
                         dry_run=False,
                         midi_out=midi_out,
                         touch_cal=touch_cal,
+                        cal_route=cal_route,
                     )
+                    if result.verify_failed:
+                        peak_verify_failed += 1
                 except Exception as exc:
                     msg = f"{name}: {exc}"
                     print(f"  [fail] {msg}", file=sys.stderr)
@@ -1226,11 +1377,19 @@ def main() -> int:
                 )
                 print("Restoring surge-xt-cli and touch-patch-browser services...", file=sys.stderr)
 
+    if cal_attempted > 0 and peak_verify_failed / cal_attempted > 0.10:
+        print(
+            f"Error: {peak_verify_failed}/{cal_attempted} patches failed post-gain verify (>10%)",
+            file=sys.stderr,
+        )
+        exit_code = 1
     if updated:
         print(f"Wrote {updated} calibration entries to {output_path}")
-    else:
+    elif cal_attempted == 0:
         print("No entries updated.")
         exit_code = 0
+    else:
+        print("No entries updated.")
     if _interrupted:
         exit_code = 130
         write_failure_report(

--- a/scripts/dedupe-patch-normalization.py
+++ b/scripts/dedupe-patch-normalization.py
@@ -152,7 +152,7 @@ def dedupe(
         merged = dict(data[winner])
         losers = [k for k in unique if k != winner]
         for loser in losers:
-            for field in ("user_gain_db", "enabled"):
+            for field in ("user_trim_db", "enabled"):
                 if field in data.get(loser, {}) and field not in merged:
                     merged[field] = data[loser][field]
             merged_keys.add(loser)

--- a/tests/test_calibration_integrity.py
+++ b/tests/test_calibration_integrity.py
@@ -273,5 +273,63 @@ class CalibrateListMissingContractTests(unittest.TestCase):
             self.assertEqual(missing_keys, [missing_key])
 
 
+
+class ClosedLoopThresholdTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cal = load_cal_module()
+
+    def test_finalize_loop_uses_same_gate_as_save(self) -> None:
+        from patch_browser.patch_normalization import POST_GAIN_VERIFY_PEAK_MAX_DBTP
+
+        src = Path(self.cal.__file__).read_text()
+        self.assertIn("post_gain_verify_passes(last_peak)", src)
+        self.assertNotIn("SAFE_PEAK_DBTP + 0.5", src.split("def finalize_gain_with_closed_loop")[1].split("def is_invalid_measurement")[0])
+
+
+class PostGainVerifyGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cal = load_cal_module()
+
+    def test_post_gain_verify_rejects_hot_peak(self) -> None:
+        self.assertFalse(self.cal.post_gain_verify_passes(-1.0))
+
+    def test_calibrate_skips_save_on_verify_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "norm.json"
+            store = self.cal.PatchNormalizationStore(out_path)
+            fake_loader = mock.Mock()
+            fake_loader.load_patch.return_value = True
+            fake_loader.osc_enabled = True
+            fake_loader.osc_client = mock.Mock()
+            with (
+                mock.patch.object(
+                    self.cal, "measure_strike_anchor_lufs", return_value=(-18.0, -6.0)
+                ),
+                mock.patch.object(
+                    self.cal, "measure_sustain_anchor_lufs", return_value=(-18.0, -6.0)
+                ),
+                mock.patch.object(self.cal, "measure_light_touch_lufs", return_value=None),
+                mock.patch.object(
+                    self.cal,
+                    "finalize_gain_with_closed_loop",
+                    return_value=(2.0, -16.0, -1.5),
+                ),
+                mock.patch.object(self.cal.time, "sleep"),
+            ):
+                result = self.cal.calibrate_patch(
+                    Path("/tmp/Hot.fxp"),
+                    fake_loader,
+                    store,
+                    audio_device="plughw:Loopback,1,0",
+                    mock_lufs=None,
+                    dry_run=False,
+                    midi_out=mock.Mock(),
+                )
+            self.assertFalse(result.ok)
+            self.assertTrue(result.verify_failed)
+            self.assertIsNone(store.get_raw_gain_db("Hot"))
+
+
 if __name__ == "__main__":
+
     unittest.main()

--- a/tests/test_calibration_integrity.py
+++ b/tests/test_calibration_integrity.py
@@ -164,9 +164,7 @@ class NormCapIntegrityTests(unittest.TestCase):
 
 class CalibrationPipelineDoesNotSilentlySaveGarbageTests(unittest.TestCase):
     """End-to-end via the real capture path (mock_lufs intentionally bypasses
-    is_invalid_measurement entirely — it's a write-any-value testing escape
-    hatch, not representative of the real gate). Mock capture_gesture_wav /
-    measure_lufs instead so is_invalid_measurement is actually exercised."""
+    is_invalid_measurement and post-gain verify gates are exercised."""
 
     def setUp(self) -> None:
         self.cal = load_cal_module()
@@ -272,6 +270,29 @@ class CalibrateListMissingContractTests(unittest.TestCase):
 
             self.assertEqual(missing_keys, [missing_key])
 
+
+
+
+
+class MockLufsRefusesSaveTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cal = load_cal_module()
+
+    def test_mock_lufs_does_not_persist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "norm.json"
+            store = self.cal.PatchNormalizationStore(out_path)
+            result = self.cal.calibrate_patch(
+                Path("/tmp/Mock.fxp"),
+                mock.Mock(),
+                store,
+                audio_device="plughw:Loopback,1,0",
+                mock_lufs=-18.0,
+                dry_run=False,
+                midi_out=None,
+            )
+            self.assertFalse(result.ok)
+            self.assertIsNone(store.get_raw_gain_db("Mock"))
 
 
 class ClosedLoopThresholdTests(unittest.TestCase):

--- a/tests/test_norm_trim_v2.py
+++ b/tests/test_norm_trim_v2.py
@@ -1,0 +1,167 @@
+"""Patch normalization v2 — Norm trim offset, legacy migration, vol fader law."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from patch_browser.patch_loader import PatchLoader
+from patch_browser.patch_normalization import (
+    NORM_TRIM_DB_MAX,
+    NORM_TRIM_DB_MIN,
+    POST_GAIN_VERIFY_PEAK_MAX_DBTP,
+    VOL_FADER_LAW_LINEAR,
+    PatchNormalizationStore,
+    clamp_user_trim_db,
+    db_to_linear,
+    post_gain_verify_passes,
+    volume_fader_law,
+    volume_fader_trim_to_db,
+)
+from patch_browser.touch_ui_constants import VOLUME_MAX, VOLUME_MIN
+
+
+class FakeOscClient:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, float]] = []
+
+    def send_message(self, address: str, value: float) -> None:
+        self.messages.append((address, value))
+
+
+class PostGainVerifyTests(unittest.TestCase):
+    def test_passes_at_safe_peak(self) -> None:
+        self.assertTrue(post_gain_verify_passes(-3.0))
+        self.assertTrue(post_gain_verify_passes(POST_GAIN_VERIFY_PEAK_MAX_DBTP))
+
+    def test_fails_above_tolerance(self) -> None:
+        self.assertFalse(post_gain_verify_passes(-2.0))
+        self.assertFalse(post_gain_verify_passes(float("nan")))
+        self.assertFalse(post_gain_verify_passes(float("inf")))
+
+
+class UserTrimTests(unittest.TestCase):
+    def test_effective_gain_is_calibrated_plus_trim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_path = Path(tmp) / "user.json"
+            user_path.write_text(
+                json.dumps(
+                    {
+                        "Lead": {
+                            "gain_db": 6.0,
+                            "user_trim_db": -2.0,
+                            "enabled": True,
+                        }
+                    }
+                )
+            )
+            store = PatchNormalizationStore(user_path)
+            self.assertEqual(store.get_effective_gain_db("Lead"), 4.0)
+            self.assertEqual(store.get_user_trim_db("Lead"), -2.0)
+
+    def test_slider_default_is_zero_trim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_path = Path(tmp) / "user.json"
+            user_path.write_text(json.dumps({"Lead": {"gain_db": 6.0, "enabled": True}}))
+            store = PatchNormalizationStore(user_path)
+            self.assertEqual(store.get_slider_default_gain_db("Lead"), 0.0)
+
+    def test_set_user_trim_drops_legacy_user_gain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_path = Path(tmp) / "user.json"
+            user_path.write_text(json.dumps({"Lead": {"gain_db": 4.0, "user_gain_db": 8.0}}))
+            store = PatchNormalizationStore(user_path)
+            store.set_user_trim_db("Lead", -3.0)
+            store.save()
+            saved = json.loads(user_path.read_text())
+            self.assertEqual(saved["Lead"]["user_trim_db"], -3.0)
+            self.assertNotIn("user_gain_db", saved["Lead"])
+
+    def test_clear_user_trim_clears_both_legacy_and_trim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_path = Path(tmp) / "user.json"
+            user_path.write_text(
+                json.dumps({"Lead": {"gain_db": 6.0, "user_gain_db": 2.0, "enabled": True}})
+            )
+            store = PatchNormalizationStore(user_path)
+            store.clear_user_trim_db("Lead")
+            self.assertFalse(store.has_user_trim_override("Lead"))
+            self.assertEqual(store.get_effective_gain_db("Lead"), 6.0)
+
+    def test_legacy_migration_on_load_persisted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_path = Path(tmp) / "user.json"
+            user_path.write_text(
+                json.dumps({"Lead": {"gain_db": 6.0, "user_gain_db": 3.0, "enabled": True}})
+            )
+            store = PatchNormalizationStore(user_path)
+            self.assertEqual(store.get_user_trim_db("Lead"), -3.0)
+            saved = json.loads(user_path.read_text())
+            self.assertEqual(saved["Lead"]["user_trim_db"], -3.0)
+            self.assertNotIn("user_gain_db", saved["Lead"])
+
+    def test_extreme_v1_override_clamped_to_trim_ceiling(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_path = Path(tmp) / "user.json"
+            user_path.write_text(
+                json.dumps({"Lead": {"gain_db": 0.0, "user_gain_db": 24.0, "enabled": True}})
+            )
+            store = PatchNormalizationStore(user_path)
+            self.assertEqual(store.get_user_trim_db("Lead"), NORM_TRIM_DB_MAX)
+
+    def test_trim_clamp(self) -> None:
+        self.assertEqual(clamp_user_trim_db(-30.0), NORM_TRIM_DB_MIN)
+        self.assertEqual(clamp_user_trim_db(20.0), NORM_TRIM_DB_MAX)
+
+
+class RuntimeTrimTests(unittest.TestCase):
+    def test_trim_reaches_osc_send(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            user_path = Path(tmp) / "user.json"
+            user_path.write_text(
+                json.dumps(
+                    {
+                        "Lead": {
+                            "gain_db": 6.0,
+                            "user_trim_db": -2.0,
+                            "enabled": True,
+                        }
+                    }
+                )
+            )
+            store = PatchNormalizationStore(user_path)
+            loader = PatchLoader(normalization_store=store)
+            loader.osc_client = FakeOscClient()
+            loader.osc_enabled = True
+            loader.user_volume_trim = 1.0
+            loader.refresh_patch_volume("Lead")
+            sent = loader.osc_client.messages[-1][1]
+            self.assertAlmostEqual(sent, db_to_linear(4.0))
+
+
+class VolFaderLawTests(unittest.TestCase):
+    def test_default_is_console(self) -> None:
+        os.environ.pop("MPE_VOL_FADER_LAW", None)
+        self.assertEqual(volume_fader_law(), "console")
+
+    def test_linear_law_even_step_at_half(self) -> None:
+        os.environ["MPE_VOL_FADER_LAW"] = VOL_FADER_LAW_LINEAR
+        try:
+            half = VOLUME_MIN + 0.5 * (VOLUME_MAX - VOLUME_MIN)
+            db_half = volume_fader_trim_to_db(
+                half, fader_min=VOLUME_MIN, fader_max=VOLUME_MAX
+            )
+            db_top = volume_fader_trim_to_db(
+                VOLUME_MAX, fader_min=VOLUME_MIN, fader_max=VOLUME_MAX
+            )
+            assert db_half is not None and db_top is not None
+            self.assertLessEqual(abs((db_top - db_half) - 30.0), 3.0)
+        finally:
+            os.environ.pop("MPE_VOL_FADER_LAW", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_patch_normalization.py
+++ b/tests/test_patch_normalization.py
@@ -382,7 +382,8 @@ class PatchNormalizationStoreTests(unittest.TestCase):
             store = PatchNormalizationStore(user_path)
             self.assertEqual(store.get_effective_gain_db("Lead"), 3.0)
             self.assertEqual(store.get_calibrated_gain_db("Lead"), 6.0)
-            self.assertTrue(store.has_user_gain_override("Lead"))
+            self.assertEqual(store.get_user_trim_db("Lead"), -3.0)
+            self.assertTrue(store.has_user_trim_override("Lead"))
 
             loader = PatchLoader(normalization_store=store)
             loader.osc_client = FakeOscClient()
@@ -392,7 +393,7 @@ class PatchNormalizationStoreTests(unittest.TestCase):
             from patch_browser.patch_normalization import db_to_linear, NORM_MAX_AMP_VOLUME_LINEAR
 
             sent = loader.osc_client.messages[-1][1]
-            expected = min(db_to_linear(3.0), NORM_MAX_AMP_VOLUME_LINEAR)
+            expected = min(db_to_linear(3.0), NORM_MAX_AMP_VOLUME_LINEAR)  # 6 + (-3) trim
             self.assertAlmostEqual(sent, expected)
 
     def test_clear_user_gain_reverts_to_calibrated(self) -> None:
@@ -402,8 +403,8 @@ class PatchNormalizationStoreTests(unittest.TestCase):
                 json.dumps({"Lead": {"gain_db": 6.0, "user_gain_db": 2.0, "enabled": True}})
             )
             store = PatchNormalizationStore(user_path)
-            store.clear_user_gain_db("Lead")
-            self.assertFalse(store.has_user_gain_override("Lead"))
+            store.clear_user_trim_db("Lead")
+            self.assertFalse(store.has_user_trim_override("Lead"))
             self.assertEqual(store.get_effective_gain_db("Lead"), 6.0)
 
     def test_set_calibration_preserves_user_gain_override(self) -> None:
@@ -413,11 +414,12 @@ class PatchNormalizationStoreTests(unittest.TestCase):
             store = PatchNormalizationStore(user_path)
             store.set_calibration("Lead", 5.0, -20.0, true_peak_dbtp=-4.0)
             self.assertEqual(store.get_calibrated_gain_db("Lead"), 5.0)
-            self.assertEqual(store.get_effective_gain_db("Lead"), 8.0)
+            self.assertEqual(store.get_effective_gain_db("Lead"), 9.0)  # trim +4 preserved on re-cal
             store.save()
             saved = json.loads(user_path.read_text())
             self.assertEqual(saved["Lead"]["gain_db"], 5.0)
-            self.assertEqual(saved["Lead"]["user_gain_db"], 8.0)
+            self.assertEqual(saved["Lead"]["user_trim_db"], 4.0)
+            self.assertNotIn("user_gain_db", saved["Lead"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Cherry-pick port of patch normalization v2 from `yolo/patch-norm-v2`:

- `a93c97a` — cal integrity, Norm trim UX (+601/-76, 12 files)
- `948c781` — review fix: dual-anchor verify, dead code removal

**Dropped:** `f0de9d7` (committed ELF binary — dev builds via `make` in `native/`).

## Test plan

- [x] `mpe test local patch`
- [x] `mpe test local all`