### PR TITLE
Bound shutdown stop timeouts (DefaultTimeoutStopSec + peak meter)

### DIFF
--- a/Documents/specs/system-hygiene-baseline.md
+++ b/Documents/specs/system-hygiene-baseline.md
@@ -191,7 +191,8 @@ the primary next experiment.
 - `mpe-pressure-remap`: wait USB **and** ALSA MIDI; `Restart=no`; udev hot-plug restart
 - `mpe-irq-affinity.service` + movable IRQs → CPU1
 - `boot-assert-cmdline.sh` on jackd prestart
-- `apply-appliance-hygiene.sh`: timers masked, services pruned, USB PM on, WiFi PS off, HDMI disabled in cmdline
+- `apply-appliance-hygiene.sh`: timers masked, services pruned, USB PM on, WiFi PS off, HDMI disabled in cmdline; **DefaultTimeoutStopSec=10s** via `config/systemd/mpe-appliance.conf`
+- Shutdown: [`shutdown-timeout-fix-2026-08-21.md`](../docs/measurements/shutdown-timeout-fix-2026-08-21.md) — peak-meter `TimeoutStopSec=5`, interruptible SIGTERM
 
 *Last updated: 2026-08-21 (America/Toronto)*
 

--- a/config/mpe-peak-meter.service
+++ b/config/mpe-peak-meter.service
@@ -18,6 +18,9 @@ LimitMEMLOCK=infinity
 ExecStart=@MPE_MODULE_REPO@/scripts/start-mpe-peak-meter.sh
 Restart=on-failure
 RestartSec=3
+# JACK leaf client — must not inherit 90s default when jackd tears down first.
+TimeoutStopSec=5
+KillMode=mixed
 StandardOutput=journal
 StandardError=journal
 

--- a/config/systemd/mpe-appliance.conf
+++ b/config/systemd/mpe-appliance.conf
@@ -1,0 +1,11 @@
+# MPE appliance — bounded systemd stop timeouts.
+#
+# Installed to /etc/systemd/system.conf.d/mpe-appliance.conf by
+# scripts/apply-appliance-hygiene.sh (configure-pi-paths runs that script).
+#
+# Default upstream is 90s; a stuck user@ session or JACK leaf client should not
+# block poweroff for a minute. Per-unit overrides still apply (e.g. splash
+# TimeoutStopSec=infinity, peak-meter 5s).
+
+[Manager]
+DefaultTimeoutStopSec=10s

--- a/docs/SHUTDOWN.md
+++ b/docs/SHUTDOWN.md
@@ -1,6 +1,6 @@
 # Shutdown splash (touch DSI)
 
-*Last updated: 2026-07-31 (America/Toronto)*
+*Last updated: 2026-08-21 (America/Toronto)*
 
 Touch-panel shutdown follows the **Plymouth pattern**: a dedicated systemd unit paints the splash **before** `systemd-poweroff.service` runs, not an in-process pygame hold inside `touch-patch-browser`.
 
