### PR TITLE
Fix CI calibrate MIDI test (verify_only mock)

### DIFF
--- a/tests/test_calibrate_midi.py
+++ b/tests/test_calibrate_midi.py
@@ -73,6 +73,7 @@ class CalibrateMidiReuseTests(unittest.TestCase):
                 folder=None,
                 limit=0,
                 force=False,
+                verify_only=False,
                 no_touch_cal=False,
                 patch=None,
                 mock_lufs=None,


### PR DESCRIPTION
## Summary

- CI unittest job failed on `test_calibrate_midi.CalibrateMidiReuseTests.test_main_closes_shared_midi_out_when_opened`
- The mocked `parse_args` return value omitted `verify_only`; unset `Mock` attributes are truthy, so `main()` entered the `--verify-only` branch and called real `ffmpeg` capture
- GitHub runners have no `ffmpeg`; the laptop does, so the failure only showed up in CI

## Test plan

- [x] `mpe test calibration` passes locally
- [x] `mpe test` full suite passes locally
- [ ] CI Tests workflow green on this PR