@@ -92,6 +92,8 @@ Compare stop durations across tests. A unit gap near its `TimeoutStopSec` (e.g. 
 
 **Common slow culprit:** `mpe-pressure-remap.service` and `surge-poly-governor.service` used to inherit systemd’s default **90s** stop timeout. They now ship with `TimeoutStopSec=5` — run `configure-pi-paths.sh --local --force` after pulling.
 
+**Global default (2026-08-21):** `config/systemd/mpe-appliance.conf` sets `DefaultTimeoutStopSec=10s` under `/etc/systemd/system.conf.d/` via `apply-appliance-hygiene.sh`. Stops `user@1000` and other unpinned units from waiting 90s. **`mpe-peak-meter.service`** was the missed MPE unit — now `TimeoutStopSec=5` plus interruptible SIGTERM in the binary (JACK leaf client on jackd shutdown).
+
 ## Diagnostic mode (skip splash, step trace)
 
 When shutdown feels stuck (~1 minute on the spinner):
@@ -133,4 +135,3 @@ Touch mode enables `mpe-shutdown-splash.service` via `scripts/lib/mpe-services.s
 ## Migration from `touch-shutdown-animation.service`
 
 Older touch images enabled `touch-shutdown-animation.service` (in-browser / legacy unit). That unit is **not** shipped in `config/` anymore. `configure-pi-paths.sh` disables it, removes a stale `/etc/systemd/system/touch-shutdown-animation.service` if present, and enables `mpe-shutdown-splash.service` in touch mode.
-

--- a/docs/measurements/shutdown-timeout-fix-2026-08-21.md
+++ b/docs/measurements/shutdown-timeout-fix-2026-08-21.md
@@ -1,0 +1,48 @@
+# Shutdown stop-timeout fix (2026-08-21)
+
+*No Pi measurement required — deploy + one labeled shutdown test.*
+
+## Symptom
+
+Poweroff/reboot felt stuck ~1 minute. Journal showed units sitting at their stop timeout:
+
+| unit | stop timeout |
+|---|---|
+| `mpe-peak-meter` | **90s** (inherited default — missed in prior pass) |
+| `user@1000` | 120s |
+| tailscaled, NetworkManager, wpa_supplicant, avahi, bluetooth | 90s each |
+
+MPE audio units were already bounded (jackd 10s, surge 15s, touch 10s, midi-clock 5s). **`DefaultTimeoutStopSec=90s`** globally is the rest.
+
+## Fix (repo)
+
+1. **`config/systemd/mpe-appliance.conf`** — `[Manager] DefaultTimeoutStopSec=10s`
+   - Installed by `apply-appliance-hygiene.sh` → `/etc/systemd/system.conf.d/mpe-appliance.conf`
+   - `systemctl daemon-reexec` when the file changes
+2. **`config/mpe-peak-meter.service`** — `TimeoutStopSec=5`, `KillMode=mixed`
+3. **`native/mpe-peak-meter/mpe-peak-meter.c`** — 100 ms interruptible waits so SIGTERM / `jack_on_shutdown` is not delayed by `sleep(1)` or 2 s connect polling
+
+Per-unit overrides unchanged (`mpe-shutdown-splash` = infinity).
+
+## Deploy
+
+```bash
+git pull   # on dev after merge
+sudo ./scripts/configure-pi-paths.sh --local --force
+# rebuild peak meter if binary changed:
+cd native/mpe-peak-meter && make && sudo cp mpe-peak-meter /usr/local/bin/
+sudo systemctl daemon-reload
+```
+
+## Verify (optional, ~2 min)
+
+```bash
+./scripts/shutdown-mark-test.sh ssh "post-timeout-fix"
+sudo systemctl poweroff
+# after boot:
+./scripts/shutdown-measure-last.sh
+```
+
+Expect `mpe-peak-meter` stop under 5s and no unit gap at 90s unless something else is still unpinned.
+
+*Last updated: 2026-08-21 (America/Toronto)*

--- a/native/mpe-peak-meter/mpe-peak-meter.c
+++ b/native/mpe-peak-meter/mpe-peak-meter.c
@@ -100,6 +100,24 @@ static void on_shutdown(void *arg)
     g_running = 0;
 }
 
+/* Poll g_running in 100 ms slices so SIGTERM/jack shutdown is not delayed by sleep(1). */
+static void wait_running(void)
+{
+    while (g_running) {
+        struct timespec ts = { .tv_sec = 0, .tv_nsec = 100000000L };
+        (void)nanosleep(&ts, NULL);
+    }
+}
+
+static void interruptible_usleep(useconds_t us)
+{
+    while (us > 0 && g_running) {
+        useconds_t chunk = us > 100000U ? 100000U : us;
+        usleep(chunk);
+        us -= chunk;
+    }
+}
+
 static int env_truthy(const char *value)
 {
     if (value == NULL || *value == '\0') {
@@ -249,7 +267,7 @@ static void *writer_thread(void *arg)
         int looper_playback = atomic_load_explicit(&g_looper_playback, memory_order_relaxed);
         unsigned long xruns = atomic_load_explicit(&g_xrun_count, memory_order_relaxed);
         write_meter_state(held_peak, surge_wired, looper_client, looper_playback, xruns);
-        usleep(WRITER_INTERVAL_US);
+        interruptible_usleep(WRITER_INTERVAL_US);
     }
     write_meter_state(0.0f, 0, 0, 0, atomic_load_explicit(&g_xrun_count, memory_order_relaxed));
     return NULL;
@@ -260,7 +278,7 @@ static void *connect_thread(void *arg)
     (void)arg;
     while (g_running) {
         ensure_wiring();
-        usleep(CONNECT_INTERVAL_US);
+        interruptible_usleep(CONNECT_INTERVAL_US);
     }
     return NULL;
 }
@@ -347,9 +365,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    while (g_running) {
-        sleep(1);
-    }
+    wait_running();
 
     pthread_join(connector, NULL);
     pthread_join(writer, NULL);

--- a/scripts/apply-appliance-hygiene.sh
+++ b/scripts/apply-appliance-hygiene.sh
@@ -133,4 +133,25 @@ else
     bash "$SCRIPT_DIR/apply-movable-irq-affinity.sh"
 fi
 
+echo "=== systemd manager stop timeout (DefaultTimeoutStopSec=10s) ==="
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MANAGER_SRC="$REPO_ROOT/config/systemd/mpe-appliance.conf"
+MANAGER_DST="/etc/systemd/system.conf.d/mpe-appliance.conf"
+if [ -f "$MANAGER_SRC" ]; then
+    if [ "$DRY" = true ]; then
+        echo "would: install $MANAGER_SRC -> $MANAGER_DST"
+    else
+        _run mkdir -p /etc/systemd/system.conf.d
+        if [ ! -f "$MANAGER_DST" ] || ! cmp -s "$MANAGER_SRC" "$MANAGER_DST"; then
+            _run cp "$MANAGER_SRC" "$MANAGER_DST"
+            echo "installed $MANAGER_DST (DefaultTimeoutStopSec=10s)"
+            _run systemctl daemon-reexec
+        else
+            echo "systemd manager conf already current"
+        fi
+    fi
+else
+    echo "warn: missing $MANAGER_SRC" >&2
+fi
+
 echo "apply-appliance-hygiene: done"


### PR DESCRIPTION
## Summary

- Set global `DefaultTimeoutStopSec=10s` via `config/systemd/mpe-appliance.conf` (installed by `apply-appliance-hygiene.sh`)
- Bound `mpe-peak-meter.service` to `TimeoutStopSec=5` + `KillMode=mixed` — the MPE unit missed in the prior shutdown pass
- Peak meter binary: 100 ms interruptible waits so SIGTERM / `jack_on_shutdown` is not delayed by `sleep(1)` or 2 s connect polling

Diagnosis: [`docs/measurements/shutdown-timeout-fix-2026-08-21.md`](docs/measurements/shutdown-timeout-fix-2026-08-21.md)

## Test plan

- [ ] `cd native/mpe-peak-meter && make` (laptop)
- [ ] Pi: `sudo ./scripts/configure-pi-paths.sh --local --force` (installs manager conf + unit)
- [ ] Rebuild/install peak meter binary on Pi if enabled
- [ ] Optional: `./scripts/shutdown-mark-test.sh ssh "post-timeout-fix"` then `shutdown-measure-last.sh` after reboot — expect no 90s unit gaps
