### PR TITLE
Merge Scarlett measurement arc: doctrine, W1/V7 harnesses, findings

### DIFF
--- a/.claude/skills/measurement-design/SKILL.md
+++ b/.claude/skills/measurement-design/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: measurement-design
+description: Design or review a measurement on the MPE appliance (xrun runs, latency ladders, DSP load, soaks, cyclictest, IRQ census). Use before opening any Pi measurement window, before writing a measurement prompt for another agent, and when interpreting results. Enforces cheap-check-first ordering, per-cell pre-registration, and instrument audits.
+---
+
+# Measurement design (MPE appliance)
+
+Pi time is expensive and Mitch has explicitly said he is tired of multi-hour tests followed
+by "I made a design error." **The job here is to prevent that, not to be thorough.** More
+cells is not more rigour.
+
+Full reasoning: [`docs/measurements/MEASUREMENT-DISCIPLINE.md`](../../../docs/measurements/MEASUREMENT-DISCIPLINE.md).
+Instrument self-test history: `AGENTS.md` -> "Self-test the instrument before it costs him anything".
+
+## The failure this prevents
+
+**An inference gets promoted to a premise without anyone paying to confirm it.** The
+confirming check is nearly always an order of magnitude cheaper than the test that
+eventually exposes the error.
+
+## Step 1 — cheap check first (do not skip)
+
+**Is there a free or offline check that could make this window unnecessary, or that its
+interpretation depends on?** Do that first.
+
+Free checks that have each invalidated hours of Pi time: reading the instrument's source;
+`systemctl`/service survey; re-analysing existing logs per-stream; `git merge-base` on a
+branch believed to contain a fix; arithmetic on the config (period rate, cushion size,
+byte rate).
+
+If such a check exists and has not been done, **stop and do it.**
+
+## Step 2 — pre-register the cell
+
+Write this into the measurement doc **before** running:
+
+```
+## Pre-registration
+Question:       <the one thing this cell decides>
+Claim class:    rate | shape | ranking
+n:              <streams x runs>
+Premises:       | premise | verified how | when |
+Instruments:    <what each counts; when last audited>
+Prediction:     <expected value, written before the run>
+Falsifier:      <what result would make me abandon the hypothesis>
+Cheaper check:  <what free check was considered, and why it is insufficient>
+```
+
+**Prediction and Falsifier are load-bearing.** If you cannot say what would surprise you,
+the cell is not designed. A hypothesis with no disconfirming outcome is being illustrated,
+not tested.
+
+## Step 3 — audit every instrument before it informs a decision
+
+Two questions, both in writing, dated:
+
+1. **What exactly increments it?** Read the source. *What reading would this produce if it
+   were broken?* If that matches a healthy reading, it is not an instrument.
+2. **Is its resolution sufficient?** A sampler below the Nyquist rate of its signal produces
+   an authoritative-looking trace with the answer removed.
+
+**Period rates on this box:** 47 Hz at 1024, 94 Hz at 512, 188 Hz at 256.
+
+Known instrument facts (do not re-derive):
+
+| instrument | what it actually is |
+|---|---|
+| `mpe-xrun-probe` xrun count | event count, **no magnitude**; conflates ALSA underruns with JACK graph overruns |
+| probe `frames_late` | inter-callback jitter — **not** whether the graph finished computing |
+| jackd journal `ALSA: xrun of at least N msecs` | genuine ALSA underruns **with magnitude**; free, post-hoc |
+| `/proc/asound/card<N>/pcm0p/sub0/status` | `appl_ptr - hw_ptr` = fill level; **takes the substream lock** — perturbs the path it observes |
+
+## Step 4 — check the observer effect
+
+Any instrument that runs **during** a window is a perturbation until proven otherwise.
+
+- No subprocess forks in polling loops (CPU doctrine).
+- Pin off the audio cores (2-3) and off CPU0 (unmovable xhci IRQ) — use CPU1.
+- `SCHED_OTHER`, `nice 19`.
+- **Run a with/without control cell** and report it either way. "We checked and it was clean"
+  is a finding.
+
+Post-hoc capture (journal, log parsing) costs nothing during the window. Prefer it.
+
+## Step 5 — claim class and n
+
+| claim | needs |
+|---|---|
+| **rate** ("this config gives X/min") | a few runs in one stream |
+| **shape** ("bimodal"/"unimodal") | **>= 10 streams** with `--restart-between` |
+| **ranking** ("A beats B") | intervals reported, not just means |
+
+Stream-start variance is large and real on this box
+(`docs/measurements/stream-start-variance-2026-08-21.md`). Report **within-stream sd and
+between-stream sd separately.** Small-n shape claims have already produced two contradictory
+conclusions in one session.
+
+## Step 6 — one variable, proven on paper
+
+**Write both configs side by side and list every quantity that differs.** If more than one
+differs, it is not a comparison. Remember that changing period changes the deadline, the
+cushion, the USB frame alignment and the DSP efficiency simultaneously.
+
+If a bundle is genuinely worth it (to save reboots), **say so in the doc**: a bundle cannot
+attribute effect to cause.
+
+## Step 7 — record actual state, not intended state
+
+Results must never be attributable to a config they were not run under. Stamp into the result
+file: period, nperiods, rate, device + **resolved card index** (it moves between boots),
+IRQ priorities/affinities, module params, kernel cmdline, git SHA.
+
+"I applied it earlier" is not a record.
+
+## Step 8 — writing a prompt for another agent
+
+Open with two lists, always:
+
+- **Already dead — do not re-test.** Without this, refuted hypotheses return.
+- **Parked, and why.**
+
+Then: read-first docs, the pre-registration block, explicit interpretation branches ("state
+which row you landed in"), and a **hard stop** before anything that changes config.
+
+Standing constraints to restate in every prompt:
+- Never run commands against the Pi while a window is open — including read-only ones.
+- Resolve the card index live; never hardcode it.
+- No forks in periodic loops.
+- Report n, and the claim class it supports.
+
+## Anti-patterns
+
+| smell | why it is wrong |
+|---|---|
+| "run a longer soak to be sure" | duration rarely buys what design does; 8-hour soaks were cut for this reason |
+| "more cells = more rigour" | Mitch pushed back on exactly this, correctly |
+| "the metric went down, so it worked" | check n and claim class first — three streams cannot establish shape |
+| "we applied that earlier" | verify at measurement time (Step 7) |
+| "this is read-only so it is free" | reading `/proc/asound` takes a driver lock; SSH forks processes |

--- a/.claude/skills/measurement-design/SKILL.md
+++ b/.claude/skills/measurement-design/SKILL.md
@@ -44,11 +44,40 @@ Instruments:    <what each counts; when last audited>
 Prediction:     <expected value, written before the run>
 Falsifier:      <what result would make me abandon the hypothesis>
 Cheaper check:  <what free check was considered, and why it is insufficient>
+Shortest form:  <the shortest version of this test that would still change the decision>
+Why not that:   <justification for anything longer — required if the two differ>
 ```
 
 **Prediction and Falsifier are load-bearing.** If you cannot say what would surprise you,
 the cell is not designed. A hypothesis with no disconfirming outcome is being illustrated,
 not tested.
+
+### Always ask: what is the shortest useful version of this test?
+
+**The shortest version is not necessarily the right one — but it must be asked and answered,
+and any gap between it and what you run must be justified in writing.** This is a standing
+requirement from Mitch, added after a run of tests that were longer than their conclusions
+needed.
+
+Test bloat is the default failure: a window gets sized by habit rather than by what it has
+to resolve. The 8-hour soaks were cut for exactly this reason and nothing was lost.
+
+**Size the window from the expected event rate, not from convention.** To observe ~30 events:
+
+| expected rate | window needed |
+|---|---|
+| 2776/min (64 frames) | **~1 second** |
+| 112/min | ~15 s |
+| 12/min | ~2.5 min |
+| 0.13/min (512 cond A) | **~4 hours** — or change the metric, because this is not a rate you can measure in a window |
+
+That last row is the important one: when the shortest useful version is implausibly long,
+**that is a signal the metric is wrong for the question**, not a reason to run a soak. Look
+for a metric with a higher event rate — fill level, DSP p99, magnitudes — or a comparison
+that does not require counting rare events.
+
+Ask the same of **n**: three streams cannot establish shape, but ten runs inside one stream
+will not either. Spend the samples where the variance actually is.
 
 ## Step 3 — audit every instrument before it informs a decision
 
@@ -137,3 +166,5 @@ Standing constraints to restate in every prompt:
 | "the metric went down, so it worked" | check n and claim class first — three streams cannot establish shape |
 | "we applied that earlier" | verify at measurement time (Step 7) |
 | "this is read-only so it is free" | reading `/proc/asound` takes a driver lock; SSH forks processes |
+| a 60 s window because the last one was 60 s | size it from the expected event rate (Step 2) |
+| a soak to measure a 0.13/min rate | the metric is wrong for the question — find one with a higher event rate |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,3 +245,28 @@ any measurement involves him:
    same thing whether it worked or not.
 
 A remote command that returns no output is not evidence that it ran.
+
+### And a working instrument can still be the wrong one
+
+The rule above catches an instrument that returns **nothing**. On 2026-08-21 we hit the
+other half: instruments that return **confident, plausible numbers that do not mean what we
+assumed.** Both would have passed every check in the previous section.
+
+| instrument | produced | actually meant |
+|---|---|---|
+| `mpe-xrun-probe` xrun count | non-zero every run, self-tests clean | an **event count with no magnitude**, conflating ALSA underruns with JACK graph overruns — see `docs/measurements/xrun-counter-audit-2026-08-21.md` |
+| proposed 10-20 Hz fill poller | a smooth, legible trace | **sub-Nyquist** against period rates of 47/94/188 Hz — a confident trace of nothing |
+
+So two more checks, before an instrument informs any decision:
+
+4. **Audit what it actually counts**, in writing, dated. One-time cost per instrument.
+   Ask: *what reading would this produce if it were broken?* If that matches a healthy
+   reading, it is not an instrument.
+5. **Check its resolution against the signal.** A sampler below the Nyquist rate of the
+   thing it measures yields an authoritative-looking trace with the answer removed.
+
+**Full doctrine: [`docs/measurements/MEASUREMENT-DISCIPLINE.md`](docs/measurements/MEASUREMENT-DISCIPLINE.md)**
+— cheap-check-first ordering, per-cell pre-registration (prediction **and** falsifier written
+before the run), claim classes and minimum n, and the requirement that the harness stamp
+**actual** state into every result rather than intended state. Read it before designing a
+measurement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,16 @@ So two more checks, before an instrument informs any decision:
    reading, it is not an instrument.
 5. **Check its resolution against the signal.** A sampler below the Nyquist rate of the
    thing it measures yields an authoritative-looking trace with the answer removed.
+6. **Ask what the shortest useful version of the test is**, and justify anything longer in
+   writing. Size windows from the **expected event rate**, not convention — ~30 events takes
+   ~1 s at 2776/min but ~4 hours at 0.13/min. When the shortest useful version comes out
+   implausibly long, **the metric is wrong for the question**, not a reason to run a soak.
+
+**Before designing any measurement, invoke the `measurement-design` skill**
+(`.claude/skills/measurement-design/SKILL.md`). It carries the checklist, the audited
+instrument facts, and the rules for writing a measurement prompt for another agent — use it
+before opening a Pi window, before handing a prompt to an agent, and when interpreting
+results.
 
 **Full doctrine: [`docs/measurements/MEASUREMENT-DISCIPLINE.md`](docs/measurements/MEASUREMENT-DISCIPLINE.md)**
 — cheap-check-first ordering, per-cell pre-registration (prediction **and** falsifier written

--- a/docs/measurements/MEASUREMENT-DISCIPLINE.md
+++ b/docs/measurements/MEASUREMENT-DISCIPLINE.md
@@ -49,7 +49,20 @@ Instruments:       <what each one actually counts, and when that was last audite
 Prediction:        <expected value, written down before the run>
 Falsifier:         <what result would make me abandon the hypothesis>
 Cheaper check:     <what free/offline check was considered and why it is insufficient>
+Shortest form:     <shortest version that would still change the decision>
+Why not that:      <justification for running anything longer>
 ```
+
+**Always ask what the shortest useful version of this test is.** The shortest is not
+necessarily optimal — but it must be asked, answered, and any gap justified in writing.
+Test bloat is the default: windows get sized by habit, not by what they must resolve.
+
+Size the window from the **expected event rate**, not convention. To see ~30 events at
+2776/min takes ~1 second; at 112/min ~15 s; at 12/min ~2.5 min; **at 0.13/min ~4 hours.**
+When the shortest useful version comes out implausibly long, that is evidence **the metric is
+wrong for the question** — not a reason to run a soak. Switch to a metric with a higher event
+rate (fill level, DSP p99, ALSA magnitudes) or to a comparison that does not require counting
+rare events.
 
 **"Prediction" is the load-bearing line.** If you cannot say what would surprise you, the
 cell is not designed yet. **"Falsifier" is second** — a hypothesis with no disconfirming
@@ -120,6 +133,7 @@ be re-argued.
 
 ## The half-page version
 
+0. Ask the shortest useful version of the test. Justify anything longer.
 1. Cheap check before expensive window. Always.
 2. Write the prediction and the falsifier before the run.
 3. Audit the instrument before its first decision.

--- a/docs/measurements/MEASUREMENT-DISCIPLINE.md
+++ b/docs/measurements/MEASUREMENT-DISCIPLINE.md
@@ -1,0 +1,130 @@
+# Measurement discipline — how to stop re-learning the same lesson
+
+Written 2026-08-21 after a session in which **every** wasted measurement traced to one move.
+
+## The pattern
+
+**An inference gets promoted to a premise without anyone paying to confirm it.**
+
+The confirming check is almost always **cheaper than the test that eventually exposes the
+error** — usually by an order of magnitude.
+
+| assumed | cost to check | cost of not checking |
+|---|---|---|
+| the xrun counter means "the buffer emptied" | 5 min, offline | most of a session's interpretation |
+| E1 was reverted on `plan/t7-sequence` | one `git merge-base` | a test run on the wrong config |
+| 192 vs 256 isolates frame alignment | re-read T13 | one full confounded run (T12) |
+| Scarlett unimodal ⇒ adaptive clock lock | note that n=3 | a conclusion withdrawn hours later |
+| the HDMI cmdline change applied | one post-reboot check | still partial; found by accident |
+| 10 Hz resolves the fill trace | period-rate arithmetic | a trace that shows nothing, convincingly |
+
+The last one was written *while* documenting the others. **Naming the pattern does not stop
+it. A mechanism does.**
+
+## Rule 0 — cheap-first, always
+
+**Before opening any measurement window, ask: is there a free or offline check that could
+make this window unnecessary?**
+
+This session's four highest-value findings all came from free checks, not from Pi time:
+the counter audit (offline), the service survey (3 min), the per-run stream re-analysis
+(existing data), the branch containment check (`git merge-base`).
+
+If an offline check exists and has not been done, **do it first.** Not as a courtesy — the
+expensive test keeps discovering what the cheap check would have.
+
+## Rule 1 — pre-register every cell
+
+Fill this in **before** running. It is short on purpose; a checklist nobody completes is
+worthless.
+
+```
+## Pre-registration
+Question:          <the one thing this cell decides>
+Claim class:       rate | shape | ranking
+n:                 <streams x runs>   (shape claims need n >= 10 streams)
+Premises:          <what must be true for the result to mean anything>
+                   | premise | verified how | when |
+Instruments:       <what each one actually counts, and when that was last audited>
+Prediction:        <expected value, written down before the run>
+Falsifier:         <what result would make me abandon the hypothesis>
+Cheaper check:     <what free/offline check was considered and why it is insufficient>
+```
+
+**"Prediction" is the load-bearing line.** If you cannot say what would surprise you, the
+cell is not designed yet. **"Falsifier" is second** — a hypothesis with no disconfirming
+outcome is not being tested, it is being illustrated.
+
+## Rule 2 — audit an instrument before its first decision, not after a surprise
+
+Any metric used to make a decision needs a **written statement of exactly what increments
+it**, dated. One-time cost per instrument; it never has to be paid again.
+
+Apply the [measurement-integrity](../../MEMORY.md) test to each:
+
+> **What reading would this instrument produce if it were broken?**
+> If that is the same as a healthy reading, it is not an instrument.
+
+Also check its **resolution against the thing it measures**. A sampler below the Nyquist
+rate of its signal produces a confident, empty trace. Period rates: 47 Hz at 1024, 94 Hz at
+512, 188 Hz at 256.
+
+## Rule 3 — the harness records actual state, never intended state
+
+A result must never be attributable to a configuration it was not run under.
+
+The harness should stamp into every result file: period, nperiods, sample rate, device and
+**resolved card index**, IRQ priorities and affinities, relevant module parameters, kernel
+cmdline, and git SHA. `boot-assert-cmdline.sh` already does this for cmdline — **generalise
+it.**
+
+"I applied it earlier" is not a record. E1 and the partial HDMI disable were both this.
+
+## Rule 4 — declare the claim class, and respect n
+
+| claim | needs |
+|---|---|
+| **rate** ("this config gives X/min") | a few runs within one stream |
+| **shape** ("bimodal", "unimodal") | **>= 10 streams**, with `--restart-between` |
+| **ranking** ("A beats B") | overlapping intervals reported, not just means |
+
+Three streams cannot establish shape. Step 1 claimed unimodal and Step 4 claimed bimodal,
+both on small n, and the two claims fought each other for no reason.
+
+**Report within-stream sd and between-stream sd separately.** Stream-start variance is a
+real, large effect on this box (`stream-start-variance-2026-08-21.md`).
+
+## Rule 5 — one variable, and prove it on paper first
+
+Before running a comparison, **write out every quantity that differs between the two cells.**
+If more than one differs, it is not a comparison.
+
+T12 changed period size *and* alignment while explicitly testing alignment — designed by the
+same person enforcing the one-variable rule on everyone else. Writing the two configs side
+by side would have caught it in thirty seconds.
+
+## Rule 6 — a bundle is not an experiment
+
+Multiple simultaneous changes are sometimes worth it to save reboots. That is fine, **as long
+as the doc says so**: a bundle cannot attribute effect to cause. Attribution has to come from
+the clean single-variable cells that justified each element.
+
+Step 3 was labelled this way deliberately. Keep doing that.
+
+## Rule 7 — retire dead lines loudly, in one place
+
+Every prompt should open with **"already dead — do not re-test"** and **"parked, and why."**
+Without it, refuted hypotheses come back: `lowlatency=N` was demoted, resurrected on a new
+mechanism, then killed properly; the aligned-period table was closed, withdrawn, and had to
+be re-argued.
+
+## The half-page version
+
+1. Cheap check before expensive window. Always.
+2. Write the prediction and the falsifier before the run.
+3. Audit the instrument before its first decision.
+4. Harness records actual state, not intended state.
+5. Declare claim class; shape needs n >= 10.
+6. Write both configs side by side before calling it one variable.
+7. Say when something is a bundle.
+8. List what is dead at the top of every prompt.

--- a/docs/measurements/MEASUREMENT-DISCIPLINE.md
+++ b/docs/measurements/MEASUREMENT-DISCIPLINE.md
@@ -128,3 +128,21 @@ be re-argued.
 6. Write both configs side by side before calling it one variable.
 7. Say when something is a bundle.
 8. List what is dead at the top of every prompt.
+
+---
+
+## Relationship to AGENTS.md
+
+`AGENTS.md` has carried **"Self-test the instrument before it costs him anything"** since
+2026-08-19, written after 382 pad taps produced zero samples. That rule catches an instrument
+returning **nothing**.
+
+**We fell into the trap again on 2026-08-21 anyway**, because the new failures were the other
+half: instruments returning **confident, plausible numbers that meant something else.** The
+xrun counter self-tested clean and passed every existing check — it simply counted a
+different thing. A 10-20 Hz fill poller would have produced a smooth, legible trace with the
+answer aliased out.
+
+That is why Rule 2 above adds **semantics** and **resolution** to the existing checks, rather
+than restating them. The two documents are one doctrine: AGENTS.md holds the short form at
+the point of use; this file holds the reasoning and the per-cell mechanics.

--- a/docs/measurements/PLAN-2026-08-21-evening.md
+++ b/docs/measurements/PLAN-2026-08-21-evening.md
@@ -196,3 +196,47 @@ Step 4's own read stands as recorded: mean below baseline but shape unstable at 
 **`threadirqs` cost is neither confirmed nor ruled out.** Do not re-run it to settle that —
 under the cushion model and the counter audit, xruns/min may not be the right term at all.
 Settle the term first (D+A), then decide whether the question is worth re-asking.
+
+---
+
+## Naming reconciliation + the instrumented window (definitive)
+
+**Phase labels collided.** This doc's original Phases A/B/C/D were re-lettered in a later
+status report (its "A" meant fill telemetry, this doc's Phase B). **Use the table below as
+the single source of truth. Ignore bare letters in older messages.**
+
+### The instrumented window — run all four together, not separately
+
+The next measurement window must carry **four** instruments simultaneously. Each alone
+leaves the exact ambiguity this session has been stuck in.
+
+| # | instrument | status | answers |
+|---|---|---|---|
+| 1 | probe `XRUN_COUNT` (`jack_set_xrun_callback`) | existing | how many events |
+| 2 | **`journalctl -u mpe-jackd` -> `ALSA: xrun of at least N msecs`** | **MISSING — add** | **how many were genuine ALSA underruns, and their magnitude** |
+| 3 | **fill level `appl_ptr - hw_ptr` @ 10-20 Hz** from `/proc/asound/card<N>/pcm0p/sub0/status` | **MISSING — add** | did the buffer drain, and in what shape |
+| 4 | `dsp_p99` | existing | was the compute deadline the binding term |
+
+**Instrument 2 is free** — jackd already emits those lines; the harness has simply never
+captured its stderr or journal. **Add it to the harness permanently, not just for this run.**
+Resolve the card index live for instrument 3 (it moved 6 -> 2 after the Step 3 reboot).
+
+### Joint readings
+
+| pattern | conclusion |
+|---|---|
+| #1 = N, **#2 = 0** | all **graph overruns** — the cushion was never in play; compute problem |
+| #2 non-zero **with magnitudes**, #3 shows matching drain | genuine underruns — drain model applies |
+| #2 non-zero but **#3 flat** | contradiction — chase hard, something is misreporting |
+| **#3 flat + #4 ~89%** | **P3 and compute-bound together** — retires the ~600 us line as a wrong-term pursuit |
+
+### Cells
+
+| # | cell | Pi time |
+|---|---|---|
+| **W1** | Instrumented window at **1024 / 512 / 256**, identical load, cond A (DSP ladder + all four instruments) | ~20 min |
+| **W2** | nperiods sweep **2/3/4/6** at period 1024, same four instruments | ~30 min |
+| **W0** | `1024 x 2` open-check — does ALSA accept it at all? | ~30 s, any idle moment |
+
+Run **W1** first. It can settle the metric question and the compute question in one pass, and
+either outcome changes whether W2 is worth running.

--- a/docs/measurements/PLAN-2026-08-21-evening.md
+++ b/docs/measurements/PLAN-2026-08-21-evening.md
@@ -140,3 +140,59 @@ without touching the period, which is the variable that has failed every time it
 | D | ~15 min |
 | step 4 (in flight) | ~12 min |
 | **total** | **~1 h 40 min**, gated — A can cancel B and C entirely |
+
+---
+
+## Amendment after Step 4 (2026-08-21, late)
+
+### Withdrawn: the Step 1 alignment closure
+
+`scarlett-verdict-2026-08-21.md` closed the alignment question on *"bimodality vanished on
+the async Scarlett, therefore the Sound Blaster's stream-start lottery was adaptive clock
+lock, not frame phase."*
+
+**Step 4 shows bimodality on that same async Scarlett** — stream 01 at 105/min against
+streams 02-03 at 26-34/min. **The evidence that closure rested on is gone. Withdraw it.**
+
+Two things stop this from reopening the line:
+
+1. **n=3 streams cannot establish distribution shape.** One-high/two-low out of three draws
+   is unremarkable from a bimodal *or* a wide unimodal distribution. Step 4 supports neither
+   claim, and its 55.0/min mean is not a reliable estimate from three streams.
+2. **The arithmetic argues against alignment regardless.** At high speed a microframe is
+   125 us = **6 samples**. On the Scarlett: 256/6 = 42.67, 512/6 = 85.33,
+   **1024/6 = 170.67** — *every* buffer we run is misaligned, **including the one with zero
+   xruns**. If frame phase were the driver, 1024 would not be clean.
+
+**Status: alignment moves from "closed" to "unsupported, still unpromising."** Do not spend
+Pi time on it. Phase B telemetry shows the mechanism directly instead of by inference.
+
+### Strengthened: the compute-bound hypothesis
+
+`dsp_p99` at **256 x 3 cond A** (no `midi-load`): **63-89%**.
+Prior at **1024 x 3 cond A**: **34.8%**.
+
+**This is the matched-condition comparison Phase D was meant to obtain — and two of its
+three points already exist.** A 2-2.5x efficiency loss from 1024 -> 256 is what fixed
+per-callback costs predict: graph traversal, parameter smoothing and block setup do not
+shrink with the buffer, so they amortise over fewer samples.
+
+At p99 = 89% there is **11% headroom**. Type-(b) graph overruns (see
+`xrun-counter-audit-2026-08-21.md`) are not a hypothesis at that point — they are expected.
+
+### Revised order
+
+**Fold Phase A into Phase D's window.** One pass gives the DSP ladder *and* the
+`appl_ptr - hw_ptr` trace at each buffer size — strictly more informative than either alone.
+A flat fill trace alongside p99 = 89% is **P3 and compute-bound in the same picture**.
+
+| # | cell | Pi time |
+|---|---|---|
+| **D+A** | DSP p99 **and** fill telemetry at 1024 / 512 / 256, identical load, cond A | ~20 min |
+| **B** | nperiods sweep 2/3/4/6 at period 1024 | ~30 min |
+| **—** | `1024 x 2` open-check: does ALSA accept it at all? | **~30 s**, any idle moment |
+
+Step 4's own read stands as recorded: mean below baseline but shape unstable at n=3, so
+**`threadirqs` cost is neither confirmed nor ruled out.** Do not re-run it to settle that —
+under the cushion model and the counter audit, xruns/min may not be the right term at all.
+Settle the term first (D+A), then decide whether the question is worth re-asking.

--- a/docs/measurements/PLAN-2026-08-21-evening.md
+++ b/docs/measurements/PLAN-2026-08-21-evening.md
@@ -1,0 +1,142 @@
+# Plan — after the cushion model and the counter audit (2026-08-21 evening)
+
+**Supersedes** `Documents/specs/queue-2026-08-21-evening.md` and the remaining cells in
+`PROMPT-find-the-600us.md` (Steps 0-3 are done; step 4 is in flight; 4b is dropped).
+
+## Why the plan changed
+
+Two results in the last hour moved the ground:
+
+1. **`cushion-model-2026-08-21.md`** — the ring buffer level is **self-restoring**.
+   `fill_after(k) = fill_0 + d_0 - d_k`: it depends on the *current* delay only, not on
+   history. So producer lateness cannot accumulate, and emptying a 42.7 ms cushion would
+   need a **single** 42.7 ms stall. Worst measured: **429 us**.
+2. **`xrun-counter-audit-2026-08-21.md`** — our xrun counter is an **event count with no
+   magnitude**, and it **conflates ALSA underruns with JACK graph overruns**. The second
+   does not require the buffer to drain at all.
+
+Together: **we do not currently know what our primary metric measures.** Everything else is
+downstream of fixing that.
+
+## Phase A — make the metric mean something (do first; mostly free)
+
+| # | task | Pi time | blocks |
+|---|---|---|---|
+| A1 | Harness captures `journalctl -u mpe-jackd` per window; report ALSA `xrun of at least N msecs` lines **and** magnitudes beside the probe count | 0 (offline) | everything |
+| A2 | Retro-check: do journals survive for T5 / T11 / T13 / Scarlett runs? If so, recompute the type-(a)/type-(b) split for free | ~5 min, read-only | — |
+| A3 | Confirm the installed jackd's xrun-callback conditions against its actual source/version | ~5 min | the two-condition claim |
+
+**Gate A.** For any past or new window:
+
+| probe count vs jackd ALSA lines | conclusion |
+|---|---|
+| equal, with magnitudes | genuine underruns — drain model applies, cushion matters |
+| **jackd lines = 0** | **all graph overruns** — cushion size is irrelevant; this is a **compute** problem, not a latency-path problem |
+| mixture | the split is the number that matters; report it every run from here |
+
+**If Gate A returns "all graph overruns," Phases B and C are unnecessary** and the work moves
+wholesale to Phase D. Check before spending Pi time.
+
+## Phase B — observe the buffer directly (~30 min)
+
+Stop inferring buffer state from a counter. Read it.
+
+`/proc/asound/card<N>/pcm0p/sub0/status` exposes `hw_ptr` and `appl_ptr`; their difference
+**is** the fill level. Poll at 10-20 Hz, log beside the xrun counter. Resolve the card index
+live — it moved 6 -> 2 after the Step 3 reboot.
+
+| # | cell | Pi time |
+|---|---|---|
+| B1 | fill telemetry, `1024 x 3` cond A | ~15 min |
+| B2 | fill telemetry, `256 x 3` cond A | ~15 min |
+
+**Gate B — read the trace shape:**
+
+| trace | model | consequence |
+|---|---|---|
+| flat, sub-ms dips, xruns anyway | **P3** counter artifact | go to Phase D |
+| descending sawtooth, resets at xrun | **P2** constant clock mismatch | rate-matching work; cushion matters |
+| random walk down to zero, no cadence | **P2'** feedback/rate-matching noise | control-loop work; cushion matters |
+| flat then one cliff | **P1** giant stall | capture what ran; back to RT tuning |
+
+If B1 hasn't started when step 4 runs, **fold the poll into step 4's window** — read-only,
+negligible cost, one window saved.
+
+## Phase C — sweep the cushion, not the period (~30 min)
+
+Every cell to date swept **period** at fixed `n=3`, moving deadline and cushion together.
+Invert it: **fix period at 1024** (deadline 21.3 ms — the load Surge already meets with zero
+xruns) and vary only `MPE_JACK_PERIODS`. No reboot, no kernel change.
+
+| `n` | cushion | total latency | P2 predicts | P2' predicts | P3 predicts |
+|---|---|---|---|---|---|
+| 2 | 21.3 ms | **42.7 ms** | 2.0x | 4.0x | flat |
+| 3 | 42.7 ms | 64.0 ms | baseline | baseline | flat |
+| 4 | 64.0 ms | 85.3 ms | 0.67x | 0.44x | flat |
+| 6 | 106.7 ms | 128.0 ms | 0.40x | 0.16x | flat |
+
+**Linear vs quadratic vs flat** is a real discriminator — the first test shape in this
+project that separates its candidate models by curve rather than by a single comparison.
+
+**`n=2` has never been tested** — every doc is x3, x6 or x8. It may simply refuse to open
+(`snd-usb-audio` conventionally wants >=3); that is a 30-second answer. **If it holds, it is
+21.3 ms off the shipping latency for free**, with no change to the compute deadline.
+
+## Phase D — the compute question (~15 min, needed regardless)
+
+`dsp_p99 ~= 92%` was recorded at 256 under `midi-load`, against 34.8% (1024) and 37.5% (512)
+under the standard 75-voice load. **Different loads — the comparison is not yet valid.**
+
+| # | cell | Pi time |
+|---|---|---|
+| D1 | DSP p99 at 1024 / 512 / 256, **identical** load, cond A | ~15 min |
+
+**Gate D:**
+- **flat ~35% across all three** -> 92% was a load artifact; the latency path stays live
+- **climbing toward ~92% at 256** -> **256 is compute-bound.** Per-callback fixed costs
+  (graph traversal, parameter smoothing, block setup) do not shrink with the buffer. No
+  amount of IRQ or scheduler tuning recovers a buffer with 8% headroom. The levers become
+  voice count, patch complexity, or accepting 512/1024 as the floor.
+
+Gate D matters whichever way Gate A lands, and it directly explains Mitch's ear test
+(*512 crackles on heavy patches*).
+
+## Parked — and why
+
+| item | reason |
+|---|---|
+| `irq/30` at FF 90 (cell 4b) | targets producer lateness; the cushion arithmetic says sub-ms lateness cannot empty a 42.7 ms buffer |
+| `isolcpus`, `nohz_full`, PREEMPT_RT | same — aimed at the wrong term until Gate B says otherwise |
+| `lowlatency=N` | killed by Step 1 (rate inverted) |
+| aligned periods 240/480/1008 | killed by the Scarlett (bimodality was adaptive clock lock) |
+| Sound Blaster IRQ cell 1c | hypothesis already dead; no value |
+
+Not wrong as engineering — aimed at a term the arithmetic says is not binding. Revisit only
+if Gate B returns P1 or P2/P2'.
+
+## In flight
+
+**Step 4** — Scarlett `256 x 3` cond A, 3 streams x 3 runs vs **69.7/min**. Finish it: the
+Step 3 bundle (`threadirqs` + v3d blacklist) is already applied and shipping, so we need to
+know whether it helped or hurt regardless of what the model says. **Read a result above
+69.7/min as the cost of threading every interrupt, not as a failure.**
+
+## Product position, unchanged for now
+
+**`1024 x 3` ships** — 64.0 ms, zero xruns, reproducible. `512` crackles on heavy patches;
+`256` is unusable on both interfaces. The Scarlett earns its place on I/O grounds (MIDI DIN,
+phantom power, real outputs) but **buys no latency on this Pi**.
+
+The nearest credible improvement is **`1024 x 2` at 42.7 ms** (Phase C) — a third off,
+without touching the period, which is the variable that has failed every time it moved.
+
+## Time
+
+| phase | Pi time |
+|---|---|
+| A | ~10 min (A1 offline) |
+| B | ~30 min |
+| C | ~30 min |
+| D | ~15 min |
+| step 4 (in flight) | ~12 min |
+| **total** | **~1 h 40 min**, gated — A can cancel B and C entirely |

--- a/docs/measurements/PLAN-V-fixed-callback-cost.md
+++ b/docs/measurements/PLAN-V-fixed-callback-cost.md
@@ -1,0 +1,107 @@
+# Plan V — find and remove the fixed per-callback cost
+
+**2026-08-21, after W1.** Supersedes `PLAN-2026-08-21-evening.md`, whose Phases B/C were
+retired by `W1-VERDICT-compute-bound-2026-08-21.md`.
+
+## Where we are
+
+W1 established, with zero ambiguity, that **every xrun ever measured on this appliance is a
+JACK graph overrun, not an ALSA underrun**: `JackEngine::XRun: Surge XT was not finished`,
+and **zero** `ALSA: xrun of at least N msecs` lines at 1024, 512 and 256. Buffer fill sat
+flat at ~83% throughout. **The ring buffer has never drained.**
+
+Everything aimed at the buffer-drain path is therefore retired (see the verdict doc): the
+~600 us gap, the cushion model, `threadirqs`, `irq/30` priority, `isolcpus`, `nohz_full`,
+PREEMPT_RT, USB runway, URB depth and rate, frame alignment, and the Scarlett-vs-dongle
+comparison as a latency question.
+
+**The binding term is compute time inside the audio callback.**
+
+## The hypothesis under test — and its weakness
+
+Fitting `T = a + b*N` across W1's three cells gave **a = 1.10 ms fixed per callback**, which
+retrodicts the whole T11 ladder including why 64 frames was catastrophic.
+
+**But it is weak evidence.** It is a least-squares fit over **three points, n=1 each**, using
+`dsp_p99` — a statistic W1 itself showed is the wrong one, since the overruns live past
+p99.7. And **1.1 ms is suspiciously large** for JACK graph overhead, which is typically tens
+of microseconds on ARM.
+
+**So V1 measures the fixed cost directly rather than inferring it.** Do not begin profiling
+or refactoring until it is confirmed to exist.
+
+## V1 — silence test (~10 min): does the fixed cost exist?
+
+Surge running, patch loaded, **zero notes playing**. With no voices, what remains is
+essentially all fixed cost. Measure absolute callback time at 1024 / 512 / 256.
+
+| outcome | reading |
+|---|---|
+| **~1.1 ms, flat across all three buffers** | **confirmed.** A real per-callback constant; proceed to V2 |
+| **flat but much smaller (tens of us)** | the regression was noise. The real story is that **per-voice cost scales badly**, not that there is a fixed constant. Re-aim at voice cost |
+| **not flat — scales with buffer** | there is no fixed term at all; the model is wrong. Say so and stop |
+
+This is the shortest useful version of the question and it needs no fitting.
+
+## V2 — client-count test (~10 min): engine cost or Surge cost?
+
+Measure JACK's own DSP load with **no clients**, then with **Surge alone**. The difference
+isolates graph traversal and inter-client context switching from Surge's internals.
+
+**This is also the direct test of the single-client architecture idea** (Surge hosting the
+looper in-process, raised earlier in the project):
+
+| result | consequence |
+|---|---|
+| graph traversal is a **meaningful share** of the fixed cost | the single-client refactor is worth building |
+| graph traversal is **~50 us** | **the refactor is dead** — a large piece of work avoided for 10 minutes of measurement |
+
+## V3 — `1024 x 2` (~15 min): the free latency win
+
+W0 confirmed ALSA accepts `nperiods=2` on this device. `1024 x 2` = **42.7 ms** total against
+today's 64.0 ms — a **third off shipping latency** with **no change to the compute deadline**
+(Surge still gets 21.3 ms for 1024 frames, exactly as now).
+
+**Independent of V1/V2.** It does not depend on understanding or fixing the fixed cost.
+
+Confirm at **n >= 3 streams**, strict mode, then it is a config change.
+
+## V4 — profile (only if V1 confirms)
+
+`perf` on the Surge process, or timestamps around `processBlock` entry/exit.
+
+Surge XT processes internally in **32-sample blocks**, so anything per-*internal*-block scales
+linearly with buffer size and **cannot** be the fixed term. The cost must be per
+`processBlock` **call**. Candidates: JUCE wrapper setup/teardown, MPE/MIDI event-queue
+walking, modulation-matrix or parameter-smoothing rebuild, denormal handling, cache reload.
+
+## Instrument changes required
+
+**Stop reporting `dsp_p99` as the primary statistic.** At 256, p99 = 76% while **0.28%** of
+periods overran — the failures are past p99.7, which p99 excludes by construction.
+
+**Report `p99.9`, `p99.99` and `max`,** and report DSP in **absolute milliseconds** as well as
+percent, since percent-of-deadline hides that the fixed cost is constant.
+
+**Revert `-s softmode`** before any counting run; the Pi came back with it after the W1
+restore.
+
+## Order and cost
+
+| # | cell | Pi time | gates |
+|---|---|---|---|
+| **V1** | silence test, 1024/512/256 | ~10 min | V2 and V4 |
+| **V2** | client-count test | ~10 min | the single-client refactor |
+| **V3** | `1024 x 2` at n >= 3 | ~15 min | independent — run regardless |
+| **V4** | profile the callback | ~30 min | only if V1 confirms |
+
+**~35 minutes decides whether a refactor is worth building and whether we can ship a third
+off our latency.**
+
+## Product position
+
+Shipping stays **`1024 x 3` (64 ms)**; **`1024 x 2` (42.7 ms)** is a candidate pending V3.
+
+Lower buffers are **not** limited by the Pi's kernel, its USB stack, or the audio interface.
+They are limited by **compute time inside our own audio graph** — a software problem in code
+we control.

--- a/docs/measurements/PLAN-V-fixed-callback-cost.md
+++ b/docs/measurements/PLAN-V-fixed-callback-cost.md
@@ -86,6 +86,51 @@ percent, since percent-of-deadline hides that the fixed cost is constant.
 **Revert `-s softmode`** before any counting run; the Pi came back with it after the W1
 restore.
 
+## V5 / V6 — clock, and the under-voltage record
+
+**The historical `get_throttled = 0x50000` in `docs/LATENCY-SPIKE.md` is explained and is
+not evidence of a marginal board.** Cause (Mitch, 2026-08-21): powering external devices
+without a powered hub, and jumpers in the GPIO power chain. **Both resolved. Not a live
+constraint** — treat under-voltage as a runtime check to monitor, not a reason to avoid
+raising power draw.
+
+Recent readings are `throttled=0x0` at 55.5 C. Clock work is therefore on the table.
+
+| # | arm | status |
+|---|---|---|
+| **V5** | CPU governor `ondemand` -> `performance` | **a documented lever that was never pulled** — see below |
+| **V6** | `arm_boost=1` (1.5 -> 1.8 GHz) | **diagnostic only** in this pass |
+
+**V5 is not a new idea.** `docs/LATENCY-SPIKE.md` recorded the governor as `ondemand`, called
+it *"a classic cause of dropouts on transient polyphony spikes"*, and named the governor arm
+**"the most promising, and the cheapest."** The mechanism was built (`14da2ca`) but ships
+**off by default**; its sibling knob (Surge RT scheduling) was completed — Surge runs FF 65
+today — and the governor apparently was not. It only became *meaningful* once the problem was
+shown to be compute-bound: `ondemand`'s ramp acts on the **tail**, which is where the
+overruns live.
+
+**V6 uses `arm_boost=1`, not manual `arm_freq`/`over_voltage`.** It is Raspberry Pi's own
+validated 1.8 GHz configuration for the Pi 4 — the same silicon and clock the Pi 400 ships
+at. Manual overclocking beyond that is out of scope.
+
+### Why clock is still second to the software fix
+
+1.5 -> 1.8 GHz is **+20%**, moving 256 from 76% to ~63% of deadline. Removing the 1.1 ms
+fixed cost — if real and removable — recovers a comparable amount, but **permanently, on
+every customer unit, with no heat, no PSU requirement and no throttling risk.** Same prize,
+better terms.
+
+### The shipping gate is thermal, not performance
+
+**For an instrument, a clock that occasionally throttles is worse than a lower clock that
+never does.** Throttling is a sudden step *down* mid-performance; on a compute-bound callback
+that is exactly the tail excursion that produces `Surge XT was not finished`. A 15-minute
+measurement **cannot** clear this — it requires a sustained soak in the real enclosure at the
+hottest ambient the instrument will see, ending at `throttled=0x0`.
+
+**V6 in this pass measures the effect only. Shipping an overclock is a separate decision,
+Mitch's, with soak data.**
+
 ## Order and cost
 
 | # | cell | Pi time | gates |
@@ -94,6 +139,8 @@ restore.
 | **V2** | client-count test | ~10 min | the single-client refactor |
 | **V3** | `1024 x 2` at n >= 3 | ~15 min | independent — run regardless |
 | **V4** | profile the callback | ~30 min | only if V1 confirms |
+| **V5** | governor `performance` at `256 x 3` | ~15 min | free; long-identified lever |
+| **V6** | `arm_boost=1` at `256 x 3`, diagnostic | ~15 min | calibrates the compute prize |
 
 **~35 minutes decides whether a refactor is worth building and whether we can ship a third
 off our latency.**

--- a/docs/measurements/PROMPT-V-fixed-callback-cost.md
+++ b/docs/measurements/PROMPT-V-fixed-callback-cost.md
@@ -86,17 +86,21 @@ session.
 
 **Then** revert softmode.
 
-### Poly governor — measure BOTH conditions, and label them
+### Poly governor — OFF for this entire pass (Mitch, 2026-08-21)
 
-Do **not** simply disable it. It is the **actual playing condition**; a fixed-cost number
-measured without it is cleaner science describing a machine nobody plays.
+**Disable `surge-poly-governor` and pin poly to a fixed value for every cell in Plan V.**
 
-| condition | used for | why |
-|---|---|---|
-| **poly governor OFF, poly pinned** | **V1, V2** | isolates the fixed cost; load must be constant to fit `a` |
-| **poly governor ON (shipping config)** | **V3, V5** | what a player actually experiences |
+**Why:** the poly governor is a **feedback loop that reacts to CPU load** — the exact quantity
+being measured. Left on, it partially absorbs the fixed cost we are trying to isolate: load
+rises, poly drops, load falls. The controller fights the measurement.
 
-State which condition every cell ran under. Never compare across conditions.
+**Understand the raw machine first, then re-enable the controller and measure what it does to
+a system we understand.** That second pass is deliberately deferred, not forgotten.
+
+**Consequence to state in the deliverable:** these numbers describe the appliance with its
+polyphony controller disabled. They are **not** the shipping configuration, and the shipping
+xrun rate may differ. Record the pinned poly value used, and use the **same value in every
+cell**.
 
 ## V1 — silence test (~10 min): does the fixed cost exist?
 
@@ -153,8 +157,8 @@ It is only *meaningful* now: while this looked like an IRQ/latency problem, cloc
 irrelevant. For a compute-bound problem it is directly proportional, and `ondemand`'s ramp
 acts precisely on the **tail**, which is where the overruns live.
 
-Run `256 x 3` under **both** governors, poly governor **ON** (shipping condition), as a
-single-variable comparison. Report DSP p99.9/max in **ms** and xruns/min for each.
+Run `256 x 3` under **both** governors, poly governor **OFF** with poly pinned (as with every
+cell in this pass), as a single-variable comparison. Report DSP p99.9/max in **ms** and xruns/min for each.
 
 **Add a transient cell that reproduces Mitch's observation**: from **silence**, trigger a
 full chord on a heavy patch, and capture `max` callback time across the transient — under
@@ -224,7 +228,8 @@ off the audio thread?"**
 ## Rules
 
 1. **One variable per cell.** Write both configs side by side before calling it a comparison.
-2. **Load must be identical and constant across cells** — fixed poly, poly governor disabled.
+2. **Load must be identical and constant across cells** — poly governor **disabled**, poly
+   pinned to the same value everywhere, and the same patch set in the same order.
 3. **No commands against the Pi while a window is open**, including read-only ones.
 4. **Resolve the card index live** (it moved 6 -> 2 after the Step 3 reboot).
 5. **Report n and the claim class it supports.** Shape claims need n >= 10 streams; W1's

--- a/docs/measurements/PROMPT-V-fixed-callback-cost.md
+++ b/docs/measurements/PROMPT-V-fixed-callback-cost.md
@@ -64,9 +64,39 @@ Two live confounds. Both are cheap and both may have contaminated **every prior 
 | V0-b | is `surge-poly-governor` active? `MPE_POLY_CEILING` / `MPE_POLY_FLOOR` / `MPE_POLY_EMERGENCY` values | it **dynamically reduces polyphony under CPU load**. If it ran during measurements, the load was **not constant across the window** — a confound possibly present in every cell to date |
 | V0-c | is `-s softmode` still on jackd? | the Pi came back with it after the W1 restore; it changes xrun handling |
 
-**Actions:** revert softmode. **Disable the poly governor and pin poly to a fixed value for
-all V cells** — load must be constant and identical. Report the governor findings; **do not
-change the CPU governor yet**, that is V5.
+### V0-d — PIN THE CPU GOVERNOR FIRST. This is a precondition, not an experiment.
+
+**If the box is on `ondemand`, CPU clock has been an uncontrolled variable in every
+measurement this project has ever taken.** Every `dsp_p99` figure was recorded at whatever
+clock the governor happened to select — and it selects based on the very load we vary. Per
+the one-variable rule, **the clock must be pinned before any fixed-cost measurement means
+anything.**
+
+**Corroborating evidence (Mitch, by ear, 2026-08-21):** *quick pops when hitting chords on
+heavy patches **from silence**.* That is the textbook `ondemand` signature — idle means the
+clock has ramped **down**; a chord on a heavy patch is a near-instant load step; the governor
+only reacts on its next sampling interval (tens of ms on Pi); during that window Surge
+computes a heavy block at a low clock and overruns. Then the clock catches up, which is why
+the pops are brief and do not sustain.
+
+**Action:** set `MPE_CPU_GOVERNOR=performance`, apply, and **verify the actual value and
+current MHz in `/sys/.../scaling_governor` and `scaling_cur_freq`** before running any cell.
+Record what it was before. Monitor `vcgencmd measure_temp` and `get_throttled` throughout the
+session.
+
+**Then** revert softmode.
+
+### Poly governor — measure BOTH conditions, and label them
+
+Do **not** simply disable it. It is the **actual playing condition**; a fixed-cost number
+measured without it is cleaner science describing a machine nobody plays.
+
+| condition | used for | why |
+|---|---|---|
+| **poly governor OFF, poly pinned** | **V1, V2** | isolates the fixed cost; load must be constant to fit `a` |
+| **poly governor ON (shipping config)** | **V3, V5** | what a player actually experiences |
+
+State which condition every cell ran under. Never compare across conditions.
 
 ## V1 — silence test (~10 min): does the fixed cost exist?
 
@@ -106,7 +136,11 @@ third off shipping latency with **no change to the compute deadline** (Surge sti
 Confirm at **n >= 3 streams**, strict mode, fixed poly. Report xruns/min and DSP against the
 `1024 x 3` baseline. **Run this regardless of how V1 and V2 turn out.**
 
-## V5 — CPU governor (~15 min): a known lever that was never pulled
+## V5 — `ondemand` vs `performance` as a shipping question (~15 min)
+
+**Note: the governor is already pinned to `performance` by V0-d as a precondition.** V5 is
+the separate question of *how much it is worth*, measured deliberately — not the act of
+setting it.
 
 **This is not a new idea. It is a documented, prioritised lever that got lost.**
 `docs/LATENCY-SPIKE.md` recorded the governor as **`ondemand`**, flagged it as *"a classic
@@ -119,9 +153,13 @@ It is only *meaningful* now: while this looked like an IRQ/latency problem, cloc
 irrelevant. For a compute-bound problem it is directly proportional, and `ondemand`'s ramp
 acts precisely on the **tail**, which is where the overruns live.
 
-If V0-a confirms `ondemand`, test `performance` as a **single-variable** change at
-`256 x 3` — the cell with least headroom. Report DSP p99.9/max in **ms**, xruns/min, against
-the current baseline.
+Run `256 x 3` under **both** governors, poly governor **ON** (shipping condition), as a
+single-variable comparison. Report DSP p99.9/max in **ms** and xruns/min for each.
+
+**Add a transient cell that reproduces Mitch's observation**: from **silence**, trigger a
+full chord on a heavy patch, and capture `max` callback time across the transient — under
+each governor. The steady-state figures may barely differ while the **transient** is the
+whole effect. A steady-state-only comparison would miss it entirely.
 
 **Safety check — monitor, do not avoid.** Record `vcgencmd measure_temp` and
 `vcgencmd get_throttled` before, during and after. **If `get_throttled` becomes non-zero,
@@ -198,15 +236,16 @@ off the audio thread?"**
 
 | # | cell | Pi time | gate |
 |---|---|---|---|
-| V0 | pre-checks: governor, poly governor, softmode | ~5 min, read-only | everything |
+| **V0** | pre-checks **and pin `performance`** + revert softmode | ~10 min | **everything — clock must be pinned first** |
 | **V1** | silence test 1024/512/256 | ~10 min | V2, V4 |
 | **V2** | client-count test | ~10 min | the single-client refactor |
 | **V3** | `1024 x 2` at n >= 3 | ~15 min | independent — run regardless |
-| **V5** | governor `performance` at `256 x 3` | ~15 min | V6 |
+| **V5** | `ondemand` vs `performance`, incl. **silence->chord transient** | ~15 min | V6 |
 | **V6** | `arm_boost=1` at `256 x 3`, diagnostic | ~15 min | revert after |
 | V4 | profile the callback | ~30 min | **only if V1 confirms** |
 
-**V1 + V2 = 20 minutes and decide whether a refactor is worth building.** Run them first.
+**V0 first — the clock must be pinned before anything else is measured.** Then **V1 + V2 =
+20 minutes and decide whether a refactor is worth building.**
 
 ## Deliverable
 

--- a/docs/measurements/PROMPT-V-fixed-callback-cost.md
+++ b/docs/measurements/PROMPT-V-fixed-callback-cost.md
@@ -1,0 +1,176 @@
+# Agent prompt — Plan V: find the fixed per-callback cost
+
+Copy everything below the line.
+
+---
+
+**Invoke the `measurement-design` skill before designing or altering any cell here.**
+
+## What changed
+
+W1 settled the question this project has been chasing all day. Journal during W1-c:
+`JackEngine::XRun: Surge XT was not finished`, with **zero** `ALSA: xrun of at least N msecs`
+lines at 1024, 512 **and** 256. Fill level flat at ~83% throughout.
+
+**Every xrun ever measured on this appliance is a JACK graph overrun, not an ALSA underrun.
+The ring buffer has never drained.**
+
+**The binding term is compute time inside the audio callback.** Nothing else.
+
+## Already dead — do not test, do not revisit
+
+`lowlatency=N` · aligned periods (240/480/1008) · URB queue depth · URB completion rate ·
+swap / SD major faults · frame alignment · Scarlett-vs-dongle as a *latency* question.
+
+## Retired by W1 — do not resurrect
+
+The "~600 us" wakeup-path gap · the cushion/drain model · `threadirqs` · `irq/30` priority ·
+IRQ placement · `isolcpus` · `nohz_full` · PREEMPT_RT · the nperiods sweep **as a
+diagnostic**.
+
+All of these targeted getting audio *out of the buffer* on time. **The buffer was always
+full.** They are not wrong engineering; they act on a term that does not exist here.
+
+## Read first
+
+| doc | why |
+|---|---|
+| `docs/measurements/W1-VERDICT-compute-bound-2026-08-21.md` | the finding, the model, and its weaknesses |
+| `docs/measurements/PLAN-V-fixed-callback-cost.md` | this plan in full |
+| `docs/measurements/xrun-counter-audit-2026-08-21.md` | what our instruments actually count |
+| `docs/measurements/MEASUREMENT-DISCIPLINE.md` | pre-registration, claim classes, shortest-useful-version |
+
+## The hypothesis — and why it must be verified before it is chased
+
+Fitting `T = a + b*N` across W1's three cells gave **a = 1.10 ms fixed per callback**, which
+retrodicts the entire T11 ladder.
+
+**It is weak evidence:** a least-squares fit over **three points, n=1 each**, using
+`dsp_p99` — a statistic W1 itself showed is wrong, because the overruns live past p99.7.
+**1.1 ms is also suspiciously large** for JACK graph overhead, typically tens of microseconds
+on ARM.
+
+**Do not profile, refactor, or optimise anything until V1 confirms the fixed cost exists.**
+
+---
+
+## V0 — free pre-checks (read-only, before any window)
+
+Two live confounds. Both are cheap and both may have contaminated **every prior measurement**.
+
+| # | check | why it matters |
+|---|---|---|
+| V0-a | `MPE_CPU_GOVERNOR` in `/etc/mpe/mpe.env`, and the **actual** governor in `/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor` + current MHz | the example file has it **commented out**, so the box may be on stock `ondemand`. Our own comment says it *"can drop voices on polyphony spikes."* For a compute-bound problem this acts directly on the tail |
+| V0-b | is `surge-poly-governor` active? `MPE_POLY_CEILING` / `MPE_POLY_FLOOR` / `MPE_POLY_EMERGENCY` values | it **dynamically reduces polyphony under CPU load**. If it ran during measurements, the load was **not constant across the window** — a confound possibly present in every cell to date |
+| V0-c | is `-s softmode` still on jackd? | the Pi came back with it after the W1 restore; it changes xrun handling |
+
+**Actions:** revert softmode. **Disable the poly governor and pin poly to a fixed value for
+all V cells** — load must be constant and identical. Report the governor findings; **do not
+change the CPU governor yet**, that is V5.
+
+## V1 — silence test (~10 min): does the fixed cost exist?
+
+Surge running, patch loaded, **zero notes playing**. With no voices, what remains is
+essentially all fixed cost. **This measures `a` directly instead of inferring it.**
+
+Measure **absolute callback time in milliseconds** (not just percent) at **1024 / 512 / 256**,
+n >= 3 runs each.
+
+| outcome | conclusion |
+|---|---|
+| **~1.1 ms, flat across all three buffers** | **confirmed** — a real per-callback constant. Proceed to V2 |
+| **flat but much smaller (tens of us)** | the regression was noise. The real story is **per-voice cost scaling badly**, not a fixed constant. Re-aim at voice cost and say so |
+| **not flat — scales with buffer** | **there is no fixed term.** The model is wrong. Say so plainly and stop |
+
+State which row you landed in.
+
+## V2 — client-count test (~10 min): engine cost or Surge cost?
+
+Measure JACK's own DSP load with **no clients**, then with **Surge alone**. The difference
+isolates graph traversal and inter-client context switching from Surge's internals.
+
+**This is the direct test of the single-client-architecture idea** (Surge hosting the looper
+in-process):
+
+| result | consequence |
+|---|---|
+| graph traversal is a **meaningful share** of the fixed cost | the refactor is worth building |
+| graph traversal is **~50 us** | **the refactor is dead** — a large piece of work avoided for 10 minutes |
+
+## V3 — `1024 x 2` (~15 min): the free latency win, independent of everything above
+
+W0 confirmed ALSA accepts `nperiods=2`. `1024 x 2` = **42.7 ms** against today's 64.0 ms — a
+third off shipping latency with **no change to the compute deadline** (Surge still gets
+21.3 ms for 1024 frames).
+
+Confirm at **n >= 3 streams**, strict mode, fixed poly. Report xruns/min and DSP against the
+`1024 x 3` baseline. **Run this regardless of how V1 and V2 turn out.**
+
+## V5 — CPU governor / clock (~15 min, only after V0 reports)
+
+**New lever, and only meaningful now that the problem is compute-bound.** While this looked
+like an IRQ/latency problem, clock speed was irrelevant. For compute it is directly
+proportional.
+
+If V0-a shows `ondemand`: test `performance` as a **single-variable** change at `256 x 3`
+(the cell with least headroom). Report DSP p99.9/max and xruns/min against the current
+baseline. Note the thermal cost — record `vcgencmd measure_temp` and `throttled` before and
+after.
+
+**Do not overclock (`arm_freq`, `over_voltage`) in this pass.** Report only whether the
+governor change helps; overclocking is a separate decision with hardware-lifetime
+implications and is Mitch's call.
+
+## V4 — profile (~30 min) — ONLY if V1 confirms
+
+`perf` on the Surge process, or timestamps around `processBlock` entry/exit.
+
+Surge XT processes internally in **32-sample blocks**, so anything per-*internal*-block scales
+linearly with buffer size and **cannot** be the fixed term. The cost must be per
+`processBlock` **call**. Candidates: JUCE wrapper setup/teardown, MPE/MIDI event-queue
+walking, modulation-matrix or parameter-smoothing rebuild, denormal handling, cache reload.
+
+Note: Surge's DSP is **single-threaded** and cannot be spread across cores. The useful
+question is not "parallelise it" but **"what in the callback is not DSP and could be deferred
+off the audio thread?"**
+
+---
+
+## Instrument requirements (all cells)
+
+1. **Report DSP in absolute milliseconds as well as percent.** Percent-of-deadline hides that
+   a fixed cost is constant.
+2. **Report `p99.9`, `p99.99` and `max` — not `p99`.** At 256, p99 = 76% while **0.28%** of
+   periods overran; p99 excludes the events of interest by construction.
+3. **Capture the jackd journal per window** and report both `JackEngine::XRun` lines and any
+   `ALSA: xrun of at least N msecs` lines. If ALSA lines ever appear, that is new and
+   important — say so loudly.
+4. **Stamp actual state into every result:** period, nperiods, rate, resolved card index,
+   governor + current MHz, poly ceiling, softmode on/off, git SHA.
+
+## Rules
+
+1. **One variable per cell.** Write both configs side by side before calling it a comparison.
+2. **Load must be identical and constant across cells** — fixed poly, poly governor disabled.
+3. **No commands against the Pi while a window is open**, including read-only ones.
+4. **Resolve the card index live** (it moved 6 -> 2 after the Step 3 reboot).
+5. **Report n and the claim class it supports.** Shape claims need n >= 10 streams; W1's
+   rate column was n=1 and its 512-beats-1024 ordering is noise.
+6. **Ask the shortest useful version of each cell** and justify anything longer.
+7. If a result refutes something above, **name the doc and say so plainly.**
+
+## Deliverable
+
+`docs/measurements/v1-fixed-cost-2026-08-21.md` on a branch off `dev`:
+
+- V0 findings (governor, poly governor, softmode) and what you changed
+- V1 table in **absolute ms**, and **which outcome row** you landed in
+- V2 split: engine cost vs Surge cost, and the **explicit verdict on the single-client
+  refactor**
+- V3 result vs the `1024 x 3` baseline, with n stated
+- V5 result if run, with thermals
+- a **"what this retires"** section
+- anything you could not measure, and why
+
+**Do not propose work beyond what these results imply.** V4 is gated on V1; if V1 says there
+is no fixed cost, say so and stop rather than looking for one anyway.

--- a/docs/measurements/PROMPT-V-fixed-callback-cost.md
+++ b/docs/measurements/PROMPT-V-fixed-callback-cost.md
@@ -106,20 +106,45 @@ third off shipping latency with **no change to the compute deadline** (Surge sti
 Confirm at **n >= 3 streams**, strict mode, fixed poly. Report xruns/min and DSP against the
 `1024 x 3` baseline. **Run this regardless of how V1 and V2 turn out.**
 
-## V5 — CPU governor / clock (~15 min, only after V0 reports)
+## V5 — CPU governor (~15 min): a known lever that was never pulled
 
-**New lever, and only meaningful now that the problem is compute-bound.** While this looked
-like an IRQ/latency problem, clock speed was irrelevant. For compute it is directly
-proportional.
+**This is not a new idea. It is a documented, prioritised lever that got lost.**
+`docs/LATENCY-SPIKE.md` recorded the governor as **`ondemand`**, flagged it as *"a classic
+cause of dropouts on transient polyphony spikes"*, and called the governor arm **"the most
+promising, and the cheapest."** The mechanism was built (`14da2ca`) but **ships off by
+default** and the example file has it commented out. Its sibling knob (Surge RT scheduling)
+was completed — Surge runs FF 65 today. **The governor apparently was not.**
 
-If V0-a shows `ondemand`: test `performance` as a **single-variable** change at `256 x 3`
-(the cell with least headroom). Report DSP p99.9/max and xruns/min against the current
-baseline. Note the thermal cost — record `vcgencmd measure_temp` and `throttled` before and
-after.
+It is only *meaningful* now: while this looked like an IRQ/latency problem, clock speed was
+irrelevant. For a compute-bound problem it is directly proportional, and `ondemand`'s ramp
+acts precisely on the **tail**, which is where the overruns live.
 
-**Do not overclock (`arm_freq`, `over_voltage`) in this pass.** Report only whether the
-governor change helps; overclocking is a separate decision with hardware-lifetime
-implications and is Mitch's call.
+If V0-a confirms `ondemand`, test `performance` as a **single-variable** change at
+`256 x 3` — the cell with least headroom. Report DSP p99.9/max in **ms**, xruns/min, against
+the current baseline.
+
+**Mandatory safety check.** `LATENCY-SPIKE.md` records `get_throttled = 0x50000` on this
+board: **under-voltage and throttling have both occurred historically.** `performance` raises
+power draw. Record `vcgencmd measure_temp` **and** `vcgencmd get_throttled` before, during
+and after. **If `get_throttled` becomes non-zero, stop and revert** — the measurement is
+invalid and the board is the constraint.
+
+### Overclocking — diagnostic only, and not in this pass
+
+**Do not set `arm_freq`, `over_voltage` or `force_turbo`.**
+
+Rationale, so it is not re-litigated: overclocking would be informative (a 20% clock bump
+yielding ~20% less callback time confirms pure compute-bound and calibrates the prize), but
+
+1. it **masks** the software problem — removing 1.1 ms of fixed cost recovers ~20% of the
+   256 deadline permanently, on every unit, without heat or power margin;
+2. this board has a **documented under-voltage history**, so it is the worst candidate for
+   raising draw;
+3. shipping an overclocked appliance is a product decision — enclosure thermals, PSU
+   headroom, silicon variation across customer units, long-term reliability — **and it is
+   Mitch's call, not a measurement outcome.**
+
+Revisit only after V1/V2/V4 have said how much fixed cost is removable.
 
 ## V4 — profile (~30 min) — ONLY if V1 confirms
 

--- a/docs/measurements/PROMPT-V-fixed-callback-cost.md
+++ b/docs/measurements/PROMPT-V-fixed-callback-cost.md
@@ -123,28 +123,38 @@ If V0-a confirms `ondemand`, test `performance` as a **single-variable** change 
 `256 x 3` — the cell with least headroom. Report DSP p99.9/max in **ms**, xruns/min, against
 the current baseline.
 
-**Mandatory safety check.** `LATENCY-SPIKE.md` records `get_throttled = 0x50000` on this
-board: **under-voltage and throttling have both occurred historically.** `performance` raises
-power draw. Record `vcgencmd measure_temp` **and** `vcgencmd get_throttled` before, during
-and after. **If `get_throttled` becomes non-zero, stop and revert** — the measurement is
-invalid and the board is the constraint.
+**Safety check — monitor, do not avoid.** Record `vcgencmd measure_temp` and
+`vcgencmd get_throttled` before, during and after. **If `get_throttled` becomes non-zero,
+stop and revert** — the measurement is invalid.
 
-### Overclocking — diagnostic only, and not in this pass
+**The historical `0x50000` in `LATENCY-SPIKE.md` is explained and is NOT a reason to avoid
+this test.** Cause (Mitch, 2026-08-21): powering external devices without a powered hub, and
+jumpers in the GPIO power chain. **Both resolved; recent readings are `0x0` at 55.5 C.**
+Treat under-voltage as a live check, not as evidence of a marginal board. Do not cite the
+historical value as a constraint.
 
-**Do not set `arm_freq`, `over_voltage` or `force_turbo`.**
+## V6 — `arm_boost=1` (~15 min): diagnostic only
 
-Rationale, so it is not re-litigated: overclocking would be informative (a 20% clock bump
-yielding ~20% less callback time confirms pure compute-bound and calibrates the prize), but
+**Use `arm_boost=1` in `config.txt` — Raspberry Pi's own validated 1.8 GHz configuration for
+the Pi 4, the same clock the Pi 400 ships at on identical silicon.**
 
-1. it **masks** the software problem — removing 1.1 ms of fixed cost recovers ~20% of the
-   256 deadline permanently, on every unit, without heat or power margin;
-2. this board has a **documented under-voltage history**, so it is the worst candidate for
-   raising draw;
-3. shipping an overclocked appliance is a product decision — enclosure thermals, PSU
-   headroom, silicon variation across customer units, long-term reliability — **and it is
-   Mitch's call, not a measurement outcome.**
+**Do not set `arm_freq`, `over_voltage` or `force_turbo` manually.** Manual overclocking
+beyond `arm_boost` is out of scope for this pass.
 
-Revisit only after V1/V2/V4 have said how much fixed cost is removable.
+Single-variable change at `256 x 3`, after V5. Report DSP p99.9/max in **ms**, xruns/min,
+temperature and `get_throttled` throughout, against the V5 baseline.
+
+**What this buys:** +20% clock should yield roughly -20% callback time. That both confirms
+pure compute-bound and **calibrates how much the fixed cost is worth chasing** — if 20% moves
+256 from 76% to ~63%, it tells us what removing 1.1 ms would be worth.
+
+**This measures the effect. It does not ship it.** For an instrument, a clock that
+occasionally throttles is **worse** than a lower clock that never does: throttling is a sudden
+step down mid-performance, and on a compute-bound callback that is precisely the tail
+excursion that produces `Surge XT was not finished`. **A 15-minute cell cannot clear that** —
+it needs a sustained soak in the real enclosure at the hottest ambient the instrument will
+see, ending at `throttled=0x0`. **Shipping an overclock is Mitch's decision with soak data,
+not a measurement outcome. Revert `arm_boost` after the cell unless told otherwise.**
 
 ## V4 — profile (~30 min) — ONLY if V1 confirms
 
@@ -184,6 +194,20 @@ off the audio thread?"**
 6. **Ask the shortest useful version of each cell** and justify anything longer.
 7. If a result refutes something above, **name the doc and say so plainly.**
 
+## Order
+
+| # | cell | Pi time | gate |
+|---|---|---|---|
+| V0 | pre-checks: governor, poly governor, softmode | ~5 min, read-only | everything |
+| **V1** | silence test 1024/512/256 | ~10 min | V2, V4 |
+| **V2** | client-count test | ~10 min | the single-client refactor |
+| **V3** | `1024 x 2` at n >= 3 | ~15 min | independent — run regardless |
+| **V5** | governor `performance` at `256 x 3` | ~15 min | V6 |
+| **V6** | `arm_boost=1` at `256 x 3`, diagnostic | ~15 min | revert after |
+| V4 | profile the callback | ~30 min | **only if V1 confirms** |
+
+**V1 + V2 = 20 minutes and decide whether a refactor is worth building.** Run them first.
+
 ## Deliverable
 
 `docs/measurements/v1-fixed-cost-2026-08-21.md` on a branch off `dev`:
@@ -193,7 +217,8 @@ off the audio thread?"**
 - V2 split: engine cost vs Surge cost, and the **explicit verdict on the single-client
   refactor**
 - V3 result vs the `1024 x 3` baseline, with n stated
-- V5 result if run, with thermals
+- V5 (governor) and V6 (`arm_boost`) results with temperature and `get_throttled` throughout
+- an explicit statement that `arm_boost` was reverted
 - a **"what this retires"** section
 - anything you could not measure, and why
 

--- a/docs/measurements/PROMPT-V7-capacity-curve.md
+++ b/docs/measurements/PROMPT-V7-capacity-curve.md
@@ -1,0 +1,144 @@
+# Agent prompt — V7 capacity curve + V3 latency win
+
+Copy everything below the line.
+
+---
+
+**Invoke the `measurement-design` skill before designing or altering any cell.**
+
+## Where this stands
+
+The appliance is **compute-bound**. `W1` established it with zero ambiguity:
+`JackEngine::XRun: Surge XT was not finished`, **zero** `ALSA: xrun of at least N msecs`
+lines at 1024/512/256, buffer fill flat at ~83%. **Every xrun ever measured here is a JACK
+graph overrun. The ring buffer has never drained.**
+
+Confirmed by ear 2026-08-21: with the poly governor off, Mitch can provoke crackle at will by
+maxing CPU. Compute-bound, reproducible by hand.
+
+## Dead — do not test, do not revisit
+
+| line | killed by |
+|---|---|
+| the "~600 us" wakeup gap, cushion/drain model, `threadirqs`, `irq/30` priority, `isolcpus`, `nohz_full`, PREEMPT_RT | W1 — the buffer never drains |
+| USB runway, URB depth, URB completion rate, frame alignment, Scarlett-vs-dongle **as latency** | Steps 1-4 + W1 |
+| **~1.1 ms fixed per-callback cost** | **V1 — a = 0.13 ms; cost scales with buffer** |
+| **single-client architecture refactor** (Surge hosting the looper) | **V2 — graph overhead is ~35 us, noise** |
+| **`ondemand` governor / `arm_boost` arms (V5, V6)** | **V0 — already `performance` @ 1800 MHz with `arm_boost=1`** |
+| **`ondemand` ramp as the cause of Mitch's pops** | **V0 + ear test — pops were the poly governor** |
+| **profiling for a fixed constant (V4)** | **V1 — no fixed constant exists** |
+
+## Read first
+
+`V1-VERDICT-no-fixed-cost-2026-08-21.md` · `V7-capacity-curve-plan.md` ·
+`W1-VERDICT-compute-bound-2026-08-21.md` · `xrun-counter-audit-2026-08-21.md` ·
+`MEASUREMENT-DISCIPLINE.md`
+
+## Standing conditions for every cell
+
+- Poly governor **OFF**, poly ceiling raised out of the way. It is a feedback controller that
+  reacts to the load being measured; it confounded W1's entire ladder.
+- **Strict mode** (no `-s softmode`).
+- CPU governor `performance` @ 1800 MHz (already set — verify, do not change).
+- Same patch, same voice-entry pattern, same everything else across cells.
+- **Report DSP in absolute ms as well as percent, and `p99.9` / `p99.99` / `max` — never
+  `p99`.** At 256, p99 = 76% while 0.28% of periods overran; p99 excludes the events of
+  interest by construction.
+- **Capture the jackd journal per window** and report `JackEngine::XRun` lines and any
+  `ALSA: xrun of at least N msecs` lines. If ALSA lines ever appear, that is new — say so
+  loudly.
+- **Stamp actual state into every result:** period, nperiods, rate, resolved card index
+  (it moved 6 -> 2), governor + MHz, poly ceiling, softmode state, git SHA.
+- **No commands against the Pi while a window is open**, including read-only ones.
+
+---
+
+## V7 — the capacity curve (~25 min) — PRIMARY
+
+**Every cell in this project has used one fixed 75-voice load and counted xruns.** That
+measures failure at an arbitrary point. It does not measure **capacity**, which is what both
+the player and the poly governor need.
+
+**Question: for each buffer size, how many voices of a defined heavy patch can be sustained
+cleanly?**
+
+| cell | buffer | method |
+|---|---|---|
+| V7-a | 1024 x 3 | ramp voice count upward; record **first graph overrun** and **highest count sustained clean** |
+| V7-b | 512 x 3 | as above |
+| V7-c | 256 x 3 | as above |
+
+**Pick one heavy patch and state which.** Mitch reports crackle on heavy patches at 512; use
+something representative of that, not a light default. Record the patch name in the
+deliverable — this number is meaningless without it.
+
+**Shortest useful version:** the transition is the datum. **Do not soak at each voice count.**
+Ramp to first failure, then confirm the sustained-clean count with **one short window** per
+buffer.
+
+### Report
+
+| buffer | voices to first overrun | highest sustained clean | DSP ms @ that count | p99.9 / max |
+|---|---|---|---|---|
+
+### What this produces
+
+1. **The answer to "what can we actually run reliably?"** — asked early in this project and
+   never measured.
+2. **A data-derived poly ceiling per buffer size**, replacing the current
+   `MPE_POLY_CEILING=12` guess.
+3. **The buffer tradeoff expressed in voices** — what a player experiences — rather than in
+   xruns/min at an arbitrary fixed load.
+
+## V3 — `1024 x 2` (~15 min) — independent, run regardless
+
+W0 confirmed ALSA accepts `nperiods=2` on this device. `1024 x 2` = **42.7 ms** total against
+today's 64.0 ms — **a third off shipping latency with no change to the compute deadline**
+(Surge still gets 21.3 ms for 1024 frames, exactly as now).
+
+**n >= 3 streams**, strict mode, same conditions as above. Report xruns/min and DSP against
+the `1024 x 3` baseline.
+
+**Unaffected by everything else in this document.** If V7 runs long, V3 still gets run.
+
+## Poly governor — DOCUMENT ONLY this pass (Mitch)
+
+**Do not implement, do not re-enable, do not change its code.** Record the design conclusions
+in the deliverable so they are not lost:
+
+- The pops were **the poly governor stealing sounding voices** when it cut polyphony under CPU
+  load. Confirmed by ear: governor off, pops gone.
+- **Fix 2 (fade, not hard cut) is the actual fix.** A hard cut is a step discontinuity — that
+  *is* the pop. Ramp a removed voice out over a few ms.
+- **Fix 1 is a steal *policy*, not a prohibition.** An earlier draft proposed refusing
+  note-ons instead of stealing; **that is wrong for a performance instrument** — the player
+  presses a key and gets silence, which reads as broken. Steal in order:
+  **released/in-release first, then quietest, then oldest.**
+- **Fix 3: hysteresis.** Separate raise/lower thresholds and rate-limit changes so the ceiling
+  does not oscillate.
+- **Open question to record, not answer:** the governor sets Surge's poly limit over OSC, and
+  **Surge decides what dies** when that limit drops below the sounding count. Establish
+  whether the fade belongs in Surge's voice handling or in how we drive the limit (e.g.
+  lowering only at note-off boundaries) before writing any code.
+
+**V7's ceiling numbers are the input this work needs.** That is why V7 comes first.
+
+## Rules
+
+1. **One variable per cell.** Write both configs side by side before calling it a comparison.
+2. **Report n and the claim class it supports.** Shape claims need n >= 10 streams.
+3. **Ask the shortest useful version of each cell** and justify anything longer.
+4. **Resolve the card index live.** Never hardcode it.
+5. If a result refutes something above, **name the doc and say so plainly.** Four hypotheses
+   have already been retired today; retiring a fifth is a good outcome, not a failure.
+
+## Deliverable
+
+`docs/measurements/v7-capacity-curve-2026-08-21.md` on a branch off `dev`:
+
+- the V7 table, with the **patch name** stated
+- the recommended **per-buffer poly ceiling** derived from it
+- V3 result vs the `1024 x 3` baseline, with n stated
+- the poly-governor design notes above, recorded for later implementation
+- a **"what this retires"** section
+- anything you could not measure, and why

--- a/docs/measurements/PROMPT-W1-instrumented-window.md
+++ b/docs/measurements/PROMPT-W1-instrumented-window.md
@@ -168,3 +168,67 @@ whether it opens; do not measure it yet. That is W2.
 **Do not propose next steps beyond stating what W1's outcome implies.** The plan is in
 `PLAN-2026-08-21-evening.md`; W1's job is to decide between its branches, not to add new
 ones.
+
+---
+
+## AMENDMENT — observer effect of the instruments themselves
+
+Do not assume the instruments are free. One is; one is not.
+
+### Instrument 2 (jackd magnitudes) — genuinely zero cost
+
+`journalctl` runs **after the window closes**, never during. And jackd has been writing those
+`xrun of at least N msecs` lines on every run already — we simply never read them. **No new
+load during the window. Do not run journalctl while a window is open.**
+
+### Instrument 3 (fill polling) — NOT free; treat it as a perturbation
+
+Reading `/proc/asound/card<N>/pcm0p/sub0/status` **takes the PCM substream lock and invokes
+the driver's `pointer()` callback** — the same lock the URB completion path uses. The poller
+therefore contends with the interrupt handler it is meant to observe. At 10 Hz against
+~2000 URB completions/sec this is small, **but it is not zero and must be quantified, not
+assumed.**
+
+**Constraints on the poller:**
+
+| requirement | why |
+|---|---|
+| **one persistent process**, opening/reading/closing the proc file in a loop | no per-sample forks (CPU doctrine) |
+| **10 Hz**, not 20 | halves lock contention; sufficient for the slow question (below) |
+| **pinned to CPU1** (`taskset -c 1`) | off the audio cores 2-3; CPU0 carries the unmovable xhci IRQ |
+| **`SCHED_OTHER`, `nice 19`** | must never preempt anything in the audio path |
+| no formatting, arithmetic or conversion inside the loop | log raw `appl_ptr`/`hw_ptr`; convert in post-processing |
+
+### What 10 Hz can and cannot answer — state this in the deliverable
+
+The period rate is **47 Hz at 1024** and **188 Hz at 256**. **10 Hz cannot see per-period
+behaviour.** The sawtooth is invisible at this sampling rate, and a single-cycle cliff would
+be caught only by luck.
+
+| question | instrument | resolved? |
+|---|---|---|
+| is the fill level **drifting down over seconds/minutes**? (P2 / P2' vs P3) | #3 at 10 Hz | **yes** |
+| did a **genuine ALSA underrun** occur, and how large? | **#2** (free, post-hoc) | **yes** |
+| what does the fill level do **within a single period**? | neither | **no — out of scope for W1** |
+
+**Do not raise the poll rate to chase the per-period question.** Resolving it at 256 needs
+~400 Hz, and that rate of lock acquisition would perturb the measurement more than it
+informs. Instrument 2 answers the question that actually matters without touching the
+running system.
+
+### Required control cell — quantify the perturbation
+
+**Run `1024 x 3` cond A twice: once with the poller running, once without.** Same load, same
+duration, everything else identical.
+
+| result | reading |
+|---|---|
+| xrun rates statistically indistinguishable | poller is transparent; W1's other cells stand as measured |
+| **poller-on materially worse** | **the poller is perturbing the measurement.** Report the magnitude, treat every polled cell as biased, and fall back to instrument 2 alone |
+
+Run this control **first**, before the ladder. If the poller is not transparent, the rest of
+W1 must be interpreted through that bias — and it is better to know before spending the
+windows than after.
+
+**Report the control result in the deliverable regardless of outcome.** "We checked and it
+was clean" is a finding worth recording.

--- a/docs/measurements/PROMPT-W1-instrumented-window.md
+++ b/docs/measurements/PROMPT-W1-instrumented-window.md
@@ -1,0 +1,170 @@
+# Agent prompt — W1: the four-instrument window
+
+Copy everything below the line.
+
+---
+
+## What this is
+
+Every xrun figure this project has produced is an **event count with no magnitude**, from a
+callback that **conflates two different failure modes**. Before measuring anything else, we
+fix the instrument. W1 does that *and* answers the compute question in the same pass.
+
+**Do not optimise anything. Do not tune anything. This is a measurement task.**
+
+## Read first — do not re-derive or re-litigate
+
+| doc | what it settled |
+|---|---|
+| `docs/measurements/xrun-counter-audit-2026-08-21.md` | our counter is event-count-only; JACK fires it for **ALSA underruns** *and* **graph overruns** |
+| `docs/measurements/cushion-model-2026-08-21.md` | buffer fill is **self-restoring** (`fill(k) = fill_0 + d_0 - d_k`); producer lateness cannot accumulate |
+| `docs/measurements/PLAN-2026-08-21-evening.md` | the plan, the four instruments, and the joint readings |
+| `docs/measurements/find-600us-2026-08-21.md` | Steps 0-4: swap ruled out, URB rate inverted, cyclictest max 429 us under load |
+
+**Already dead — do not test, do not revisit:** `lowlatency=N`; aligned periods
+(240/480/1008); URB queue depth; swap / SD major faults; Sound Blaster IRQ cell 1c.
+**Parked:** `irq/30` priority, `isolcpus`, `nohz_full`, PREEMPT_RT — producer-lateness
+levers, and the cushion arithmetic says that term is not binding. Do not bundle them in.
+
+## The core arithmetic this window tests
+
+At `1024 x 3` the cushion is 2048 frames = **42.7 ms**. The worst stall ever measured on
+this box is **429 us**. Emptying the buffer by producer lateness would need a **single**
+42.7 ms stall — **100x larger than anything observed.** Yet xruns are counted.
+
+Either they are not drain events, or something we have never measured is far larger than we
+think. **W1 distinguishes these.**
+
+---
+
+## Harness changes required first (offline, no Pi)
+
+Two instruments are missing. Add both. **Instrument 2 is a permanent harness improvement,
+not a one-off for this run.**
+
+### Instrument 2 — jackd's own xrun magnitudes
+
+jackd already prints lines of the form `ALSA: xrun of at least 0.123 msecs`. The harness
+captures **no jackd stderr or journal anywhere** (verified: `scripts/measure-latency-run.sh`
+has no `journalctl` and no stderr capture).
+
+Capture `journalctl -u mpe-jackd --since <window start> --until <window end>` for every
+window. Parse out each `xrun of at least N msecs` line. Report **the count AND every
+magnitude** (min / median / max / full list if small).
+
+### Instrument 3 — direct fill telemetry
+
+`/proc/asound/card<N>/pcm0p/sub0/status` exposes `hw_ptr` and `appl_ptr`.
+**`appl_ptr - hw_ptr` is the buffer fill level in frames.**
+
+Sample at **10-20 Hz** for the whole window; log `timestamp, appl_ptr, hw_ptr, fill_frames,
+state`. Use a plain `while` loop reading the proc file — **no per-sample subprocess forks**
+(CPU doctrine: no forks in periodic loops on the appliance). Convert to ms and to
+percent-of-buffer in post-processing, not in the loop.
+
+**Resolve the card index live from `/proc/asound/cards`.** It moved **6 -> 2** after the
+Step 3 reboot. Echo what you resolved before using it. Do not hardcode.
+
+**Sanity-check the poller before trusting it:** at idle with a stream up, `fill_frames`
+should sit near the nominal buffer and never exceed `period x nperiods`. If it does, the
+pointer arithmetic is wrong (wrap-around) — fix it before running W1.
+
+---
+
+## W1 — the instrumented ladder (~20 min)
+
+**Condition A. Identical load at every buffer size — this is the one variable that must not
+move.** Step 2's `dsp_p99 ~= 92%` used `midi-load` while the 34.8% figure did not, which is
+why that comparison was invalid. State explicitly in the deliverable which load you used.
+
+| cell | period x nperiods | total latency |
+|---|---|---|
+| W1-a | 1024 x 3 | 64.0 ms |
+| W1-b | 512 x 3 | 32.0 ms |
+| W1-c | 256 x 3 | 16.0 ms |
+
+Per cell, capture **all four instruments simultaneously**:
+
+| # | instrument | report |
+|---|---|---|
+| 1 | probe `XRUN_COUNT` | events per minute |
+| 2 | jackd `ALSA: xrun of at least N msecs` | **count and magnitudes** |
+| 3 | fill level `appl_ptr - hw_ptr` @ 10-20 Hz | min / median / p1 / max, **and the trace shape** |
+| 4 | `dsp_p99` | percent of period deadline |
+
+Also record `throttled=0x0` and `meter_live` per window as usual.
+
+### Report this table
+
+| cell | #1 events/min | #2 ALSA count | #2 magnitudes | #3 fill min | #3 shape | #4 dsp_p99 |
+|---|---|---|---|---|---|---|
+
+### Interpretation — state which row you are in, explicitly
+
+| pattern | conclusion |
+|---|---|
+| #1 = N, **#2 = 0** | **all graph overruns.** The cushion was never in play. This is a **compute** problem; the entire latency-path line of work is a wrong-term pursuit |
+| #2 > 0 with magnitudes, #3 drains to match | genuine underruns — the drain model applies and cushion size matters |
+| #2 > 0 but **#3 stays flat** | **contradiction — chase it.** Something is misreporting; say so loudly rather than picking a side |
+| **#3 flat + #4 near 90%** | **P3 and compute-bound together** — retires the ~600 us line |
+
+### Fill-trace shape (instrument 3)
+
+| trace | model |
+|---|---|
+| flat, brief sub-ms dips, xruns anyway | **P3** — counter artifact |
+| descending sawtooth, resets at each xrun | **P2** — constant clock mismatch |
+| random walk wandering to zero, no cadence | **P2'** — rate-matching / feedback noise |
+| flat then a single cliff to zero | **P1** — a real giant stall; capture what ran |
+
+### Expected, so you can be surprised properly
+
+`dsp_p99` was **34.8% at 1024** and **63-89% at 256**, both condition A. If W1 reproduces a
+steep climb, **256 is compute-bound**: per-callback fixed costs (graph traversal, parameter
+smoothing, block setup) do not shrink with the buffer, so they amortise over fewer samples.
+At ~11% headroom, graph overruns are expected rather than hypothetical.
+
+**Say so if it does not reproduce.** A flat ladder would mean the 63-89% reading was an
+artifact and would put the latency path back in play.
+
+---
+
+## W0 — 30-second check, any idle moment
+
+Does ALSA accept `1024 x 2` on this device at all? `snd-usb-audio` conventionally wants
+`nperiods >= 3`; if it refuses, jackd simply fails to start and the answer took 30 seconds.
+
+**If it opens, that is 64.0 ms -> 42.7 ms of shipping latency with no change to the compute
+deadline** — Surge still gets 21.3 ms for 1024 frames, exactly as it does today. Report only
+whether it opens; do not measure it yet. That is W2.
+
+---
+
+## Rules
+
+1. **One variable per cell.** The load must be identical across W1-a/b/c. If you cannot hold
+   it, stop and say so rather than proceeding.
+2. **No config, kernel, or priority changes.** W1 is measurement only. `irq/30` stays at
+   FF 50.
+3. **No commands against the Pi while a window is open** — including read-only ones. Batch
+   between windows. Instrument 3's poller is part of the run, not an interruption.
+4. **No subprocess forks inside the polling loop.**
+5. **Resolve the card index live.** Never hardcode it.
+6. **Report n.** Three streams cannot establish distribution shape — Step 4 was misread that
+   way. If a claim needs shape, say how many streams support it.
+7. If a result refutes something in the docs above, **name the doc and say so plainly.**
+
+## Deliverable
+
+`docs/measurements/w1-instrumented-window-2026-08-21.md`, on a branch off `dev`:
+
+- the four-instrument table, per cell
+- **which interpretation row you landed in**, stated explicitly
+- the fill-trace shape per cell, with the raw trace kept as an artifact
+- the W0 answer (opens / refuses)
+- a **"what this retires"** section — every line of work now dead, named
+- anything you could not measure, and why
+
+**Do not propose next steps beyond stating what W1's outcome implies.** The plan is in
+`PLAN-2026-08-21-evening.md`; W1's job is to decide between its branches, not to add new
+ones.

--- a/docs/measurements/PROMPT-YOLO-poly-governor.md
+++ b/docs/measurements/PROMPT-YOLO-poly-governor.md
@@ -1,0 +1,129 @@
+# Agent prompt (yolo) — poly governor: instrument and de-risk, do not retune
+
+Copy everything below the line.
+
+---
+
+## Scope
+
+**Make the governor visible and configurable. Do NOT retune its thresholds, and do NOT
+re-enable it.** Calibration is gated on the V7 capacity curve, which has not run.
+
+Target: `patch_browser/surge_poly_governor.py` (259 lines), plus
+`patch_browser/surge_cpu_monitor.py` and `patch_browser/surge_playback.py` as needed.
+
+## Why this work exists
+
+Confirmed by ear on 2026-08-21: **the "quick pops on chords from heavy patches" were this
+governor.** With it disabled the pops vanish. It was cutting Surge's poly limit under CPU
+load, and sounding voices were being removed.
+
+It was **also active with an unset env during every measurement this project has ever run**,
+silently varying voice count in response to the CPU load being measured. It confounded W1's
+entire DSP ladder. Nobody noticed because **it logs nothing but errors.**
+
+## Leading hypothesis — record it, do not act on it yet
+
+`SurgeCpuMonitor` reads **`/proc` CPU time for the `surge-xt-cli` process**. Surge's audio
+thread is essentially the whole process, so that signal tracks DSP load closely.
+
+**Measured normal DSP load at 1024 x 3 is ~58.9%. `CPU_HIGH_THRESHOLD` is 50.0.**
+
+If those are comparable quantities, **the governor's step-down threshold sits below baseline
+load** — it would be in near-permanent step-down during ordinary playing, and
+`CPU_LOW_THRESHOLD = 40.0` is low enough that it would rarely recover. That explains the pops
+far better than steal policy does: it was not protecting against overload, it was cutting
+voices continuously.
+
+**Your job is to make this measurable, not to fix it by guessing new numbers.**
+
+## Already present — do not re-add
+
+**Hysteresis exists**: separate `CPU_HIGH_THRESHOLD` / `CPU_LOW_THRESHOLD`, plus
+`CPU_HIGH_HOLD_S` (0.15) and `CPU_LOW_HOLD_S` (5.0), and asymmetric `STEP_DOWN` / `STEP_UP`.
+An earlier design note proposed adding hysteresis; **it is redundant, strike it.**
+
+---
+
+## Task A — telemetry (highest value, lowest risk)
+
+**Every poly-limit change must be logged**, to the journal, one line each:
+
+```
+poly-governor: 16 -> 14  reason=high  cpu=61.2 raw=64.8  patch="<name>"  held=0.30s
+```
+
+Include: old value, new value, **reason** (high / spike / emergency / warm / recover /
+patch-load / manual), blended `cpu` **and** `raw_percent`, the patch name, and how long the
+condition was held before acting.
+
+Also log **once at startup**: enabled/disabled, every threshold and step constant in effect,
+and the resolved floor/ceiling. **The governor's configuration must be discoverable from the
+journal without reading source.**
+
+**Cost constraint:** this runs at `POLL_INTERVAL_S = 0.15`. **Log on state change only, never
+per tick.** No subprocess forks. No string formatting in the hot path when nothing changed.
+
+## Task B — make thresholds configurable, keep defaults identical
+
+Move `CPU_EMERGENCY_THRESHOLD`, `CPU_SPIKE_THRESHOLD`, `CPU_HIGH_THRESHOLD`,
+`CPU_WARM_THRESHOLD`, `CPU_LOW_THRESHOLD`, `CPU_HIGH_HOLD_S`, `CPU_LOW_HOLD_S`, `STEP_DOWN`,
+`STEP_DOWN_SPIKE`, `STEP_DOWN_WARM`, `STEP_UP` to env overrides with the **current values as
+defaults**, following the existing `MPE_POLY_*` convention.
+
+**Behaviour must be byte-for-byte identical when no env vars are set.** State that explicitly
+in the commit message. Document each in `config/mpe.env.example`, commented out, with the
+default noted — matching how `MPE_CPU_GOVERNOR` is documented there.
+
+This lets V7's capacity numbers be applied without a code change.
+
+## Task C — investigate, do not implement: what does Surge do on a poly-limit drop?
+
+`send_polylimit()` sends an OSC float to `POLY_LIMIT_OSC`. **Surge decides which voices die
+and how.** The class docstring asserts *"Surge softkill, not MIDI note-offs"* — treat that as
+a **claim to verify, not a fact.**
+
+Establish and write up:
+
+1. When `/polylimit` drops below the currently sounding count, does Surge **fade** removed
+   voices or **hard-cut** them? A hard cut is a step discontinuity — **that is the pop.**
+2. If Surge hard-cuts, is there an alternative that does not (release the voice, let its
+   envelope run, and lower the ceiling for new notes only)?
+3. Could we avoid the problem entirely by **lowering the limit only at note-off boundaries**,
+   so the ceiling never drops below what is currently sounding?
+
+**Report findings. Do not implement a fix in this pass** — the right layer is not yet known,
+and it may not be our code.
+
+### Steal policy — for the record, not for implementation
+
+An earlier draft proposed **refusing note-ons** rather than stealing sounding voices.
+**That is wrong for a performance instrument** (Mitch, 2026-08-21): the player presses a key
+and gets silence, which reads as broken. Voice stealing is standard and expected.
+**The problem is the hard cut, not the stealing.** If a policy is ever needed, the order is
+**released/in-release first, then quietest, then oldest.**
+
+## Task D — verification
+
+- Unit-test or manually exercise the logging path: force a state change and confirm one line
+  per transition, correct fields, **no per-tick spam**.
+- Confirm defaults-unchanged: with no env set, the constants resolve to today's values.
+- Confirm no added cost in the 0.15 s loop — no forks, no per-tick allocation or formatting.
+
+## Explicit non-goals
+
+- **Do not retune any threshold.** Gated on V7.
+- **Do not re-enable the governor.** It is deliberately off; measurement depends on that.
+- **Do not implement fade or steal-policy changes.** Task C decides where that belongs.
+- Do not touch the audio path, jackd config, or buffer settings.
+
+## Deliverable
+
+Branch off `dev`. Commit the code changes plus
+`docs/measurements/poly-governor-instrumentation-2026-08-21.md` containing:
+
+- what was logged and an example line
+- the full table of env vars added, with defaults
+- **Task C findings** — what Surge actually does on a poly-limit drop, with evidence
+- an explicit statement that **defaults are unchanged and the governor remains disabled**
+- the threshold-vs-baseline mismatch recorded as an open calibration question for V7

--- a/docs/measurements/PROMPT-YOLO-poly-governor.md
+++ b/docs/measurements/PROMPT-YOLO-poly-governor.md
@@ -92,10 +92,31 @@ with the SDIO WiFi**.
 it cannot preempt them, but it pollutes their cache and competes between callbacks.
 `mpe-jackd` and `surge-xt-cli` both declare `CPUAffinity=2 3`; this one declares nothing.
 
-**Add `CPUAffinity=1`** — off the audio cores, and off CPU0 which carries the unmovable xhci
-IRQ. Note in the deliverable that this is a **pre-existing gap unrelated to the logging work**,
-and check whether `midi-clock-in`, `surge-watchdog`, `sl-watchdog` and `touch-patch-browser`
-have the same omission — report, do not fix them in this pass.
+**Add `CPUAffinity=0 1`** — both non-audio cores.
+
+**Use `0 1`, not a single core.** The requirement is *exclusion* (keep it off 2-3), not
+*placement*; two cores lets the scheduler balance. Do not pin to CPU1 alone — CPU1 is now the
+interrupt sink (relocated IRQs 41/42/43/28/57, `watchdogd`, the peak meter). Do not pin to
+CPU0 alone — it carries the unmovable xhci IRQ at ~4.14 M counts. Either is fine as one of
+two; neither is right as the only one.
+
+Note in the deliverable that this is a **pre-existing gap unrelated to the logging work.**
+
+### Report only — do not fix in this pass
+
+**systemd's global `CPUAffinity` in `system.conf` is unset**, so *every* unit defaults to all
+four cores; only `mpe-jackd` and `surge-xt-cli` declare anything. Pinning services one at a
+time is whack-a-mole — `midi-clock-in`, `surge-watchdog`, `sl-watchdog`,
+`touch-patch-browser`, `mpe-session-publisher` and anything added later are all still free to
+land on the audio cores.
+
+**The structural fix is to set the global default to `0 1` and let the audio units override
+to `2 3`** — one line, declarative, covers every present and future service.
+
+**Do not do it in this pass.** It constrains *everything* to two cores, including the touch
+UI and patch loading, which is user-visible. It needs its own change with a before/after check
+on touch-browser responsiveness. **Enumerate which units currently declare no affinity and
+record the list**; that is the input to that decision.
 
 ## Task B — make thresholds configurable, keep defaults identical
 

--- a/docs/measurements/PROMPT-YOLO-poly-governor.md
+++ b/docs/measurements/PROMPT-YOLO-poly-governor.md
@@ -61,8 +61,41 @@ Also log **once at startup**: enabled/disabled, every threshold and step constan
 and the resolved floor/ceiling. **The governor's configuration must be discoverable from the
 journal without reading source.**
 
-**Cost constraint:** this runs at `POLL_INTERVAL_S = 0.15`. **Log on state change only, never
-per tick.** No subprocess forks. No string formatting in the hot path when nothing changed.
+### Cost constraints — read before writing any logging code
+
+This daemon runs at `POLL_INTERVAL_S = 0.15` and its unit sets **`PYTHONUNBUFFERED=1`** with
+**`StandardOutput=journal`**. That means **every `print()` is an immediate `write()` syscall
+with no batching**, and journald then writes to the SD card — which lands on **IRQ 41, shared
+with the SDIO WiFi**.
+
+| logging rate | consequence |
+|---|---|
+| per-tick @ 0.15 s | ~400 lines/min, 400 unbuffered syscalls, continuous journald -> SD churn |
+| **state-change only** | a handful of lines/min — noise against the ~16 MiB/60 s of SD writes already present |
+
+**Requirements:**
+
+- **Log on state change only. Never per tick.** Guard the call so an unchanged state does no
+  work at all — no string formatting, no f-string evaluation, no allocation.
+- **No subprocess forks** (CPU doctrine).
+- If anything higher-rate is ever wanted for diagnostics, write it to **`/run/mpe` (tmpfs,
+  RAM-backed, zero SD writes)** via `RuntimeDirectory=mpe`, as `mpe-peak-meter.service`
+  already does — **not** to the journal. Journal is for state changes only.
+- Add a **spam guard**: if transitions exceed a sane rate (say 10/s), collapse to a single
+  summary line rather than emitting each. A miscalibrated threshold can make this oscillate,
+  and the logging must not amplify that.
+
+### Task A2 — pin the service (pre-existing defect, fix it here)
+
+**`surge-poly-governor.service` declares no `CPUAffinity`.** It floats across all four cores,
+**including CPU2 and CPU3 where jackd (FF 70) and Surge (FF 65) run.** It is `SCHED_OTHER` so
+it cannot preempt them, but it pollutes their cache and competes between callbacks.
+`mpe-jackd` and `surge-xt-cli` both declare `CPUAffinity=2 3`; this one declares nothing.
+
+**Add `CPUAffinity=1`** — off the audio cores, and off CPU0 which carries the unmovable xhci
+IRQ. Note in the deliverable that this is a **pre-existing gap unrelated to the logging work**,
+and check whether `midi-clock-in`, `surge-watchdog`, `sl-watchdog` and `touch-patch-browser`
+have the same omission — report, do not fix them in this pass.
 
 ## Task B — make thresholds configurable, keep defaults identical
 

--- a/docs/measurements/PROMPT-find-the-600us.md
+++ b/docs/measurements/PROMPT-find-the-600us.md
@@ -205,21 +205,32 @@ The failing config therefore does the same total USB work in fewer, larger URBs.
 are throttled at 95% of every period. Step 2 adds `cyclictest` at **FIFO 70** on top of
 jackd (FIFO 70) and surge (FIFO 65).
 
-**If the throttle is at its default, the combined RT utilization can trip it, and cyclictest
-will be measuring RT throttling rather than scheduler latency** — producing a large max
-unrelated to the 600 us.
+**Calibration (corrected).** cyclictest *sleeps* between samples — it arms a timer, blocks,
+wakes, measures the wakeup error. Its own CPU consumption is a few percent, not saturating.
+Against a measured DSP load of 35-40%, total RT utilization is nowhere near 95%, so **the
+throttle almost certainly will not fire.** The earlier framing of this as a likely confound
+was too strong.
 
-Do **not** stop a run in flight for this. Instead:
+**More importantly: throttling was never a candidate for the 600 us.** It operates at tens
+of milliseconds (up to the 50 ms reserved slice). It is a candidate for an occasional
+enormous outlier, not for a steady sub-millisecond gap.
 
-1. Let the run finish.
-2. Read `sysctl -n kernel.sched_rt_runtime_us kernel.sched_rt_period_us`.
-3. **If it is 950000 / 1000000, the Step 2 max is uninterpretable as scheduler latency.**
-   Say so, then re-run 2a/2b with `kernel.sched_rt_runtime_us = -1` (throttling disabled)
-   and compare. That is a one-variable change and needs no reboot (`sysctl -w`).
-4. If throttling is already disabled (-1), the Step 2 numbers stand as measured.
+**How to tell from the output:**
 
-Report the throttle values in the deliverable **regardless of outcome** — they are not
-currently tracked anywhere in the repo.
+| cyclictest max | reading |
+|---|---|
+| tens of **milliseconds** | consistent with RT throttling — investigate |
+| ~1 ms or below | throttling is not involved; the numbers stand as scheduler latency |
+
+**Therefore:**
+
+1. **Read** `sysctl -n kernel.sched_rt_runtime_us kernel.sched_rt_period_us` and report both
+   values. They are free to obtain and are **not tracked anywhere in the repo** — that is
+   their own defect regardless of this test.
+2. **Do not re-run Step 2 on account of throttling** unless the max actually lands in the
+   tens-of-ms range. If it does, re-run 2a/2b with `sysctl -w kernel.sched_rt_runtime_us=-1`
+   (one variable, no reboot) and compare.
+3. Do not stop a run in flight for any of this.
 
 ### Step 0 is now the priority
 

--- a/docs/measurements/PROMPT-find-the-600us.md
+++ b/docs/measurements/PROMPT-find-the-600us.md
@@ -1,0 +1,126 @@
+# Agent prompt — locate the ~600 us (2026-08-21)
+
+Copy everything below the line into the agent.
+
+---
+
+## Context you must not re-derive
+
+Read these first. Do not re-litigate their conclusions.
+
+- `docs/measurements/scarlett-verdict-2026-08-21.md` — the Scarlett is ~10x **worse** at
+  256x3 cond A (69.7/min vs the Sound Blaster's 7.1/min). Bimodality vanished on the async
+  device, so the SB's stream-start lottery was **adaptive clock lock, not frame phase**.
+  **Frame alignment is a closed question.** T15/T16/T17 and the aligned drop-in table
+  (240/480/1008) are withdrawn.
+- `docs/measurements/t13-runway-refuted-2026-08-21.md` — URB queue *depth* is not the
+  binding term (128x6 vs 256x3, identical total buffer, 466x apart).
+- `docs/measurements/t11-condA-ladder-2026-08-21.md` — at 64 frames the callback **never
+  missed its deadline** while ~6% of periods underran. Callback lateness sits near ~900 us
+  at every buffer size and does not scale with period.
+- `docs/measurements/cpu-census-2026-08-21.md` — **IRQ 30 (xhci) is unmovable and lands on
+  CPU0** (empty `effective_affinity`). `mpe-jackd` and `surge-xt-cli` are pinned to CPU 2-3.
+
+**The open question:** bare `cyclictest` floors at 209-320 us, but callback lateness is
+~900 us. **~600 us is unexplained.** It is device-independent — two interfaces with
+opposite transport characteristics both fail at small buffers. Find where it lives.
+
+## Rules
+
+1. **One variable per step.** If a step would change two things, stop and say so.
+2. **Steps 1 and 2 change no configuration and require no reboot.** Keep it that way.
+   Do not "helpfully" bundle a fix into a diagnostic step.
+3. **Never run any command against the Pi while a measurement window is open**, including
+   read-only ones. Batch queries between windows.
+4. **Do not resolve card numbers from memory** — the Scarlett's card index has been
+   reported inconsistently. Resolve it live from `/proc/asound/cards` and echo what you
+   found before using it.
+5. Report **withdrawn** claims explicitly if a step refutes something in the docs above.
+
+---
+
+## Step 1 — IRQ 30 rate census (~10 min, no reboot)
+
+**Hypothesis under test:** high speed uses 125 us microframes (8x full speed's 1 ms), and
+smaller periods mean fewer packets per URB, so the Scarlett at 256 generates far more URB
+completions — all serviced by IRQ 30 on CPU0. If true, IRQ30/s is the mechanism and
+`lowlatency=N` (which batches more packets per URB) is the lever.
+
+**Method.** For each cell, bring up the stack in condition A, let the stream settle 15 s,
+then `cat /proc/interrupts` twice **60 s apart** and take the delta on IRQ 30. Record the
+per-CPU split, not just the total. Also record IRQ 30's `effective_affinity` once to
+confirm it is still empty/CPU0.
+
+| # | device | period x nperiods | channels opened |
+|---|---|---|---|
+| 1a | Scarlett | 256 x 3 | record what jackd actually opens |
+| 1b | Scarlett | 1024 x 3 | record what jackd actually opens |
+| 1c | Sound Blaster | 256 x 3 | record what jackd actually opens |
+
+Report a table: cell, IRQ30 delta/60s, IRQ30/s, per-CPU split, xruns/min in the same window.
+
+**Interpretation — state which branch you are in:**
+- **1a markedly higher than 1b and 1c** → URB-rate hypothesis **supported**. `lowlatency=N`
+  earns a reboot slot in Step 3.
+- **1a comparable to the others** → URB-rate hypothesis **refuted**. Say so plainly, and
+  **drop `lowlatency=N` from Step 3.** Do not run it anyway.
+
+Also note whether jackd opened 4 playback channels on the Scarlett when only 2 are used. If
+so, check whether a 2-channel altsetting exists — report only, change nothing.
+
+## Step 2 — cyclictest under real conditions (~15 min, no reboot)
+
+**This is the step that finds the 600 us.** Do not skip or reorder it.
+
+With the **full audio stack running and streaming** (condition A, 256 x 3 — the config that
+fails), run `cyclictest` for **5 minutes**, `SCHED_FIFO` priority **70**, pinned:
+
+- **2a — pinned to CPU3** (inside the audio-pinned set, alongside jackd/surge)
+- **2b — pinned to CPU0** (where the unmovable xhci IRQ lands)
+
+Report min / avg / p99 / max for each, against the **bare floor of 209-320 us** already on
+record. Note that priority 70 sits above jackd's FIFO 65 by design — the point is to
+measure what the scheduler *can* deliver, not to be polite. Confirm the audio stack stayed
+up and log its xrun rate during the run so we know the load was real.
+
+**Interpretation — state which branch you are in, explicitly:**
+- **~900 us under load** → the gap is **generic scheduler latency**, nothing audio-specific.
+  Levers become `isolcpus`, `nohz_full`, `threadirqs`, ultimately PREEMPT_RT.
+- **still ~300 us under load** → the gap lives **inside the ALSA/JACK/USB wakeup path**, and
+  general RT tuning will not touch it. Levers become `threadirqs` (so IRQ 30's *handler
+  thread* can be placed even though the IRQ itself cannot), IRQ consolidation off CPU0, and
+  USB topology.
+- **2a and 2b differ sharply** → say so. That is a placement finding in its own right.
+
+**Stop here and report.** Do not proceed to Step 3 without the results of 1 and 2 in hand.
+
+## Step 3 — one reboot, carrying everything earned (~10 min)
+
+Assemble a **single** cmdline/config change containing only what Steps 1-2 justified:
+
+- **v3d removal** — hygiene, always included. It is on CPU1, outside the audio path, so
+  **expect no measurable effect**; we are removing 957k interrupts from the picture, not
+  fixing anything. **Gate:** confirm `touch_patch_browser.py` does not use GL before
+  removing the driver. If it does, relocate rather than remove.
+- **Whatever Step 2's branch implies** — most likely `threadirqs`.
+- **`snd_usb_audio.lowlatency=N`** — **only if Step 1 supported it.**
+
+Also verify, in the same window, that the HDMI IRQ and crtc threads actually disappeared
+after the earlier cmdline change. That has never been confirmed.
+
+Record in the doc that this reboot changes multiple things at once and is therefore a
+**bundle, not an experiment** — it cannot attribute effect to cause. That is accepted
+deliberately to save reboots; the attribution comes from Steps 1-2, which were clean.
+
+## Step 4 — spot-check (~12 min)
+
+One cell only: **Scarlett 256 x 3 condition A, 3 streams x 3 runs**, against the 69.7/min
+baseline. This confirms the bundle did no harm and shows whether it helped. It is not a
+re-baseline and must not be described as one.
+
+## Deliverable
+
+`docs/measurements/find-600us-2026-08-21.md` on a branch off `dev`, containing per-step
+tables, the branch you landed in at each interpretation point, and a short **"what is now
+ruled out"** section. If a step refutes something in the context docs above, say so
+directly and name the doc.

--- a/docs/measurements/PROMPT-find-the-600us.md
+++ b/docs/measurements/PROMPT-find-the-600us.md
@@ -25,6 +25,10 @@ Read these first. Do not re-litigate their conclusions.
 ~900 us. **~600 us is unexplained.** It is device-independent — two interfaces with
 opposite transport characteristics both fail at small buffers. Find where it lives.
 
+**Already done, do not repeat:** Step 2 hygiene pruned `bluetooth`, `avahi-daemon`,
+`cron`, `udisks2`, `cloud-init` and masked the maintenance timers; movable IRQs (41/42/43/
+28/57) are relocated to CPU1 at boot by `mpe-irq-affinity.service`.
+
 ## Rules
 
 1. **One variable per step.** If a step would change two things, stop and say so.
@@ -36,6 +40,49 @@ opposite transport characteristics both fail at small buffers. Find where it liv
    reported inconsistently. Resolve it live from `/proc/asound/cards` and echo what you
    found before using it.
 5. Report **withdrawn** claims explicitly if a step refutes something in the docs above.
+
+---
+
+## Step 0 — storage and log-write audit (~5 min, no reboot, read-only)
+
+**Do this first. It is read-only and may change what the later steps mean.**
+
+Context: `docs/STORAGE-ROBUSTNESS.md:7` states the appliance still runs a **full mutable
+Raspberry Pi OS on ext4**, and volatile journal storage is listed there as **proposed, not
+implemented**. Neither swap nor journald persistence has ever been audited on this box.
+
+This matters because **IRQ 41 is `mmc0/mmc1` — the SD card and the SDIO WiFi share one
+interrupt line** (1.90 M counts, currently relocated to CPU1 by `mpe-irq-affinity.service`).
+Every SD write and every WiFi packet lands on the same handler. Disk tuning and WiFi tuning
+are therefore the same problem here, not two.
+
+Report, changing nothing:
+
+| # | check | command |
+|---|---|---|
+| 0a | swap enabled? size? backing device? | `swapon --show`, `free -h`, `systemctl is-enabled dphys-swapfile` |
+| 0b | if swap is on: has it been touched? | `vmstat -s \| grep -i swap`, `/proc/vmstat` `pswpin`/`pswpout` |
+| 0c | major faults by the audio processes | `ps -o pid,comm,maj_flt -p $(pgrep -d, 'jackd\|surge')` |
+| 0d | journald storage mode + on-disk size | `journalctl --disk-usage`, `grep -r Storage= /etc/systemd/journald.conf*` |
+| 0e | SD write rate at idle vs during a stream | `/proc/diskstats` for `mmcblk0`, 60 s delta, both states |
+| 0f | does the measurement harness itself write to SD during a window? | inspect harness paths — `/run/mpe` is tmpfs and fine; anything under `/var` or `/home` is not |
+| 0g | `vm.swappiness`, and whether jackd/surge use `MemoryLock` / `mlockall` | `sysctl vm.swappiness`; check unit files |
+
+**Why this could matter to the 600 us.** If swap is enabled on the SD card, a cold page
+touched inside the audio callback takes an **SD-backed major fault**. That is
+device-independent, load-correlated, and would fit "512 crackles with heavy patches"
+precisely. It would also **not** show up the way we have been measuring: a major fault
+stalls the callback without necessarily registering as callback lateness in the harness.
+
+**Do not treat this as a confirmed cause.** It is an unexamined candidate that is cheap to
+rule in or out. Report `pswpin`/`pswpout` and `maj_flt` as the deciding numbers:
+
+- **`pswpin` > 0 or audio-process `maj_flt` growing during play** → swap is live in the
+  audio path. Escalate immediately; this outranks Steps 1-2.
+- **both flat and swap off** → ruled out. Say so and move on. Do not keep it on the list.
+
+If 0e shows meaningful SD writes during a stream, name **what** is writing before proposing
+any change.
 
 ---
 
@@ -100,8 +147,9 @@ Assemble a **single** cmdline/config change containing only what Steps 1-2 justi
 
 - **v3d removal** — hygiene, always included. It is on CPU1, outside the audio path, so
   **expect no measurable effect**; we are removing 957k interrupts from the picture, not
-  fixing anything. **Gate:** confirm `touch_patch_browser.py` does not use GL before
-  removing the driver. If it does, relocate rather than remove.
+  fixing anything. **Gate is already cleared** —
+  `docs/measurements/step2-hygiene-applied-2026-08-21.md:29` records that pygame does not
+  use GL; the blacklist was deferred, not blocked. Do not re-litigate this.
 - **Whatever Step 2's branch implies** — most likely `threadirqs`.
 - **`snd_usb_audio.lowlatency=N`** — **only if Step 1 supported it.**
 

--- a/docs/measurements/PROMPT-find-the-600us.md
+++ b/docs/measurements/PROMPT-find-the-600us.md
@@ -172,3 +172,63 @@ re-baseline and must not be described as one.
 tables, the branch you landed in at each interpretation point, and a short **"what is now
 ruled out"** section. If a step refutes something in the context docs above, say so
 directly and name the doc.
+
+---
+
+## AMENDMENT (post Step 1) — URB-rate hypothesis inverted; Step 2 confound
+
+**Step 1 result.** Scarlett cond A, IRQ 30 (`xhci_hcd`, BRCM-PCI-MSI, CPU0 only):
+
+| cell | IRQ30/s | xruns/min |
+|---|---|---|
+| 1024 x 3 | **1999** | **0** |
+| 256 x 3 | ~1000 (approx, per agent) | fails badly |
+| 1c Sound Blaster | skipped — unplugged | — |
+
+**The hypothesis is not merely refuted, it is inverted:** the config with double the
+interrupt rate has zero xruns, and the failing config has half the rate. Skipping 1c does
+not weaken this — 1a vs 1b inverts it on its own.
+
+**It is stronger than the counts suggest.** The byte rate is *identical* at both buffer
+sizes — same sample rate, same channels, same bytes/second. Only the **chunking** differs.
+The failing config therefore does the same total USB work in fewer, larger URBs.
+**Interrupt volume and throughput are off the table as causes.**
+
+**Consequences:**
+- `snd_usb_audio.lowlatency=N` is **struck from Step 3**, per Step 1's stated kill condition.
+- Every surviving candidate is a **latency** mechanism (how long one wakeup takes), not a
+  **volume** one (how many wakeups there are). Steps 0 and 2 measure exactly that.
+
+### Confound on the Step 2 run — read before interpreting
+
+`kernel.sched_rt_runtime_us` defaults to **950000** against a period of 1000000: RT tasks
+are throttled at 95% of every period. Step 2 adds `cyclictest` at **FIFO 70** on top of
+jackd (FIFO 70) and surge (FIFO 65).
+
+**If the throttle is at its default, the combined RT utilization can trip it, and cyclictest
+will be measuring RT throttling rather than scheduler latency** — producing a large max
+unrelated to the 600 us.
+
+Do **not** stop a run in flight for this. Instead:
+
+1. Let the run finish.
+2. Read `sysctl -n kernel.sched_rt_runtime_us kernel.sched_rt_period_us`.
+3. **If it is 950000 / 1000000, the Step 2 max is uninterpretable as scheduler latency.**
+   Say so, then re-run 2a/2b with `kernel.sched_rt_runtime_us = -1` (throttling disabled)
+   and compare. That is a one-variable change and needs no reboot (`sysctl -w`).
+4. If throttling is already disabled (-1), the Step 2 numbers stand as measured.
+
+Report the throttle values in the deliverable **regardless of outcome** — they are not
+currently tracked anywhere in the repo.
+
+### Step 0 is now the priority
+
+Run `scripts/audit-storage-rt.sh` (read-only, in the repo, changes nothing). It carries
+three live candidates, all latency mechanisms consistent with the Step 1 inversion:
+
+1. **Swap-backed major faults** — `pswpin`/`pswpout`, audio-process `maj_flt` during play
+2. **RT throttling** — `kernel.sched_rt_runtime_us` (also gates Step 2 above)
+3. **journald SD writes** — persistent journal on the shared `mmc`/SDIO-WiFi IRQ 41 line
+
+Run it **once idle** and **once with a stream up**, the latter in its own window, not inside
+a counted one. Use `--delta 60` for the streaming pass.

--- a/docs/measurements/V1-VERDICT-no-fixed-cost-2026-08-21.md
+++ b/docs/measurements/V1-VERDICT-no-fixed-cost-2026-08-21.md
@@ -1,0 +1,96 @@
+# V1 verdict — the fixed-cost model was wrong, and W1's ladder is confounded
+
+**2026-08-21.** Reading of `v1-fixed-cost-2026-08-21.md` (V0 + V1 + V2, ~10 min Pi time).
+
+## Retracted: the ~1.1 ms fixed per-callback cost
+
+`W1-VERDICT-compute-bound-2026-08-21.md` proposed **a = 1.10 ms fixed per callback**, fitted
+across three cells and used to retrodict the T11 ladder.
+
+**V1 silence test, outcome row 3 — not flat, scales with buffer:**
+
+| buffer | median ms (silence) | ~% of deadline |
+|---|---|---|
+| 1024 | 1.29 | ~6% |
+| 512 | 0.74 | ~7% |
+| 256 | 0.42 | ~8% |
+
+Fitting `a + b*N` on these: **a = 0.13 ms** — roughly **8x smaller** than the claimed 1.10 ms,
+and small enough that percent-of-deadline is nearly flat at silence.
+
+**The model is withdrawn.** The three-point regression over `dsp_p99` was noise. This was the
+stated weakness when it was proposed (`PLAN-V-fixed-callback-cost.md`: *"a least-squares fit
+over three points, n=1 each, using a statistic W1 itself showed is wrong"*), and V1 existed
+to kill it in ten minutes rather than after a profiling session. **V4 is gated off — do not
+profile for a fixed constant that does not exist.**
+
+## Dead: the single-client architecture refactor
+
+**Surge ON minus OFF at 1024, silence: ~35 us.** JACK graph traversal and inter-client
+context switching are **noise**. The ~1.3 ms measured at 1024 is baseline graph plus
+instrumentation, not Surge.
+
+**Hosting the looper inside Surge's process would buy nothing.** A substantial refactor
+avoided for ten minutes of measurement — the clearest win of Plan V.
+
+## Dead: the `ondemand` explanation for the pops
+
+V0 found the box **already `performance` @ 1800 MHz with `arm_boost=1`**.
+
+- **V5 and V6 are moot** — we were already at pinned max clock. W1 likely ran at full clock
+  throughout.
+- **The governor-ramp explanation for Mitch's "quick pops on chords from silence" is
+  withdrawn.** There is no ramp; the clock was pinned.
+
+## New confound found — W1's DSP ladder is not usable
+
+**The poly governor was active with an unset env during W1 and every prior cell.**
+
+It is a **feedback controller that reduces polyphony in response to CPU load** — the exact
+quantity being measured. W1's ladder (58.9 / 62.4 / 76.1%) was therefore recorded while voice
+count was being silently varied by load. **Those figures cannot carry the weight placed on
+them.** If poly was cut harder at 256, the true per-voice cost there is *worse* than 76.1%
+suggests.
+
+### What survives untouched
+
+**The graph-overrun finding stands.** `JackEngine::XRun: Surge XT was not finished`, **zero**
+`ALSA: xrun of at least N msecs` lines, fill flat at ~83%. That is a presence/absence result,
+not a rate, and no controller affects it.
+
+**The appliance is compute-bound. Only the ladder numbers are confounded.**
+
+## What the data now suggests — to be tested, not assumed
+
+Subtracting silence from W1's (confounded) loaded figures:
+
+| buffer | loaded | silence | voice work | absolute | per frame |
+|---|---|---|---|---|---|
+| 1024 | 58.9% | ~6% | ~53% | 11.3 ms | **11.0 us/frame** |
+| 256 | 76.1% | ~8% | ~68% | 3.62 ms | **14.1 us/frame** |
+
+Indicatively **~28% worse per frame at 256** — i.e. the inefficiency is in the **voice path at
+small buffers**, not in fixed overhead. **This arithmetic uses confounded inputs and is a
+hypothesis only.**
+
+## Next
+
+| # | cell | Pi time | why |
+|---|---|---|---|
+| **V7** | **Loaded ladder 1024/512/256, poly pinned 16, poly governor OFF, strict mode** | ~15 min | **the valid version of W1's ladder.** Everything we believe about "how bad is 256" rests on confounded numbers |
+| **V3** | `1024 x 2` at n >= 3 | ~15 min | independent free latency win; unaffected by any of this |
+| **EAR** | Mitch plays chords from silence on heavy patches, poly governor now OFF | 0 | see below |
+
+**V7 before V3** — V3's value does not depend on V7, but V7 repairs the foundation.
+
+### The pop hypothesis, now testable for free
+
+With `ondemand` excluded, a better candidate: **the poly governor itself.** It cuts polyphony
+when CPU rises; from silence, a chord on a heavy patch spikes CPU, the controller drops poly,
+and **voices are stolen mid-note** — brief, load-dependent, and audible exactly as described.
+
+**It is now disabled.** The cheapest test in the project is Mitch playing the same thing and
+reporting whether the pops persist. **If they vanish, the pops were our own controller.**
+
+Report instruments as required by `PROMPT-V-fixed-callback-cost.md`: absolute **ms** as well
+as percent, **p99.9 / p99.99 / max** rather than p99, and the jackd journal per window.

--- a/docs/measurements/V7-capacity-curve-plan.md
+++ b/docs/measurements/V7-capacity-curve-plan.md
@@ -1,0 +1,102 @@
+# V7 — capacity curve, and fixing the governor's actuation
+
+**2026-08-21.** Supersedes the V7 cell proposed in `V1-VERDICT-no-fixed-cost-2026-08-21.md`
+(loaded ladder at fixed poly 16), which asks the wrong question.
+
+## Two ear results that settle a lot
+
+| condition | result |
+|---|---|
+| poly governor **OFF** | **pops gone** |
+| poly governor **OFF**, CPU maxed deliberately | **crackle, on demand** |
+
+**1. The pops were our own controller.** `surge-poly-governor` cut polyphony when CPU rose,
+which **stole sounding voices mid-note**. Not the kernel, not USB, not the interface, not the
+buffer size. A feedback loop we wrote.
+
+**2. The crackle confirms compute-bound by hand.** With nothing limiting voices, the callback
+can be walked past its deadline on demand — `JackEngine::XRun: Surge XT was not finished`,
+reproducible without instrumentation.
+
+## The governor is right; its actuator is wrong
+
+Both configurations fail audibly:
+
+| poly governor | failure mode |
+|---|---|
+| **on** | **pops** — sounding voices truncated when the ceiling drops |
+| **off** | **crackle** — deadline exceeded under overload |
+
+The controller's *goal* (protect the deadline) is correct. Its *actuation* (kill voices that
+are currently sounding) is what is audible.
+
+### Fix 1 — never truncate a sounding voice
+
+Apply a reduced ceiling to **new** voices only: refuse note-ons above the ceiling rather than
+stealing from those already sounding. **A note that never starts is far less audible than a
+note that stops.** This removes the pops while keeping overload protection.
+
+Implementation note: the governor sets Surge's poly limit over OSC. When that limit drops
+below the currently-sounding count, Surge decides what dies. **Check what Surge actually does
+in that case** before assuming the fix belongs in our governor — it may belong in how we
+drive the limit (monotonic-down only at note-off boundaries) rather than in Surge.
+
+### Fix 2 — fade, do not cut
+
+If a sounding voice must be removed, ramp it out over a few milliseconds. **A hard cut is a
+step discontinuity — that is the pop.** Standard voice-stealing practice.
+
+### Fix 3 — hysteresis
+
+Whatever the ceiling logic, it must not oscillate around the threshold. Rate-limit changes
+and separate the raise and lower thresholds.
+
+## The measurement that is actually needed: a capacity curve
+
+**Every cell in this project has used one fixed load (75 voices) and counted xruns.** That
+measures failure at an arbitrary point. It does not measure **capacity**, which is what both
+the player and the governor need.
+
+**V7: for each buffer size, how many voices of a defined heavy patch can be sustained
+cleanly?**
+
+| cell | buffer | method |
+|---|---|---|
+| V7-a | 1024 x 3 | ramp voice count upward; record first graph overrun and the highest count sustained clean |
+| V7-b | 512 x 3 | as above |
+| V7-c | 256 x 3 | as above |
+
+**Conditions:** poly governor **OFF**, poly ceiling raised out of the way, strict mode,
+governor `performance` @ 1800 MHz (already set), same patch and same voice-entry pattern in
+every cell.
+
+**Report:** voices-to-first-overrun, highest sustained-clean count, and DSP in **absolute ms**
+with **p99.9 / p99.99 / max** — not p99. Capture the jackd journal per window.
+
+### What it produces
+
+1. **The answer to "what can we actually run reliably?"** — asked early in this project and
+   never measured.
+2. **A data-derived poly ceiling per buffer size**, replacing the current
+   `MPE_POLY_CEILING=12` guess.
+3. **The real shape of the buffer tradeoff** — expressed in voices, which is what a player
+   experiences, rather than in xruns per minute at an arbitrary fixed load.
+
+### Shortest useful version
+
+Ramping to first failure at three buffer sizes. **Do not run soaks at each voice count** —
+the transition is the datum. Confirm the sustained-clean count with a single short window per
+buffer, not a long one.
+
+## Still open, unchanged
+
+- **V3 — `1024 x 2`** at n >= 3. Independent free latency win: 64.0 ms -> 42.7 ms with no
+  change to the compute deadline. Unaffected by any of the above.
+- Re-enable the poly governor **after** Fixes 1-3, and re-test by ear. The controller-on pass
+  was deferred, not dropped.
+
+## Retired
+
+`V5` / `V6` (governor, `arm_boost`) — V0 found the box **already `performance` @ 1800 MHz with
+`arm_boost=1`**. Nothing to gain; the `ondemand` explanation for the pops is withdrawn and
+replaced by the poly-governor finding above.

--- a/docs/measurements/V7-capacity-curve-plan.md
+++ b/docs/measurements/V7-capacity-curve-plan.md
@@ -30,21 +30,26 @@ Both configurations fail audibly:
 The controller's *goal* (protect the deadline) is correct. Its *actuation* (kill voices that
 are currently sounding) is what is audible.
 
-### Fix 1 — never truncate a sounding voice
+### Fix 1 — steal by a sensible policy (NOT "never steal")
 
-Apply a reduced ceiling to **new** voices only: refuse note-ons above the ceiling rather than
-stealing from those already sounding. **A note that never starts is far less audible than a
-note that stops.** This removes the pops while keeping overload protection.
+**Corrected 2026-08-21 (Mitch).** An earlier draft proposed refusing note-ons instead of
+stealing sounding voices. **That is wrong for a performance instrument:** the player presses a
+key and gets silence, which reads as broken. Voice stealing is standard and expected, and a
+quiet old note disappearing is not noticed.
+
+**The problem is the hard cut, not the stealing.** Steal in priority order — **released/in-
+release first, then quietest, then oldest** — and always with Fix 2 applied.
 
 Implementation note: the governor sets Surge's poly limit over OSC. When that limit drops
 below the currently-sounding count, Surge decides what dies. **Check what Surge actually does
 in that case** before assuming the fix belongs in our governor — it may belong in how we
 drive the limit (monotonic-down only at note-off boundaries) rather than in Surge.
 
-### Fix 2 — fade, do not cut
+### Fix 2 — fade, do not cut  **(the actual fix)**
 
 If a sounding voice must be removed, ramp it out over a few milliseconds. **A hard cut is a
-step discontinuity — that is the pop.** Standard voice-stealing practice.
+step discontinuity — that *is* the pop.** This is the change that removes the artefact;
+Fix 1 only decides which voice is least missed.
 
 ### Fix 3 — hysteresis
 

--- a/docs/measurements/W1-VERDICT-compute-bound-2026-08-21.md
+++ b/docs/measurements/W1-VERDICT-compute-bound-2026-08-21.md
@@ -1,0 +1,136 @@
+# W1 verdict — it was never the buffer. It is a 1.1 ms fixed cost per callback.
+
+**2026-08-21.** Reading of `w1-instrumented-window-2026-08-21.md`.
+
+## The finding
+
+Journal during W1-c: `JackEngine::XRun: Surge XT was not finished`.
+**Zero** `ALSA: xrun of at least N msecs` lines at **every** buffer size.
+
+**Every xrun this project has measured is a graph overrun. The ring buffer never drained,
+at any buffer size, ever.** Fill level sat flat at ~83% of buffer throughout.
+
+## What this retires — permanently
+
+All of the following targeted *getting audio out of the buffer on time*. The buffer was
+always full. **They were aimed at a term that does not exist in this system.**
+
+| line of work | status |
+|---|---|
+| the "~600 us unexplained" wakeup-path gap | **retired** — measured a real quantity that never mattered |
+| cushion / drain model (`cushion-model-2026-08-21.md`) | **retired** — correct arithmetic, irrelevant premise |
+| `threadirqs`, `irq/30` priority, IRQ placement | **retired** |
+| `isolcpus`, `nohz_full`, PREEMPT_RT | **retired** |
+| USB runway, URB depth, URB completion rate | already dead; now moot |
+| frame alignment, aligned-period table | already dead; now moot |
+| Scarlett vs Sound Blaster as a latency question | **moot** — neither device was ever the constraint |
+| nperiods sweep W2 (`n` = 2/3/4/6) as a *diagnostic* | **retired** — cushion size cannot matter if it never drains |
+
+**W2 survives only as a latency win, not as an experiment.** `1024 x 2` opens (W0 confirmed).
+It cuts total latency 64.0 ms -> 42.7 ms with **no change to the compute deadline** — Surge
+still gets 21.3 ms for 1024 frames. Worth taking on its own merits.
+
+## The model
+
+Converting `dsp_p99` to absolute time (cond A, 75-voice `midi-load`, n=1 per cell):
+
+| buffer | deadline | dsp_p99 | time used |
+|---|---|---|---|
+| 1024 | 21.33 ms | 58.9% | 12.57 ms |
+| 512 | 10.67 ms | 62.4% | 6.66 ms |
+| 256 | 5.33 ms | 76.1% | 4.06 ms |
+
+Least-squares fit of `T = a + b*N` over the three points:
+
+> **a = 1.10 ms fixed per callback**
+> **b = 0.0111 ms per frame**
+
+Predicted vs measured: 12.51/12.57, 6.81/6.66, 3.96/4.06. **A fixed ~1.1 ms is paid on every
+callback regardless of buffer size.**
+
+| buffer | fixed cost as share of deadline |
+|---|---|
+| 1024 | 5.2% |
+| 512 | 10.3% |
+| 256 | **20.7%** |
+| 128 | **41.4%** |
+| 64 | **82.8%** |
+
+## Independent validation — it retrodicts the T11 ladder
+
+Extending the fit to buffers W1 never ran, against `t11-condA-ladder-2026-08-21.md`,
+collected before this model existed:
+
+| buffer | predicted total load | T11 measured xruns/min |
+|---|---|---|
+| 512 | 64% | 0.13 |
+| 256 | 74% | 12.1 |
+| 128 | **95%** | 677.6 |
+| 64 | **136%** | 2776 |
+
+**One fixed cost explains the whole ladder.** It also resolves the T11 anomaly that never
+made sense — *"at 64 frames the callback never missed its deadline while 6% of periods
+underran."* The callback never missed its **wakeup**; it missed its **computation**. Two
+different quantities, exactly as `xrun-counter-audit-2026-08-21.md` warned.
+
+**Caveat:** T11 ran cond A *without* `midi-load`, so `b` differs between the datasets. The
+retrodiction is qualitative — the *shape* of the ladder, not its numbers.
+
+## Two defects in W1 itself
+
+**1. n=1 per cell.** The rate column shows 512 at 2/min *better* than 1024 at 6/min —
+inverted, and certainly noise at a single draw. Per `MEASUREMENT-DISCIPLINE.md` that is a
+rate claim on n=1 and does not support ordering.
+**The decisive finding does not depend on it:** "zero ALSA lines across three cells" is a
+presence/absence claim, and zero is zero.
+
+**2. `dsp_p99` is the wrong statistic.** At 256, p99 = 76% while **0.28%** of periods
+overran (32/min against ~11,280 periods/min). **The overruns live past p99.** We are watching
+a percentile that by construction excludes the events we care about.
+
+**Report `p99.9`, `p99.99` and `max` from here.** This is the same resolution error as the
+10 Hz fill poller, one layer up: an instrument whose output looks authoritative and has the
+answer removed by construction.
+
+**3. Housekeeping:** the Pi came back with `-s softmode`, which changes xrun handling.
+**Revert before any further counting.**
+
+## Where the work goes now
+
+The question is no longer "why is audio late out of the buffer." It is:
+
+> **What is Surge doing for 1.1 ms on every callback, independent of block size?**
+
+Candidates, none yet measured:
+
+| candidate | why plausible |
+|---|---|
+| JACK graph traversal + inter-client context switches | per-cycle cost, independent of block size; this is what the **single-client architecture** idea (Surge hosting the looper in-process) attacks directly |
+| JUCE wrapper per-block overhead | fixed setup/teardown per `processBlock` |
+| MPE / MIDI event processing | per-callback event-queue walk |
+| parameter smoothing + modulation matrix setup | Surge runs internal 32-sample blocks; some setup is per-callback |
+| denormal handling, cache reload | fixed per-entry cost |
+
+**If the 1.1 ms were eliminated, 256 would sit at ~55% of deadline** — comfortable. That
+makes this worth real effort, and it is the first lever in this project that acts on the
+actual binding term.
+
+## Next
+
+| # | cell | why |
+|---|---|---|
+| **V1** | Re-run the ladder with **p99.9 / p99.99 / max**, n >= 3 streams, strict mode | current statistic excludes the events of interest |
+| **V2** | **Profile the callback** — where do the 1.1 ms go? `perf` on the Surge process, or in-callback timing around graph entry/exit | identifies the actual target |
+| **V3** | `1024 x 2` as a shipping change (42.7 ms) | free latency win, independent of all of the above |
+
+**Do not run V1 before fixing softmode**, and pre-register both V1 and V2 per
+`.claude/skills/measurement-design`.
+
+## Product position
+
+**Shipping stays `1024 x 3` (64 ms) today**, with `1024 x 2` (42.7 ms) as an immediate
+candidate pending a confirmation run.
+
+Lower buffers are **not** blocked by the Pi's kernel, its USB stack, or the audio interface.
+They are blocked by **~1.1 ms of fixed per-callback cost inside the audio graph.** That is a
+software problem in our own stack, and it is tractable.

--- a/docs/measurements/cushion-model-2026-08-21.md
+++ b/docs/measurements/cushion-model-2026-08-21.md
@@ -1,0 +1,129 @@
+# The cushion does not deplete — so what empties it? (2026-08-21)
+
+## The arithmetic that forces this question
+
+At `1024 x 3` the cushion is `(3-1) x 1024` = **2048 frames = 42.7 ms**.
+The worst stall ever measured on this box is **429 us** (Step 2 cyclictest, under real load).
+
+**That is a factor of 100.** Yet xruns occur at this config.
+
+## Why "the cushion slowly wears down" is wrong
+
+JACK writes a **full period on every wakeup, regardless of when that wakeup happens.** Let
+`P` = period, `d_k` = how late the k-th write is.
+
+Just before write *k*, the buffer has drained by `P + d_k - d_{k-1}`. The write adds `P`.
+So:
+
+```
+fill_after(k) = fill_after(k-1) - d_k + d_{k-1}
+              = fill_0 + d_0 - d_k
+```
+
+**The level depends only on the current delay, not on the history.** Lateness produces a
+transient dip whose depth is `d_k`, and the level returns as soon as the write lands. There
+is no accumulation and no ratchet. A late callback is a **phase shift, not a withdrawal.**
+
+This also matches T5: index of dispersion **1.091** (`t5-soak-2026-08-21.md`). A ratcheting
+reserve would step down on a cadence and produce *periodic* xruns — dispersion near 0. We
+measured Poisson-random.
+
+**Consequence:** to empty the buffer, a **single** stall must exceed the entire cushion —
+42.7 ms at `1024 x 3`. Nothing we have measured is within two orders of magnitude of that.
+
+**So the xruns at 1024 are not simple producer-lateness drain events.** Something else is
+happening, and every test so far has assumed otherwise.
+
+## Candidate models
+
+| # | model | mechanism | predicted xrun rate vs `n` (period fixed) |
+|---|---|---|---|
+| **P1** | **rare giant stall** | some unmeasured stall exceeds the whole cushion | ~0 at every `n` — **already in trouble**, since we observe non-zero at n=3 and cyclictest saw no >1 ms event under load |
+| **P2** | **constant clock mismatch** | device consumes faster than host refills; level drains linearly | **rate proportional to 1/(n-1)** — hyperbolic |
+| **P2'** | **rate-matching noise / feedback hunting** | async feedback loop is noisy; fill level *random-walks* | **rate proportional to 1/(n-1)^2** — hitting time of a random walk against a barrier scales as distance squared |
+| **P3** | **counter artifact** | the xrun counter increments on something that is not an underrun | **flat in `n`** — cushion size irrelevant |
+
+**P2' is the one that fits what we already know.** Pure constant drift (P2) would give
+near-periodic xruns and a dispersion near 0; we measured **1.091**, i.e. Poisson-random. A
+random walk hitting a barrier produces approximately Poisson arrivals. It also explains why
+the Scarlett (async, feedback endpoint, an actual control loop) behaved *worse* than the
+Sound Blaster rather than better.
+
+**P3 cannot be dismissed.** It is the [measurement-integrity](../../MEMORY.md) shape that has
+bitten this project repeatedly: a reading that looks the same whether the system is fine or
+broken.
+
+## How the test shape must change
+
+Every cell so far has varied the **period** (64/128/192/240/256/512/1024) at **fixed
+nperiods=3**. That varies the *deadline* and the *cushion* together, and it has now been
+run into the ground.
+
+**Invert it: fix the period, sweep the cushion.**
+
+At a fixed period of 1024 the compute deadline is constant at 21.3 ms — the load Surge
+already meets with zero xruns. Only the cushion changes. The three models then give three
+**distinguishable curves**, which is what no previous test has offered:
+
+| `n` | cushion | latency | P2 predicts | P2' predicts | P3 predicts |
+|---|---|---|---|---|---|
+| 2 | 21.3 ms | 42.7 ms | 2.0x the n=3 rate | 4.0x | same |
+| 3 | 42.7 ms | 64.0 ms | baseline | baseline | same |
+| 4 | 64.0 ms | 85.3 ms | 0.67x | 0.44x | same |
+| 6 | 106.7 ms | 128.0 ms | 0.40x | 0.16x | same |
+
+**Linear vs quadratic vs flat.** That is a real discriminator, and it needs no reboot and no
+kernel change — only `MPE_JACK_PERIODS`.
+
+**n=2 has never been tested.** Every measurement doc is x3, x6 or x8.
+
+## The decisive measurement: watch the fill level directly
+
+Rather than inferring the level from xruns, **read it**. ALSA exposes it per-substream:
+
+```
+/proc/asound/card<N>/pcm0p/sub0/status     # state, hw_ptr, appl_ptr, avail
+```
+
+`appl_ptr - hw_ptr` **is** the fill level. Poll it at 10-20 Hz through a run and log it
+alongside the xrun counter. The trace settles all four models on sight:
+
+| trace shape | model |
+|---|---|
+| flat, with brief sub-ms dips, xruns anyway | **P3** — the counter is not reporting drain |
+| sawtooth descending steadily, reset at each xrun | **P2** — constant clock mismatch |
+| random walk wandering down to zero, no cadence | **P2'** — rate-matching noise |
+| flat then one cliff to zero | **P1** — a real giant stall; capture what ran |
+
+This is cheap, read-only, and it measures the quantity in question **directly** instead of
+inferring it from a counter whose semantics we have never audited.
+
+## Free, offline, do it first
+
+**Audit what actually increments the xrun counter** — the harness, `mpe-xrun-probe`, and
+which JACK/ALSA condition it reads. No Pi time, no measurement window. If the counter
+includes anything other than a genuine playback underrun (delay reports, softmode events,
+callback-overrun flags), **P3 is confirmed at zero cost** and a large part of this session's
+data needs reinterpreting.
+
+## Revised priority
+
+| # | test | cost | decides |
+|---|---|---|---|
+| **C** | audit xrun counter semantics (offline) | 0 | P3 outright |
+| **A** | fill-level telemetry at `1024 x 3` | ~15 min | all four models, directly |
+| **B** | nperiods sweep 2/3/4/6 at period 1024 | ~30 min | P2 vs P2' vs P3 by curve shape |
+| — | ~~cell 4b (`irq/30` FF 90)~~ | — | **deprioritised** — tunes producer lateness, which the arithmetic above says is not the binding term |
+| — | DSP p99 ladder at fixed load | ~15 min | still needed; separate question about 256 |
+
+**Note on `n=2`:** it is both a diagnostic and, if it holds, **21.3 ms off the shipping
+latency for free** — 64.0 ms to 42.7 ms with no change to the compute deadline. It may
+simply refuse to open (`snd-usb-audio` conventionally wants >=3); that is a 30-second answer.
+
+## What this retires
+
+`irq/30` priority, `isolcpus`, `nohz_full`, PREEMPT_RT and the rest of the RT-tuning list all
+target **producer lateness**. The arithmetic here says producer lateness of the magnitude we
+can measure (sub-millisecond against a 42.7 ms cushion) **cannot** be what empties the
+buffer. They are not wrong as engineering; they are aimed at the wrong term. Park them until
+A/B/C say what the binding term actually is.

--- a/docs/measurements/cushion-model-2026-08-21.md
+++ b/docs/measurements/cushion-model-2026-08-21.md
@@ -110,7 +110,7 @@ data needs reinterpreting.
 
 | # | test | cost | decides |
 |---|---|---|---|
-| **C** | audit xrun counter semantics (offline) | 0 | P3 outright |
+| **C** | audit xrun counter semantics (offline) | 0 | P3 outright — **partial:** counter is real JACK engine events; underrun vs mismatch **not** separated ([`xrun-counter-audit-2026-08-21.md`](xrun-counter-audit-2026-08-21.md)) |
 | **A** | fill-level telemetry at `1024 x 3` | ~15 min | all four models, directly |
 | **B** | nperiods sweep 2/3/4/6 at period 1024 | ~30 min | P2 vs P2' vs P3 by curve shape |
 | — | ~~cell 4b (`irq/30` FF 90)~~ | — | **deprioritised** — tunes producer lateness, which the arithmetic above says is not the binding term |

--- a/docs/measurements/cushion-model-2026-08-21.md
+++ b/docs/measurements/cushion-model-2026-08-21.md
@@ -106,15 +106,15 @@ includes anything other than a genuine playback underrun (delay reports, softmod
 callback-overrun flags), **P3 is confirmed at zero cost** and a large part of this session's
 data needs reinterpreting.
 
-## Revised priority
+## Revised priority (post Step 4 amendment)
 
 | # | test | cost | decides |
 |---|---|---|---|
-| **C** | audit xrun counter semantics (offline) | 0 | P3 outright — **partial:** counter is real JACK engine events; underrun vs mismatch **not** separated ([`xrun-counter-audit-2026-08-21.md`](xrun-counter-audit-2026-08-21.md)) |
-| **A** | fill-level telemetry at `1024 x 3` | ~15 min | all four models, directly |
-| **B** | nperiods sweep 2/3/4/6 at period 1024 | ~30 min | P2 vs P2' vs P3 by curve shape |
-| — | ~~cell 4b (`irq/30` FF 90)~~ | — | **deprioritised** — tunes producer lateness, which the arithmetic above says is not the binding term |
-| — | DSP p99 ladder at fixed load | ~15 min | still needed; separate question about 256 |
+| **D+A** | DSP p99 **and** fill telemetry at 1024 / 512 / 256, identical load, cond A | ~20 min | compute-bound vs cushion models; flat fill + high p99 ⇒ P3 + graph overrun |
+| **B** | nperiods sweep 2/3/4/6 at period 1024 | ~30 min | P2 vs P2′ vs P3 by curve |
+| **—** | `1024×2` open-check | ~30 s | 21 ms off shipping latency if ALSA accepts |
+| ~~4b~~ | irq/30 FF 90 | — | **parked** — producer lateness not binding term until D+A says otherwise |
+| ~~alignment~~ | frame-phase tables | — | **unsupported, unpromising** — do not spend Pi time |
 
 **Note on `n=2`:** it is both a diagnostic and, if it holds, **21.3 ms off the shipping
 latency for free** — 64.0 ms to 42.7 ms with no change to the compute deadline. It may

--- a/docs/measurements/find-600us-2026-08-21.md
+++ b/docs/measurements/find-600us-2026-08-21.md
@@ -1,12 +1,12 @@
 # Find the ~600 µs — Steps 0–4 (2026-08-21)
 
-*Last updated: 2026-08-21 (America/Toronto)*
+*Last updated: 2026-08-21 (America/Toronto) — post Step 4 amendment*
 
 **Branch:** `yolo/scarlett-measurement-2026-08-21` · **Pi restored:** 1024×3 cond A on Scarlett **hw:2**.
 
-Steps 0–4 complete. **4b aborted** (one partial run only). **Next:** offline gate C done → fill telemetry + cushion sweep per [`cushion-model-2026-08-21.md`](cushion-model-2026-08-21.md).
+Steps 0–4 complete. **Next:** **D+A** (~20 min) → **B** (~30 min) + **1024×2 open-check** (~30 s). See [`PLAN-2026-08-21-evening.md`](PLAN-2026-08-21-evening.md) amendment.
 
-**Pivot:** producer-lateness tuning (4b, isolcpus, PREEMPT_RT) **parked** until fill-level telemetry says what empties the buffer — see cushion model.
+**Pivot:** settle binding term (D+A fill trace + DSP ladder) before any RT tuning or Step 4 re-run.
 
 **Run order note:** Step 0 was deferred until after Steps 1–2 (already running). Escalation clause did not apply retroactively — swap/maj_flt were flat when checked.
 
@@ -158,13 +158,16 @@ So the unexplained **~600 µs is not generic scheduler inability to wake threads
 | range (stream means) | **26 – 105/min** | **40 – 86/min** |
 | all windows `meter_live=1` | yes | yes |
 
-### Interpretation — **inconclusive bundle read; stream-start lottery returns**
+### Interpretation — **inconclusive bundle read; Step 1 shape inference withdrawn**
 
-Mean **below** baseline (55 vs 70), but **bimodal again**: stream 01 at **105/min** while 02–03 sit **26–34/min**. Same shape as pre-Step-1 Sound Blaster lottery, now on Scarlett post-bundle — reads as **stream-start variance**, not a clean “bundle helped/hurt” attribution.
+Mean **55.0/min** from **3 streams** — not a reliable estimate. Stream 01 **105/min**,
+streams 02–03 **26–34/min**: at n=3 this **neither confirms nor refutes** bimodality (one-high/two-low is unremarkable). It **does** withdraw the Step 1 closure that Scarlett unimodality proved adaptive-clock-lock over frame phase — see [`scarlett-verdict-2026-08-21.md`](scarlett-verdict-2026-08-21.md) amendment.
 
-**threadirqs threading cost?** Not ruled in or out — one bad stream dominates the mean. If the binding term is not producer lateness (cushion model), this number may not respond to the bundle anyway.
+**threadirqs cost:** neither confirmed nor ruled out. **Do not re-run Step 4** to settle it — xruns/min may not be the binding term; settle term first (D+A).
 
-**4b (`irq/30` FF 90):** interrupted after **one** run (20/min, dsp_p99 61.6%) — **not reported as a cell.** Pi restored to FF 50 + 1024×3.
+**Compute signal (stronger):** dsp_p99 **63–89%** at 256 cond A (no midi-load) vs **34.8%** at 1024 cond A — matched load, ~2–2.5× efficiency loss. Two of three D+A points exist; need **512** + fill telemetry.
+
+**4b (`irq/30` FF 90):** interrupted after one run — **parked** with RT tuning.
 
 ---
 
@@ -172,89 +175,35 @@ Mean **below** baseline (55 vs 70), but **bimodal again**: stream 01 at **105/mi
 
 | claim | status |
 |---|---|
-| Frame-phase / aligned-period table (240/480/1008) | **Closed** (Step 1 Scarlett bimodality) |
+| Frame-phase / aligned-period table (240/480/1008) | **Unsupported, unpromising** — Step 1 closure **withdrawn**; 1024/6 misaligned yet clean |
 | URB queue *depth* as binding term | **Closed** (T13) |
 | URB *completion rate* at 256 vs 1024 | **Refuted** (Step 1) |
 | `lowlatency=N` as first lever | **Dropped** (Step 1 kill condition) |
 | Generic scheduler latency explains ~900 µs callback lateness | **Refuted** (Step 2 — cyclictest max ~400 µs under load) |
-| **Swap / SD-backed major faults in audio path** | **Ruled out** (Step 0 — swap off, `pswpin`=0, `maj_flt` flat) |
+| **Swap / SD-backed major faults in audio path** | **Ruled out** (Step 0) |
+| Scarlett unimodal → adaptive clock lock closed frame phase | **Withdrawn** (Step 4, n=3) |
 
 ## What is still open
 
-| # | test | status |
+| # | cell | status |
 |---|---|---|
-| **C** | xrun counter audit (offline) | **done** — [`xrun-counter-audit-2026-08-21.md`](xrun-counter-audit-2026-08-21.md); P3 not eliminated |
-| **A** | fill-level telemetry `1024×3` | next — `/proc/asound/card2/pcm0p/sub0/status` @ 10–20 Hz |
-| **B** | nperiods sweep 2/3/4/6 @ period 1024 | after A — P2 vs P2′ vs P3 by curve |
-| **D** | DSP p99 ladder 1024/512/256, identical load | separate — ear/crackle at 256 |
-| ~~4b~~ | irq/30 FF 90 | **skipped** — parked with RT tuning |
-
-- **Heavy-patch DSP headroom** — Mitch ear at 512; needs patch ID
-- **IRQ 41 shared line** — structural context only
-- **HDMI disable partial** — CEC/HPD threads survived cmdline disable (confirmed Step 3)
-- **Card index 6→2** — harmless; `detect-jack-device.sh` resolves live ([`xrun-counter-audit`](xrun-counter-audit-2026-08-21.md) / prestart path)
+| **C** | xrun counter audit | **done** — [`xrun-counter-audit-2026-08-21.md`](xrun-counter-audit-2026-08-21.md) |
+| **D+A** | DSP p99 **+ fill telemetry** at 1024 / 512 / 256, cond A, identical load | **next** (~20 min) — flat fill + p99 89% ⇒ P3 + compute-bound |
+| **B** | nperiods 2/3/4/6 @ period 1024 | after D+A (~30 min) |
+| **—** | `1024×2` ALSA open-check | ~30 s, any idle moment |
+| ~~4b~~ | irq/30 FF 90 | **parked** |
+| ~~Step 4 re-run~~ | proper n streams for bundle read | **not worth Pi time** until term settled |
 
 ## Related docs
 
+- [`PLAN-2026-08-21-evening.md`](PLAN-2026-08-21-evening.md) — revised order post Step 4
 - [`cushion-model-2026-08-21.md`](cushion-model-2026-08-21.md) — self-restoring cushion; invert test shape
-- [`xrun-counter-audit-2026-08-21.md`](xrun-counter-audit-2026-08-21.md) — what `RESULT xruns=` actually counts
+- [`xrun-counter-audit-2026-08-21.md`](xrun-counter-audit-2026-08-21.md) — what `RESULT xruns=` counts
+- [`scarlett-verdict-2026-08-21.md`](scarlett-verdict-2026-08-21.md) — alignment closure withdrawn
 
 ## Plain product statement
 
-The Scarlett does not buy lower latency on this Pi. The bottleneck is **Pi-side wakeup path latency**, not interface clock mode, full-speed transport, frame alignment, or xhci IRQ rate at 256 vs 1024. **1024 remains the shippable buffer**; 512/256 need Pi-side fixes or acceptance of crackle under load.
-
----
-
-## Post-Step-3 note — the knob is unlocked but not turned
-
-`threadirqs` gave `irq/30-xhci_hcd` a handler thread at **FF 50 on CPU0**. That is simply
-the `threadirqs` default. The *reason* we wanted it threaded was that a thread's priority and
-affinity are ordinary scheduling decisions, unlike the hardware IRQ, which refused
-`set_affinity` (empty `effective_affinity`, `cpu-census-2026-08-21.md`).
-
-**Step 3 therefore delivered a capability, not a fix.**
-
-### Lever now available (free, no reboot, reversible)
-
-At FF 50 the xhci handler sits **below** jackd (FF 70), surge (FF 65), the peak meter
-(FF 65), and the six `card1-crtc` threads (FF 50, same band). Standard RT-audio practice —
-what `rtirq` does on tuned systems — raises the soundcard/USB IRQ thread **above** the audio
-thread, because the data must land before the callback that consumes it runs.
-
-```sh
-chrt -f -p 90 "$(pgrep -f 'irq/30-xhci')"     # apply
-chrt -f -p 50 "$(pgrep -f 'irq/30-xhci')"     # revert
-```
-
-This is the **most direct available test of the Step 2 Branch B finding**: if the gap is
-after the interrupt fires and before the callback runs, "the URB completed but its handler
-waited to be scheduled" is the leading candidate, and this addresses it head-on. One
-variable, no reboot, instantly reversible.
-
-### How to read Step 4
-
-`threadirqs` adds a context switch to **every** interrupt. **A result above 69.7/min is a
-real possibility and is informative** — it would measure the cost of threading, not a failed
-step. Deciding this in advance so the number is not rationalised after the fact.
-
-### Revised order
-
-| # | cell | cost | what it decides |
-|---|---|---|---|
-| 4 | Scarlett 256x3 cond A, 3 streams x 3 runs vs **69.7/min** | ~12 min | reads the Step 3 bundle |
-| 4b | same cell, `irq/30` at **FF 90** | ~12 min, no reboot | tests Branch B directly |
-| 5 | **DSP p99 ladder** — 1024 / 512 / 256, *identical* load, cond A | ~15 min | is 256 compute-bound or latency-bound? |
-
-Cell 5 remains the one that decides whether wakeup-path tuning is the right *kind* of work
-at 256 at all. `dsp_p99 ~= 92%` was recorded in Step 2 against prior figures of 34.8% (1024)
-and 37.5% (512) — but under `midi-load`, not the standard 75-voice load, so **the comparison
-is not yet valid.** Fix the load, then compare.
-
-### Also outstanding
-
-- HDMI disable is **partial** — CEC/HPD threads on disconnected ports survived the cmdline
-  change. First post-reboot confirmation; minor, but it means the earlier change did not do
-  everything assumed.
-- Card index moved **6 -> 2**. Verified harmless: `jackd-prestart.sh` resolves the device
-  from `/proc/asound/cards` into `/run/mpe/jack-device` at boot, and `asoundrc.mpe-pi` uses
-  `CARD=Passthrough` by name. Nothing hardcodes an index.
+The Scarlett earns its place on I/O (MIDI, phantom, outputs) but **buys no latency on this Pi**.
+**1024×3 ships** (64 ms). Leading hypothesis for 256 crackle: **compute-bound** (dsp_p99 63–89%
+vs 34.8% at 1024 under matched cond A) — D+A confirms or retires. Nearest win without solving
+the model: **1024×2** @ 42.7 ms if ALSA opens it.

--- a/docs/measurements/find-600us-2026-08-21.md
+++ b/docs/measurements/find-600us-2026-08-21.md
@@ -1,0 +1,130 @@
+# Find the ~600 µs — Steps 0–2 (2026-08-21)
+
+*Last updated: 2026-08-21 (America/Toronto)*
+
+**Branch:** `yolo/scarlett-measurement-2026-08-21` · **Pi restored:** 1024×3 cond A after diagnostics.
+
+Steps 0–2 complete — **Step 3 reboot bundle next** per [`PROMPT-find-the-600us.md`](PROMPT-find-the-600us.md).
+
+**Run order note:** Step 0 was deferred until after Steps 1–2 (already running). Escalation clause did not apply retroactively — swap/maj_flt were flat when checked.
+
+## Device record (live at run time)
+
+| | |
+|---|---|
+| Scarlett ALSA card | **6** (`USB` / Scarlett 4i4 USB @ 480M, hub 1-1.2) |
+| jackd playback | **4 ch** S32_LE FL FR FC LFE (stereo synth uses 2) |
+| IRQ 30 affinity | `0-1` (counts **100% CPU0** in `/proc/interrupts`) |
+| IRQ 41 | **mmc0 + mmc1 shared** (`GICv2 158`), affinity **CPU1** (~1.12M counts) |
+| `lowlatency` | **Y** (unchanged — **dropped from Step 3** per Step 1 kill condition) |
+| Sound Blaster | **unplugged** — cell 1c not run |
+
+---
+
+## Step 0 — storage / swap / journald (read-only)
+
+**Method:** no config changes. 60 s idle diskstats, then 90 s `measure-latency-run.sh` 256×3 cond A with `--output /tmp/step0-load.log` (tmpfs). Deciding numbers: `pswpin`/`pswpout`, jackd/surge `maj_flt` delta.
+
+| check | result |
+|---|---|
+| **0a swap active** | **No** — `swapon --show` empty; `dphys-swapfile` not installed (`not-found` / `inactive`) |
+| **0a swap file on disk** | `/var/swap` 2 GiB exists but **not activated** |
+| **0b pswpin / pswpout** | **0 / 0** (lifetime); idle 60 s delta **0**; load 90 s delta **0** |
+| **0c maj_flt jackd** | **0 → 0** during load |
+| **0c maj_flt surge** | **0 → 1** during load (single fault — noise, not growth) |
+| **0d journald** | **8 MiB** on disk; `Storage=auto`; `/var/log/journal` minimal |
+| **0e mmcblk0 writes** | idle 60 s: **32,624 sectors** (~16 MiB); load 90 s: **87,744 sectors** (~43 MiB) |
+| **0f harness SD writes** | per-window detail → `/tmp/latency-*.out` (tmpfs); this run log → `/tmp` |
+| **0g swappiness** | **60** (irrelevant while swap off) |
+| **0g MemoryLock** | `LimitMEMLOCK=infinity` on **jackd** and **surge-xt-cli** |
+
+### Interpretation — **swap / SD-major-fault path RULED OUT**
+
+Escalation clause (**`pswpin` > 0 or audio `maj_flt` growing during play**) **not triggered**. Swap is off and untouched; audio processes did not accumulate major faults under load.
+
+→ **Do not keep swap on the candidate list.** Proceed to Step 3.
+
+**SD writes during stream:** non-zero (~43 MiB / 90 s) but **not** paired with major faults or swap activity. Likely background journal + OS (326 journal lines / 2 min at check time). Harness itself was on tmpfs for this run. **IRQ 41** (`mmc0` + SDIO **mmc1**) is the structural line — SD I/O and WiFi share one handler on CPU1; network tuning and disk tuning were never independent levers on this box.
+
+---
+
+## Step 1 — IRQ 30 rate census
+
+**Method:** condition A (looper stopped), `set-surge-audio` per cell, 15 s settle, IRQ30 delta over 60 s idle stream (no midi-load — xruns 0 in window).
+
+| cell | buffer | IRQ30 Δ/60s | IRQ30/s | CPU0 | CPU1–3 | xruns/min |
+|---|---:|---:|---:|---:|---:|---:|
+| **1a** Scarlett | 256×3 | 59,998 | **999** | all | 0 | 0 |
+| **1b** Scarlett | 1024×3 | 119,973 | **1,999** | all | 0 | 0 |
+| **1c** Sound Blaster | 256×3 | — | — | — | — | **skipped** |
+
+### Interpretation — **URB-rate hypothesis REFUTED**
+
+Prediction was **1a ≫ 1b** (small period → more URB completions → more IRQ30).
+
+Observed: **1b is ~2× 1a** (1999/s vs 999/s). Smaller period did **not** increase xhci IRQ rate.
+
+→ **`snd_usb_audio.lowlatency=N` is dropped from Step 3.** Do not run it on this evidence.
+
+**Caveat:** 1c missing (dongle unplugged). Absolute rates may include hub traffic (LUMI/APC on same xhci tree); **relative 256 vs 1024 on the same Scarlett session** is the decisive comparison.
+
+**Note:** jackd opens **4 playback channels** on Scarlett; altsetting report only — no change made.
+
+---
+
+## Step 2 — cyclictest under real conditions
+
+**Config:** Scarlett 256×3 cond A. Background: `measure-latency-run.sh` 320 s with midi-load (599 xruns in window ≈ **112/min**, `meter_live=1`, `dsp_p99≈92%`).
+
+**Bare floor on record:** 209–320 µs (stock kernel, idle cyclictest).
+
+| run | CPU pin | SCHED_FIFO | min | avg | max |
+|---|---|---:|---:|---:|---:|
+| **2a** | **3** | 70 | 3 µs | 18 µs | **429 µs** |
+| **2b** | **0** | 70 | 3 µs | 17 µs | **366 µs** |
+
+Audio stack stayed up for both runs.
+
+### Interpretation — **Branch: ALSA/JACK/USB wakeup path (~300 µs cyclictest, ~900 µs callback)**
+
+Under **real load**, cyclictest max stays **366–429 µs** — same order as the bare floor, **not** ~900 µs.
+
+So the unexplained **~600 µs is not generic scheduler inability to wake threads.** The scheduler delivers; something **after** IRQ / between `snd_pcm_period_elapsed` and Surge's callback entry adds latency.
+
+**2a vs 2b:** No sharp split (429 vs 366 µs). Pinning the test thread to CPU0 vs CPU3 does not reproduce the callback gap — **not a simple placement win.**
+
+### Levers earned for Step 3 (report only — not executed)
+
+| lever | earned? |
+|---|---|
+| `lowlatency=N` | **No** (Step 1 refuted) |
+| `threadirqs` | **Yes** — handler-thread placement; IRQ 30 still fires on CPU0 |
+| v3d removal | **Hygiene bundle** — expect ~0 effect on audio metric |
+| `isolcpus` / `nohz_full` / PREEMPT_RT | **Deprioritized** — cyclictest under load did not show a 900 µs scheduler ceiling |
+
+**Next inside the wakeup path (if Step 3 bundle flat):** ftrace on xrun — `irq_handler_entry` → `sched_wakeup` → `sched_switch` filtered to jackd/surge.
+
+---
+
+## What is now ruled out
+
+| claim | status |
+|---|---|
+| Frame-phase / aligned-period table (240/480/1008) | **Closed** (Step 1 Scarlett bimodality) |
+| URB queue *depth* as binding term | **Closed** (T13) |
+| URB *completion rate* at 256 vs 1024 | **Refuted** (Step 1) |
+| `lowlatency=N` as first lever | **Dropped** (Step 1 kill condition) |
+| Generic scheduler latency explains ~900 µs callback lateness | **Refuted** (Step 2 — cyclictest max ~400 µs under load) |
+| **Swap / SD-backed major faults in audio path** | **Ruled out** (Step 0 — swap off, `pswpin`=0, `maj_flt` flat) |
+
+## What is still open
+
+- **Step 3 bundle** — **`threadirqs`** + **v3d hygiene** only (`lowlatency=N` **not** in bundle); gate v3d on touch UI GL check
+- **Step 4 spot-check** — Scarlett 256×3, 3 streams × 3 runs vs **69.7/min** baseline
+- **Heavy-patch DSP headroom** — Mitch ear at 512; needs patch ID from Mitch
+- Sound Blaster IRQ cell 1c if dongle replugged (optional — URB hypothesis already failed on 1a vs 1b)
+- **IRQ 41 shared line** — hold as structural context for future SD/WiFi work; not a Step 3 lever
+
+## Plain product statement
+
+The Scarlett does not buy lower latency on this Pi. The bottleneck is **Pi-side wakeup path latency**, not interface clock mode, full-speed transport, frame alignment, or xhci IRQ rate at 256 vs 1024. **1024 remains the shippable buffer**; 512/256 need Pi-side fixes or acceptance of crackle under load.

--- a/docs/measurements/find-600us-2026-08-21.md
+++ b/docs/measurements/find-600us-2026-08-21.md
@@ -1,10 +1,12 @@
-# Find the ~600 µs — Steps 0–3 (2026-08-21)
+# Find the ~600 µs — Steps 0–4 (2026-08-21)
 
 *Last updated: 2026-08-21 (America/Toronto)*
 
-**Branch:** `yolo/scarlett-measurement-2026-08-21` · **Pi restored:** 1024×3 cond A on Scarlett **hw:2** after Step 3 reboot.
+**Branch:** `yolo/scarlett-measurement-2026-08-21` · **Pi restored:** 1024×3 cond A on Scarlett **hw:2**.
 
-Steps 0–3 complete — **Step 4 spot-check next** per [`PROMPT-find-the-600us.md`](PROMPT-find-the-600us.md).
+Steps 0–4 complete. **4b aborted** (one partial run only). **Next:** offline gate C done → fill telemetry + cushion sweep per [`cushion-model-2026-08-21.md`](cushion-model-2026-08-21.md).
+
+**Pivot:** producer-lateness tuning (4b, isolcpus, PREEMPT_RT) **parked** until fill-level telemetry says what empties the buffer — see cushion model.
 
 **Run order note:** Step 0 was deferred until after Steps 1–2 (already running). Escalation clause did not apply retroactively — swap/maj_flt were flat when checked.
 
@@ -132,7 +134,37 @@ So the unexplained **~600 µs is not generic scheduler inability to wake threads
 | Scarlett + stack | **hw:2**, 1024×3, `throttled=0x0` |
 | touch UI | inactive at verify (jackd/surge active) |
 
-**Expectation:** v3d removal is hygiene (~957 k IRQ off the board); **no measurable audio effect predicted.** `threadirqs` enables handler-thread placement; IRQ 30 hard edge still lands on CPU0 — Step 4 spot-check is the harm/help read against **69.7/min** baseline.
+**Expectation:** v3d removal is hygiene (~957 k IRQ off the board); **no measurable audio effect predicted.** `threadirqs` enables handler-thread placement; IRQ 30 hard edge still lands on CPU0.
+
+**Capability vs fix:** Step 3 delivered **`threadirqs`** — `irq/30-xhci_hcd` is now a schedulable thread at **FF 50** (default). That unlocks priority/affinity; it does not apply rtirq-style elevation. **4b skipped** per cushion-model pivot.
+
+---
+
+## Step 4 — bundle spot-check (256×3 cond A)
+
+**Config:** post–Step 3 bundle (`threadirqs` + v3d blacklist). Scarlett **card 2**. Protocol: 3 jackd restarts × 3×60 s windows (`measure-stream-sample.sh`). Baseline: **69.7/min** mean (10 streams, pre-bundle — [`scarlett-step1-256x3-condA-2026-08-21.md`](scarlett-step1-256x3-condA-2026-08-21.md)).
+
+**Pi logs:** `~/step4-bundle-256-A-stream-{01..03}.log`
+
+| stream | run1 | run2 | run3 | stream mean (/min) | dsp_p99 (runs) |
+|---:|---:|---:|---:|---:|---|
+| **01** | 101 | 109 | 105 | **105.0** | 88.6, 88.4, 78.7 |
+| **02** | 25 | 29 | 25 | **26.3** | 63.2, 65.0, 69.0 |
+| **03** | 31 | 30 | 40 | **33.7** | 66.1, 72.8, 67.8 |
+
+| stat | Step 4 | baseline |
+|---|---:|---:|
+| mean (3 streams) | **55.0/min** | **69.7/min** |
+| range (stream means) | **26 – 105/min** | **40 – 86/min** |
+| all windows `meter_live=1` | yes | yes |
+
+### Interpretation — **inconclusive bundle read; stream-start lottery returns**
+
+Mean **below** baseline (55 vs 70), but **bimodal again**: stream 01 at **105/min** while 02–03 sit **26–34/min**. Same shape as pre-Step-1 Sound Blaster lottery, now on Scarlett post-bundle — reads as **stream-start variance**, not a clean “bundle helped/hurt” attribution.
+
+**threadirqs threading cost?** Not ruled in or out — one bad stream dominates the mean. If the binding term is not producer lateness (cushion model), this number may not respond to the bundle anyway.
+
+**4b (`irq/30` FF 90):** interrupted after **one** run (20/min, dsp_p99 61.6%) — **not reported as a cell.** Pi restored to FF 50 + 1024×3.
 
 ---
 
@@ -149,11 +181,23 @@ So the unexplained **~600 µs is not generic scheduler inability to wake threads
 
 ## What is still open
 
-- **Step 4 spot-check** — Scarlett 256×3 cond A, **3 streams × 3 runs** vs **69.7/min** baseline (not a re-baseline)
-- **Heavy-patch DSP headroom** — Mitch ear at 512; needs patch ID from Mitch
-- Sound Blaster IRQ cell 1c if dongle replugged (optional — URB hypothesis already failed on 1a vs 1b)
-- **IRQ 41 shared line** — hold as structural context for future SD/WiFi work; not a Step 3 lever
-- **HDMI vc4 thread prune** — CEC/HPD threads survive cmdline disable; separate experiment if needed
+| # | test | status |
+|---|---|---|
+| **C** | xrun counter audit (offline) | **done** — [`xrun-counter-audit-2026-08-21.md`](xrun-counter-audit-2026-08-21.md); P3 not eliminated |
+| **A** | fill-level telemetry `1024×3` | next — `/proc/asound/card2/pcm0p/sub0/status` @ 10–20 Hz |
+| **B** | nperiods sweep 2/3/4/6 @ period 1024 | after A — P2 vs P2′ vs P3 by curve |
+| **D** | DSP p99 ladder 1024/512/256, identical load | separate — ear/crackle at 256 |
+| ~~4b~~ | irq/30 FF 90 | **skipped** — parked with RT tuning |
+
+- **Heavy-patch DSP headroom** — Mitch ear at 512; needs patch ID
+- **IRQ 41 shared line** — structural context only
+- **HDMI disable partial** — CEC/HPD threads survived cmdline disable (confirmed Step 3)
+- **Card index 6→2** — harmless; `detect-jack-device.sh` resolves live ([`xrun-counter-audit`](xrun-counter-audit-2026-08-21.md) / prestart path)
+
+## Related docs
+
+- [`cushion-model-2026-08-21.md`](cushion-model-2026-08-21.md) — self-restoring cushion; invert test shape
+- [`xrun-counter-audit-2026-08-21.md`](xrun-counter-audit-2026-08-21.md) — what `RESULT xruns=` actually counts
 
 ## Plain product statement
 

--- a/docs/measurements/find-600us-2026-08-21.md
+++ b/docs/measurements/find-600us-2026-08-21.md
@@ -1,10 +1,10 @@
-# Find the ~600 µs — Steps 0–2 (2026-08-21)
+# Find the ~600 µs — Steps 0–3 (2026-08-21)
 
 *Last updated: 2026-08-21 (America/Toronto)*
 
-**Branch:** `yolo/scarlett-measurement-2026-08-21` · **Pi restored:** 1024×3 cond A after diagnostics.
+**Branch:** `yolo/scarlett-measurement-2026-08-21` · **Pi restored:** 1024×3 cond A on Scarlett **hw:2** after Step 3 reboot.
 
-Steps 0–2 complete — **Step 3 reboot bundle next** per [`PROMPT-find-the-600us.md`](PROMPT-find-the-600us.md).
+Steps 0–3 complete — **Step 4 spot-check next** per [`PROMPT-find-the-600us.md`](PROMPT-find-the-600us.md).
 
 **Run order note:** Step 0 was deferred until after Steps 1–2 (already running). Escalation clause did not apply retroactively — swap/maj_flt were flat when checked.
 
@@ -12,11 +12,13 @@ Steps 0–2 complete — **Step 3 reboot bundle next** per [`PROMPT-find-the-600
 
 | | |
 |---|---|
-| Scarlett ALSA card | **6** (`USB` / Scarlett 4i4 USB @ 480M, hub 1-1.2) |
+| Scarlett ALSA card | **2** post-reboot (`USB` / Scarlett 4i4 USB @ 480M, hub 1-1.2) — was **6** pre-reboot |
 | jackd playback | **4 ch** S32_LE FL FR FC LFE (stereo synth uses 2) |
-| IRQ 30 affinity | `0-1` (counts **100% CPU0** in `/proc/interrupts`) |
-| IRQ 41 | **mmc0 + mmc1 shared** (`GICv2 158`), affinity **CPU1** (~1.12M counts) |
-| `lowlatency` | **Y** (unchanged — **dropped from Step 3** per Step 1 kill condition) |
+| IRQ 30 | **threaded** — `irq/30-xhci_hcd` at **FF 50**, CPU0; hard IRQ still on CPU0 |
+| IRQ 41 | **mmc0 + mmc1 shared** (`GICv2 158`), affinity **CPU1** |
+| `threadirqs` | **on cmdline** (Step 3) |
+| `lowlatency` | **Y** (unchanged — **not** in Step 3 bundle) |
+| v3d | **blacklisted** — module not loaded (Step 3) |
 | Sound Blaster | **unplugged** — cell 1c not run |
 
 ---
@@ -102,7 +104,35 @@ So the unexplained **~600 µs is not generic scheduler inability to wake threads
 | v3d removal | **Hygiene bundle** — expect ~0 effect on audio metric |
 | `isolcpus` / `nohz_full` / PREEMPT_RT | **Deprioritized** — cyclictest under load did not show a 900 µs scheduler ceiling |
 
-**Next inside the wakeup path (if Step 3 bundle flat):** ftrace on xrun — `irq_handler_entry` → `sched_wakeup` → `sched_switch` filtered to jackd/surge.
+**Next inside the wakeup path (if Step 4 flat):** ftrace on xrun — `irq_handler_entry` → `sched_wakeup` → `sched_switch` filtered to jackd/surge.
+
+---
+
+## Step 3 — reboot bundle (single reboot, not an experiment)
+
+**Applied 2026-08-21 ~21:04 ET.** One reboot carries everything Steps 1–2 earned. Attribution comes from Steps 0–2; this bundle **cannot** attribute effect to cause — accepted to save reboots.
+
+| change | applied? | notes |
+|---|---|---|
+| **`threadirqs`** on cmdline | **Yes** | backup `cmdline.txt.bak-find600us-*` |
+| **`blacklist v3d`** | **Yes** | `/etc/modprobe.d/blacklist-v3d-mpe.conf` |
+| **`snd_usb_audio.lowlatency=N`** | **No** | Step 1 kill condition |
+| RT priority on `irq/30` | **No** | not in this bundle |
+
+### Post-reboot verification
+
+| check | result |
+|---|---|
+| `threadirqs` in cmdline | **present** |
+| `irq/30-xhci_hcd` thread | **FF 50**, PSR **0** (CPU0) |
+| v3d module | **not loaded**; IRQ 43 no longer `v3d` (now `feb00000.codec`) |
+| pre-reboot v3d IRQ 43 count | ~525 k on CPU1 |
+| HDMI / vc4 threads | **partial** — `video=HDMI-A-1:d video=HDMI-A-2:d` already on cmdline; **CEC/HPD irq threads on disconnected HDMI ports still present** (4× `vc4 crtc` + DSI + hdmi cec/hpd). Not fully eliminated; first time confirmed post-reboot |
+| `boot-assert-cmdline` | **ok** |
+| Scarlett + stack | **hw:2**, 1024×3, `throttled=0x0` |
+| touch UI | inactive at verify (jackd/surge active) |
+
+**Expectation:** v3d removal is hygiene (~957 k IRQ off the board); **no measurable audio effect predicted.** `threadirqs` enables handler-thread placement; IRQ 30 hard edge still lands on CPU0 — Step 4 spot-check is the harm/help read against **69.7/min** baseline.
 
 ---
 
@@ -119,12 +149,68 @@ So the unexplained **~600 µs is not generic scheduler inability to wake threads
 
 ## What is still open
 
-- **Step 3 bundle** — **`threadirqs`** + **v3d hygiene** only (`lowlatency=N` **not** in bundle); gate v3d on touch UI GL check
-- **Step 4 spot-check** — Scarlett 256×3, 3 streams × 3 runs vs **69.7/min** baseline
+- **Step 4 spot-check** — Scarlett 256×3 cond A, **3 streams × 3 runs** vs **69.7/min** baseline (not a re-baseline)
 - **Heavy-patch DSP headroom** — Mitch ear at 512; needs patch ID from Mitch
 - Sound Blaster IRQ cell 1c if dongle replugged (optional — URB hypothesis already failed on 1a vs 1b)
 - **IRQ 41 shared line** — hold as structural context for future SD/WiFi work; not a Step 3 lever
+- **HDMI vc4 thread prune** — CEC/HPD threads survive cmdline disable; separate experiment if needed
 
 ## Plain product statement
 
 The Scarlett does not buy lower latency on this Pi. The bottleneck is **Pi-side wakeup path latency**, not interface clock mode, full-speed transport, frame alignment, or xhci IRQ rate at 256 vs 1024. **1024 remains the shippable buffer**; 512/256 need Pi-side fixes or acceptance of crackle under load.
+
+---
+
+## Post-Step-3 note — the knob is unlocked but not turned
+
+`threadirqs` gave `irq/30-xhci_hcd` a handler thread at **FF 50 on CPU0**. That is simply
+the `threadirqs` default. The *reason* we wanted it threaded was that a thread's priority and
+affinity are ordinary scheduling decisions, unlike the hardware IRQ, which refused
+`set_affinity` (empty `effective_affinity`, `cpu-census-2026-08-21.md`).
+
+**Step 3 therefore delivered a capability, not a fix.**
+
+### Lever now available (free, no reboot, reversible)
+
+At FF 50 the xhci handler sits **below** jackd (FF 70), surge (FF 65), the peak meter
+(FF 65), and the six `card1-crtc` threads (FF 50, same band). Standard RT-audio practice —
+what `rtirq` does on tuned systems — raises the soundcard/USB IRQ thread **above** the audio
+thread, because the data must land before the callback that consumes it runs.
+
+```sh
+chrt -f -p 90 "$(pgrep -f 'irq/30-xhci')"     # apply
+chrt -f -p 50 "$(pgrep -f 'irq/30-xhci')"     # revert
+```
+
+This is the **most direct available test of the Step 2 Branch B finding**: if the gap is
+after the interrupt fires and before the callback runs, "the URB completed but its handler
+waited to be scheduled" is the leading candidate, and this addresses it head-on. One
+variable, no reboot, instantly reversible.
+
+### How to read Step 4
+
+`threadirqs` adds a context switch to **every** interrupt. **A result above 69.7/min is a
+real possibility and is informative** — it would measure the cost of threading, not a failed
+step. Deciding this in advance so the number is not rationalised after the fact.
+
+### Revised order
+
+| # | cell | cost | what it decides |
+|---|---|---|---|
+| 4 | Scarlett 256x3 cond A, 3 streams x 3 runs vs **69.7/min** | ~12 min | reads the Step 3 bundle |
+| 4b | same cell, `irq/30` at **FF 90** | ~12 min, no reboot | tests Branch B directly |
+| 5 | **DSP p99 ladder** — 1024 / 512 / 256, *identical* load, cond A | ~15 min | is 256 compute-bound or latency-bound? |
+
+Cell 5 remains the one that decides whether wakeup-path tuning is the right *kind* of work
+at 256 at all. `dsp_p99 ~= 92%` was recorded in Step 2 against prior figures of 34.8% (1024)
+and 37.5% (512) — but under `midi-load`, not the standard 75-voice load, so **the comparison
+is not yet valid.** Fix the load, then compare.
+
+### Also outstanding
+
+- HDMI disable is **partial** — CEC/HPD threads on disconnected ports survived the cmdline
+  change. First post-reboot confirmation; minor, but it means the earlier change did not do
+  everything assumed.
+- Card index moved **6 -> 2**. Verified harmless: `jackd-prestart.sh` resolves the device
+  from `/proc/asound/cards` into `/run/mpe/jack-device` at boot, and `asoundrc.mpe-pi` uses
+  `CARD=Passthrough` by name. Nothing hardcodes an index.

--- a/docs/measurements/scarlett-step0-gate-2026-08-21.md
+++ b/docs/measurements/scarlett-step0-gate-2026-08-21.md
@@ -1,0 +1,59 @@
+# Scarlett measurement — Step 0 config gate (2026-08-21)
+
+*Last updated: 2026-08-21 (America/Toronto)*
+
+Gate before Step 1–5 stream sampling. **Do not re-derive device facts below** — they
+are the baseline for this session.
+
+## Device record (given)
+
+| Field | Value |
+|---|---|
+| ALSA card | **6** (`USB` / Scarlett 4i4 USB) |
+| USB speed | **480M** (high speed) |
+| USB path | hub **1-1.2** (`usb-0000:01:00.0-1.2`) |
+| Transfer | **ASYNC** playback + **feedback** endpoint **0x81** |
+| Format | **S32_LE** / 24-bit |
+| Playback channels | **4** (FL FR FC LFE) |
+| Packet size | **144** bytes (6 samples × 4 ch × 6 bytes per 125 µs microframe) |
+| Sound Blaster | **unplugged** (Tier 1 out) |
+
+## Topology (baseline — do not change mid-run)
+
+```
+usb1 (xhci 480M)
+  └── 1-1 VIA hub
+        ├── 1-1.1 LUMI Keys BLOCK   12M
+        ├── 1-1.2 Scarlett 4i4      480M  ← jackd hw:6
+        └── 1-1.3 APC MINI          12M
+```
+
+Hub runs transaction translation for the 12M devices.
+
+## Gate checks
+
+| Check | Result |
+|---|---|
+| Clock / sync | `Sync Status` = **Locked** (internal; no S/PDIF/ADAT control exposed in amixer) |
+| Sample rate | **48000 Hz** running (`stream0` Momentary freq; JACK `rate=48000`) |
+| Direct Monitor | No `Direct Monitor` control in ALSA mixer (Gen3 driver); analog path is PCM 1/2 → phones (set at session start) |
+| `Standalone Switch` | **on** — noted; host playback verified working |
+| JACK device | `hw:6` Scarlett |
+| Peak meter under load | **PASS** — `peak_linear=0.255` with `midi-load.py 5` (3 voices) |
+| `meter_live` / wired | `wired=1`, `jack_online=1` at gate time |
+
+## Headphone routing (session setup)
+
+Analogue Output 03/04 → PCM 1/2 (required for audible monitor; default was PCM 3/4).
+
+## Pre-run jack state
+
+```
+period=512 periods=3 rate=48000
+```
+
+Harness will set **256×3** for Step 1.
+
+## Verdict
+
+**Gate passed.** Proceed to Step 1.

--- a/docs/measurements/scarlett-step1-256x3-condA-2026-08-21.md
+++ b/docs/measurements/scarlett-step1-256x3-condA-2026-08-21.md
@@ -1,0 +1,73 @@
+# Scarlett Step 1 — 256×3 condition A stream sample (2026-08-21)
+
+*Last updated: 2026-08-21 (America/Toronto)*
+
+**Config:** Scarlett 4i4 USB card 6 @ 480M (ASYNC + feedback 0x81). Sound Blaster
+unplugged. Hub topology per [`scarlett-step0-gate-2026-08-21.md`](scarlett-step0-gate-2026-08-21.md).
+**Protocol:** 10 jackd restarts × 2×60 s windows (`measure-stream-sample.sh`). All windows
+`meter_live=1`, `throttled=0x0`.
+
+**Pi logs:** `~/scarlett-256-A-streams-stream-{01..10}.log`, `~/scarlett-256-A-streams-index.log`
+
+## Per-stream xruns/min (mean of two 60 s windows)
+
+| stream | run1 | run2 | stream mean (/min) |
+|---:|---:|---:|---:|
+| 01 | 61 | 41 | **51.0** |
+| 02 | 38 | 42 | **40.0** |
+| 03 | 68 | 76 | **72.0** |
+| 04 | 76 | 74 | **75.0** |
+| 05 | 69 | 89 | **79.0** |
+| 06 | 62 | 69 | **65.5** |
+| 07 | 82 | 89 | **85.5** |
+| 08 | 84 | 75 | **79.5** |
+| 09 | 69 | 79 | **74.0** |
+| 10 | 76 | 75 | **75.5** |
+
+**Between-stream shape:** **unimodal** — every stream 40–86/min. No cluster at 2–5/min, no
+cluster at 18–22/min.
+
+| stat | value |
+|---|---:|
+| mean (10 streams) | **69.7/min** |
+| range | **40.0 – 85.5/min** |
+| worst stream | **07** (85.5/min) |
+| best stream | **02** (40.0/min) |
+
+Within-stream: pairs differ by up to ~20/min (e.g. stream 01: 61 vs 41) but stay in the
+same band — no within-stream lottery like the old bad/good mode flip.
+
+## Mechanism verdict (Step 1 question)
+
+**Bimodality vanished on the Scarlett.**
+
+Sound Blaster post-hygiene at 256×3 cond A was **bimodal** (six streams ~2–5/min, two
+streams ~18–22/min, mean 7.1). Scarlett ASYNC + feedback endpoint shows **one mode only**,
+all high.
+
+→ **The start-phase lottery on the Sound Blaster was the ADAPTIVE clock-lock draw**, not a
+universal frame-phase effect. Async clocking removed the two-product power-on problem.
+
+→ **Frame-phase misalignment (256 = 42.67 HS microframes) did NOT produce bimodality here.**
+That hypothesis is **not supported** for between-stream variance on this device.
+
+Do not soften: this is a **null on frame-phase lottery**, not a win on rate.
+
+## Rate verdict (plain)
+
+**The Scarlett did not rescue 256×3.** Mean ~70/min vs Sound Blaster stream-sample mean
+~7/min *(indicative — different device, different session)*. Matches Mitch's ear: 256 still
+crackles; high-speed microframes did not move the cliff.
+
+DSP under harness load: median ~37–44%, p99 ~70–93% (75-voice midi-load) — headroom exists
+under *synthetic* load; ear crackle on heavy patches is still an open axis (Step 3).
+
+## Shipping implication (interim)
+
+Scarlett **does not** change what ships at 256. It **does** remove the bad-draw lottery at
+power-on. The binding problem at 256 is **Pi-side rate**, not dongle clock mode — redirects
+work to cyclictest-under-load (Step 2) and heavy-patch DSP (Step 3), not aligned-period
+tables as the first lever.
+
+Steps 4–5 (512/1024 ladder on Scarlett) remain optional confirmation; ear test already
+suggests 1024 good / 512 heavy-patch limited.

--- a/docs/measurements/scarlett-step1-256x3-condA-2026-08-21.md
+++ b/docs/measurements/scarlett-step1-256x3-condA-2026-08-21.md
@@ -39,19 +39,24 @@ same band — no within-stream lottery like the old bad/good mode flip.
 
 ## Mechanism verdict (Step 1 question)
 
-**Bimodality vanished on the Scarlett.**
+**~~Bimodality vanished on the Scarlett.~~ — WITHDRAWN post Step 4 (2026-08-21 late)**
 
-Sound Blaster post-hygiene at 256×3 cond A was **bimodal** (six streams ~2–5/min, two
-streams ~18–22/min, mean 7.1). Scarlett ASYNC + feedback endpoint shows **one mode only**,
-all high.
+Step 4 (same async Scarlett, n=3): stream 01 **105/min**, streams 02–03 **26–34/min**. The
+Step 1 unimodal read is **not stable**. **n=3 cannot establish shape** — one-high/two-low
+is unremarkable from bimodal or wide unimodal. **Do not re-read Step 4 as confirming
+bimodality back.**
 
-→ **The start-phase lottery on the Sound Blaster was the ADAPTIVE clock-lock draw**, not a
-universal frame-phase effect. Async clocking removed the two-product power-on problem.
+Original Step 1 observation (n=10): all streams 40–86/min, no 2–5/min cluster. That session
+data stands; the **inference** (adaptive clock lock closed frame phase) is withdrawn.
 
-→ **Frame-phase misalignment (256 = 42.67 HS microframes) did NOT produce bimodality here.**
-That hypothesis is **not supported** for between-stream variance on this device.
+→ **Frame-phase alignment:** **unsupported, still unpromising.** HS microframe = 6 samples;
+1024/6 = 170.67 misaligned yet clean at 1024×3. No Pi time on alignment tables.
 
-Do not soften: this is a **null on frame-phase lottery**, not a win on rate.
+→ **Sound Blaster bimodal vs Scarlett unimodal:** inconclusive as a mechanism proof; device
+swap still shows Scarlett ~10× worse mean at 256.
+
+Do not soften: Step 1 was a **null on frame-phase lottery for that n=10 sample**, not a
+permanent closure.
 
 ## Rate verdict (plain)
 

--- a/docs/measurements/scarlett-verdict-2026-08-21.md
+++ b/docs/measurements/scarlett-verdict-2026-08-21.md
@@ -1,75 +1,69 @@
 # The Scarlett is not the answer — the bottleneck is the Pi (2026-08-21)
 
+*Amended 2026-08-21 (late): Step 1 alignment closure **withdrawn** — see §Amendment below.*
+
 Reading of `scarlett-step1-256x3-condA-2026-08-21.md`.
 
 ## Two results, one good and one bad
 
-| 256x3, condition A | Scarlett 4i4 (async, 480M) | Sound Blaster (adaptive, 12M) |
+| 256×3, condition A | Scarlett 4i4 (async, 480M) | Sound Blaster (adaptive, 12M) |
 |---|---|---|
-| shape | **unimodal**, 40.0-85.5/min | **bimodal**, ~2-5 vs ~18-22/min |
+| shape (Step 1, n=10) | **unimodal**, 40.0–85.5/min | **bimodal**, ~2–5 vs ~18–22/min |
 | mean | **69.7/min** | 7.1/min |
 | worst stream | 85.5/min | ~22/min |
 
-**Good: the mechanism question is closed.** Bimodality disappeared on a device with an
-asynchronous endpoint and a feedback channel. The stream-start lottery was the Sound
-Blaster's **adaptive clock lock**, not frame phase. The alignment hypothesis is not
-supported, and the aligned-period drop-in table (240/480/1008) can be dropped.
+**Good (partially withdrawn — see Amendment):** Step 1 read unimodal Scarlett vs bimodal
+Sound Blaster as closing the adaptive-clock-lock vs frame-phase question.
 
-**Bad: the Scarlett is roughly 10x worse at 256.** Better interface, worse result. It
+**Bad: the Scarlett is roughly 10× worse at 256.** Better interface, worse result. It
 matches the ear test — 256 crackles badly — and it means the transport swap did not move
 the cliff.
 
-## What this rules out
+## Amendment — Step 1 alignment closure withdrawn (post Step 4)
 
-The problem is **not** the dongle's clock mode, not its full-speed transport, and not
-frame alignment. Those were the three leading candidates and all three are now excluded
-by a device that fixes all of them and performs worse.
+Step 4 on the **same async Scarlett** (post-bundle, n=3 streams): stream 01 **105/min**,
+streams 02–03 **26–34/min**. The unimodal shape Step 1 relied on is **not stable** — but
+**n=3 cannot establish bimodal vs wide unimodal either**, and the 55.0/min mean is not a
+reliable estimate.
 
-**The bottleneck is on the Pi.** That is consistent with everything else measured:
-callbacks never miss their deadline at any buffer size, yet the buffer empties anyway,
-and callback lateness sits at a fixed ~900 us that does not scale with period.
+**Withdraw:** *"bimodality vanished → Sound Blaster lottery was adaptive clock lock, not
+frame phase."* The evidence for that closure is gone.
 
-## Leading hypothesis for why *worse*, not merely *not better*
+**Alignment status:** **unsupported, still unpromising** — not reopened for Pi time. At HS,
+125 µs microframes = **6 samples**; 256/6, 512/6, **1024/6 = 170.67** are all misaligned,
+**including 1024×3 with zero xruns**. Frame phase cannot explain clean 1024 if it drives 256.
 
-**High speed trades delivery granularity for servicing rate.** Full speed delivers once
-per 1 ms; high speed uses 125 us microframes — **eight times as many transfer opportunities
-per second**. `snd-usb-audio` packs packets into URBs, and the smaller the period, the fewer
-packets per URB and the more URB completions the host controller must service.
+**Do not spend Pi time on alignment tables (240/480/1008).** Fill telemetry (Phase D+A) shows
+mechanism directly.
 
-Every one of those completions is work for **xhci IRQ 30 — which is unmovable and pinned to
-CPU0.** If the binding term is the Pi's capacity to service that interrupt promptly, then a
-high-speed device at a small period demands far more of exactly the resource that is
-already scarce.
+## What this rules out (updated)
 
-Two aggravating factors on this specific device:
+The problem is **not** the dongle's clock mode or full-speed transport alone. **URB completion
+rate at 256 vs 1024 is refuted** (Step 1 inverted: 1024 had *higher* IRQ30/s, zero xruns).
+Frame alignment is **unsupported**, not closed.
 
-- **4 playback channels at 24-bit** (S32_LE, 144-byte packets) against the Sound Blaster's
-  2. Roughly double the payload for a stereo synth that uses two of them.
-- **`snd_usb_audio.lowlatency=Y`** submits URBs on demand rather than deep-queuing. On a
-  high-speed device that means many more small submissions — more completions, more
-  interrupt servicing.
+**The bottleneck is on the Pi** — term still under audit (cushion model, xrun counter, D+A).
 
-**Status: hypothesis, not measurement.** It fits every observation but has not been tested.
+## Leading hypotheses (status as of post–Step 4)
+
+| hypothesis | status |
+|---|---|
+| URB submission *rate* / `lowlatency=N` | **Refuted** (Step 1 inverted 256 vs 1024 IRQ) |
+| Frame-phase alignment | **Unsupported, unpromising** — closure withdrawn |
+| Producer lateness ~600 µs empties cushion | **Arithmetic weak** — see [`cushion-model-2026-08-21.md`](cushion-model-2026-08-21.md) |
+| **Compute-bound at 256** (fixed per-callback cost) | **Strengthened** — dsp_p99 **63–89%** at 256 cond A vs **34.8%** at 1024; see [`PLAN-2026-08-21-evening.md`](PLAN-2026-08-21-evening.md) |
 
 ## Consequences for the plan
 
-**`lowlatency=N` is un-demoted, for the Scarlett specifically.** It was demoted after T13
-because it acts on URB queue *depth*, and T13 showed depth is not the binding term. But if
-the problem here is submission *rate*, batching more packets per URB reduces completions
-directly. Different mechanism, same knob. **15 minutes, and it is now the cheapest test on
-the list.**
+**`lowlatency=N` remains dropped** (Step 1 kill condition — inverted IRQ, not depth).
 
-**Channel count is worth checking.** If jackd is opening 4 playback channels to use 2, the
-device may be configurable to a 2-channel altsetting — halving payload for free.
+**Step 2 cyclictest** still refutes generic scheduler ceiling under load (~429 µs max).
 
-**Step 2 (cyclictest under real conditions) is now the most important measurement in the
-project.** The ~900 us versus the 209-320 us floor is ~600 us unexplained, it is
-device-independent, and two devices with opposite transport characteristics have now both
-failed at small buffers. If that gap is generic scheduler latency, the remaining levers are
-`threadirqs`, `isolcpus`/`nohz_full`, and PREEMPT_RT — all Pi-side, none device-side.
+**Next (revised):** **D+A** — DSP p99 ladder + fill telemetry at 1024/512/256, identical
+cond A load; then **B** (nperiods sweep at period 1024). **`1024×2` open-check** (~30 s)
+whenever Pi is idle.
 
-**The alignment line of work is closed.** T15, T16, T17 and the aligned drop-in table are
-withdrawn. No further Pi time on frame phase.
+**Alignment line withdrawn.** T15–T17 and aligned drop-in table stay off the list.
 
 ## Product reading
 

--- a/docs/measurements/scarlett-verdict-2026-08-21.md
+++ b/docs/measurements/scarlett-verdict-2026-08-21.md
@@ -1,0 +1,82 @@
+# The Scarlett is not the answer — the bottleneck is the Pi (2026-08-21)
+
+Reading of `scarlett-step1-256x3-condA-2026-08-21.md`.
+
+## Two results, one good and one bad
+
+| 256x3, condition A | Scarlett 4i4 (async, 480M) | Sound Blaster (adaptive, 12M) |
+|---|---|---|
+| shape | **unimodal**, 40.0-85.5/min | **bimodal**, ~2-5 vs ~18-22/min |
+| mean | **69.7/min** | 7.1/min |
+| worst stream | 85.5/min | ~22/min |
+
+**Good: the mechanism question is closed.** Bimodality disappeared on a device with an
+asynchronous endpoint and a feedback channel. The stream-start lottery was the Sound
+Blaster's **adaptive clock lock**, not frame phase. The alignment hypothesis is not
+supported, and the aligned-period drop-in table (240/480/1008) can be dropped.
+
+**Bad: the Scarlett is roughly 10x worse at 256.** Better interface, worse result. It
+matches the ear test — 256 crackles badly — and it means the transport swap did not move
+the cliff.
+
+## What this rules out
+
+The problem is **not** the dongle's clock mode, not its full-speed transport, and not
+frame alignment. Those were the three leading candidates and all three are now excluded
+by a device that fixes all of them and performs worse.
+
+**The bottleneck is on the Pi.** That is consistent with everything else measured:
+callbacks never miss their deadline at any buffer size, yet the buffer empties anyway,
+and callback lateness sits at a fixed ~900 us that does not scale with period.
+
+## Leading hypothesis for why *worse*, not merely *not better*
+
+**High speed trades delivery granularity for servicing rate.** Full speed delivers once
+per 1 ms; high speed uses 125 us microframes — **eight times as many transfer opportunities
+per second**. `snd-usb-audio` packs packets into URBs, and the smaller the period, the fewer
+packets per URB and the more URB completions the host controller must service.
+
+Every one of those completions is work for **xhci IRQ 30 — which is unmovable and pinned to
+CPU0.** If the binding term is the Pi's capacity to service that interrupt promptly, then a
+high-speed device at a small period demands far more of exactly the resource that is
+already scarce.
+
+Two aggravating factors on this specific device:
+
+- **4 playback channels at 24-bit** (S32_LE, 144-byte packets) against the Sound Blaster's
+  2. Roughly double the payload for a stereo synth that uses two of them.
+- **`snd_usb_audio.lowlatency=Y`** submits URBs on demand rather than deep-queuing. On a
+  high-speed device that means many more small submissions — more completions, more
+  interrupt servicing.
+
+**Status: hypothesis, not measurement.** It fits every observation but has not been tested.
+
+## Consequences for the plan
+
+**`lowlatency=N` is un-demoted, for the Scarlett specifically.** It was demoted after T13
+because it acts on URB queue *depth*, and T13 showed depth is not the binding term. But if
+the problem here is submission *rate*, batching more packets per URB reduces completions
+directly. Different mechanism, same knob. **15 minutes, and it is now the cheapest test on
+the list.**
+
+**Channel count is worth checking.** If jackd is opening 4 playback channels to use 2, the
+device may be configurable to a 2-channel altsetting — halving payload for free.
+
+**Step 2 (cyclictest under real conditions) is now the most important measurement in the
+project.** The ~900 us versus the 209-320 us floor is ~600 us unexplained, it is
+device-independent, and two devices with opposite transport characteristics have now both
+failed at small buffers. If that gap is generic scheduler latency, the remaining levers are
+`threadirqs`, `isolcpus`/`nohz_full`, and PREEMPT_RT — all Pi-side, none device-side.
+
+**The alignment line of work is closed.** T15, T16, T17 and the aligned drop-in table are
+withdrawn. No further Pi time on frame phase.
+
+## Product reading
+
+The Scarlett still earns its place on the product grounds already argued — MIDI DIN,
+phantom power, real outputs, one cable into gear the musician already owns. **It does not
+buy lower latency on this Pi.**
+
+Mitch's ear test stands as the practical summary on the Scarlett: **1024 good, 512 crackles
+on heavy patches, 256 unusable.** That is the same ceiling as the dongle. Whatever is
+limiting this instrument is not the interface.

--- a/docs/measurements/v1-fixed-cost-2026-08-21.md
+++ b/docs/measurements/v1-fixed-cost-2026-08-21.md
@@ -1,0 +1,82 @@
+# Plan V — V0 / V1 / V2 results
+
+*Measured: 2026-08-21 (America/Toronto)*  
+*Pi artifacts: `/root/plan-v-20260821-221011`*  
+*Harness: `docs/scarlett-findings` @ `0d44df2`*
+
+## V0 — pre-checks and actions
+
+| check | finding | action taken |
+|---|---|---|
+| **V0-a governor** | `MPE_CPU_GOVERNOR=performance`; all CPUs **1800 MHz**; **`arm_boost=1`** already in `config.txt` | **none** (V5/V6 baselines may already be active — see below) |
+| **V0-b poly governor** | `surge-poly-governor` was **active**; poly env vars **unset** (defaults + dynamic governor) | `MPE_POLY_GOVERNOR=0`, `MPE_POLY_CEILING=16`, `MPE_POLY_FLOOR=16`; unit **stopped + disabled** |
+| **V0-c softmode** | `MPE_JACK_SOFTMODE=1`; jackd had **`-s`** | strict mode during cells; **restored softmode** after V2 |
+
+**Confound note:** Poly governor was likely active during **all prior measurement cells** (service active, env unset). W1 and earlier runs may have had **non-constant poly** under load. V1/V2 below used fixed poly=16, governor off.
+
+**Clock note:** Box was already on **`performance` @ 1.8 GHz** with `arm_boost=1` before V0. Historical `get_throttled=0x50000` is **not** cited as a constraint; all readings this session **`0x0`**.
+
+## V1 — silence test (Surge on, zero notes)
+
+**n = 3 runs × 30 s per buffer.** Metric: `jack_cpu_load` → absolute ms per period (p50 / p99 / max).
+
+| buffer | period ms | dsp_ms median (runs) | dsp_ms p99 (typical) | dsp_ms max (typical) |
+|---|---|---|---|---|
+| **1024×3** | 21.33 | 1.286 – 1.294 | ~1.31 | ~1.32 |
+| **512×3** | 10.67 | 0.743 – 0.750 | ~0.76 | ~0.82 |
+| **256×3** | 5.33 | 0.417 – 0.422 | ~0.45 | ~0.55 |
+
+Median absolute ms **scales ~linearly with period length** (~6–8% of deadline at all three sizes). It is **not flat at ~1.1 ms**.
+
+As **percent of deadline:** ~6.0% @ 1024 → ~7.0% @ 512 → ~7.9% @ 256 (slight uptick at smaller buffers).
+
+### V1 outcome row — **explicit**
+
+**Row 3: not flat — scales with buffer.** There is **no fixed absolute-ms per-callback term** of the kind the W1 regression inferred. The `T = a + b·N` model with **a ≈ 1.1 ms** is **not confirmed**; the silence data fit a **proportional (per-sample) cost** far better than a constant offset.
+
+**V4 is gated off.** Do not profile for a fixed term that V1 did not confirm.
+
+## V2 — client-count test @ 1024×3
+
+**n = 3 runs × 30 s each.** Same strict mode, fixed poly, no midi-load.
+
+| condition | dsp_ms median | dsp_ms p99 | dsp_ms max |
+|---|---|---|---|
+| **Surge OFF** (other JACK clients remain: peak meter, `jack_cpu_load`, etc.) | **1.312 – 1.315** | ~1.33 | ~1.40 |
+| **Surge ON** (silence, patch loaded) | **1.347 – 1.348** | ~1.37 | ~1.38 |
+
+**Delta (Surge ON − OFF): ~0.035 ms (~35 µs)** on median; p99 delta ~0.04 ms.
+
+### V2 verdict — single-client refactor
+
+**The refactor is dead.** JACK graph / inter-client overhead is **~35–40 µs**, not a meaningful share of the ~1.3 ms silence budget. Surge silence at 1024 adds almost nothing over an empty-ish graph; the ~1.3 ms at 1024 is **baseline graph + instrumentation**, not Surge DSP.
+
+## What this retires
+
+| item | status |
+|---|---|
+| **Fixed ~1.1 ms per-callback constant** (W1 regression) | **retired** — V1 shows proportional scaling, not flat ms |
+| **V4 profile-the-callback** | **not run** — gated on V1 confirm |
+| **Single-client architecture refactor** (Surge hosts looper) | **retired** — V2 delta ~35 µs |
+| **“Graph traversal is the problem”** | **retired** at measured scale |
+
+## What remains open (not run this session)
+
+| cell | note |
+|---|---|
+| **V3** | 1024×2 — independent, still pending |
+| **V5** | governor `performance` — **already active**; cell may be baseline-only or skip |
+| **V6** | `arm_boost=1` — **already active**; diagnostic compare vs stock 1.5 GHz needs revert-to-stock branch, not yet run |
+
+## Could not measure
+
+| item | why |
+|---|---|
+| Surge-isolated cost with **zero** JACK clients | JACK requires clients for `jack_cpu_load`; empty graph still carries peak meter etc. |
+| High-confidence shape / CI | n=3 per cell — rates and medians are point estimates |
+
+## Artifacts
+
+- Master log: `/root/plan-v-20260821-221011/plan-v.log`
+- V1: `/root/plan-v-20260821-221011/v1-silence.log`
+- V2: `/root/plan-v-20260821-221011/v2-client-count.log`

--- a/docs/measurements/v7-capacity-curve-2026-08-21.md
+++ b/docs/measurements/v7-capacity-curve-2026-08-21.md
@@ -1,0 +1,105 @@
+# V7 capacity curve + V3 latency win
+
+*Measured: 2026-08-21 (America/Toronto)*  
+*Pi artifacts: `/root/plan-v7-20260821-223340`*  
+*Harness: `docs/scarlett-findings` @ `3784a3f`*
+
+## Patch
+
+**Crystals** (`~/Documents/Surge XT/Patches/Quick Select/Crystals.fxp`) — loaded on Surge at run time per `~/.patch_browser_poly_state.json`.
+
+Capacity numbers are **meaningless without this patch name.**
+
+## Standing conditions
+
+| item | value |
+|---|---|
+| Poly governor | **OFF** (unit stopped/disabled) |
+| Poly ceiling/floor | **64** (out of the way) |
+| Strict mode | **ON** during cells; softmode restored after |
+| Governor / clock | `performance` @ **1800 MHz**, `arm_boost=1`, `throttled=0x0` throughout |
+| Card | **2** (live resolve) |
+| Load pattern | `midi-load-hold.py` — N simultaneous MPE voices, 12 s probe / 20 s confirm |
+| Probe step | +2 voices; first xrun delta > 0 = first overrun |
+
+## V7 — capacity curve
+
+| buffer | voices to first overrun | highest sustained clean | DSP ms @ clean (median) | DSP p99.9 / max @ clean |
+|---|---|---|---|---|
+| **1024×3** | **6** | **4** | 10.07 ms (47% of 21.3 ms period) | 97.9% / 99.5% |
+| **512×3** | **4** | **2** | 3.28 ms (31% of 10.7 ms) | 66.1% / 73.4% |
+| **256×3** | **4** | **2** | 1.73 ms (32% of 5.3 ms) | 91.8% / 92.0% |
+
+Confirm windows: **n ≈ 20** jack_cpu_load samples each (20 s) — shape claims not supported; transition counts are the datum.
+
+### Recommended poly ceilings (from V7, Crystals + hold pattern)
+
+Use **sustained-clean** as the hard cap; leave one voice headroom for performance if desired:
+
+| buffer | sustained clean | suggested `MPE_POLY_CEILING` |
+|---|---|---|
+| 1024×3 | 4 | **4** (was **12** — guess was ~3× too high for this patch) |
+| 512×3 | 2 | **2** |
+| 256×3 | 2 | **2** |
+
+**V7's ceiling numbers are the input the governor work needs** — tune against these, not against 12.
+
+### Probe log (transition detail)
+
+| buffer | ramp |
+|---|---|
+| 1024 | 2→0, 4→0, **6→86 xruns** |
+| 512 | 2→0, **4→2 xruns** |
+| 256 | 2→0, **4→14 xruns** |
+
+## V3 — `1024×2` vs `1024×3` baseline
+
+**n = 3 runs × 60 s**, condition A, `midi-load.py` (default 3-voice harness load), strict mode.
+
+| config | meter xruns/min (runs) | probe xruns/min | dsp_p99 | ALSA xrun lines |
+|---|---|---|---|---|
+| **1024×2** | 1248 / 1289 / 1248 → **~1262** | ~1400 | 100% | **0** |
+| **1024×3** | 1227 / 1337 / 1379 → **~1314** | (not extracted) | 100% | **0** |
+
+**Latency win stands:** `1024×2` = **42.7 ms** shipping total vs **64.0 ms** today, **same 21.3 ms Surge compute deadline** per callback.
+
+**Under this overload load, xruns/min does not materially improve** with nperiods=2 (both saturated at ~100% DSP). V3 confirms ALSA accepts the config and quantifies that the win is **latency**, not headroom under fixed midi-load.
+
+W0 (opens) + this run (stable strict measurement) → **candidate shipping config** pending product sign-off, not xrun improvement under overload.
+
+## Poly governor — document only (no code this pass)
+
+Recorded for later implementation (`PROMPT-YOLO-poly-governor.md`):
+
+- **Root cause of pops:** poly governor cut polyphony under CPU load → **stole sounding voices** (confirmed by ear with governor off/on).
+- **Fix 2 (fade) is the actual fix** — hard cut = step discontinuity = the pop.
+- **Fix 1 is steal *policy*, not prohibition:** released/in-release first, then quietest, then oldest. Refusing note-ons reads as broken on a performance instrument.
+- **Fix 3:** hysteresis — separate raise/lower thresholds, rate-limit changes.
+- **Open question:** governor sets poly limit over OSC; Surge decides what dies when limit drops below sounding count. **Does fade belong in Surge voice handling or in how we drive the limit** (e.g. lower only at note-off boundaries)? Settle before code.
+
+## What this retires
+
+| item | killed by |
+|---|---|
+| `MPE_POLY_CEILING=12` as a universal guess | **V7** — Crystals sustains **4** @ 1024, **2** @ 512/256 |
+| Fixed 75-voice-equivalent load as capacity proxy | **V7** — transition counts replace arbitrary soak |
+| nperiods=2 as an xrun fix under overload | **V3** — same saturation; win is latency only |
+| (prior dead list items 1–7) | see `PROMPT-V7-capacity-curve.md` |
+
+## Could not measure
+
+| item | why |
+|---|---|
+| Capacity > 32 simultaneous hold voices | ramp capped at 32; Crystals failed well below |
+| Per-patch ceilings for patches other than Crystals | one patch per V7 design |
+| V5/V6 clock arms | V0 — already at performance + arm_boost |
+
+## Artifacts
+
+- `/root/plan-v7-20260821-223340/v7-capacity.log`
+- `/root/plan-v7-20260821-223340/v3-1024x2.log`
+- `/root/plan-v7-20260821-223340/v3-baseline-1024x3.log`
+
+## Branch hygiene (Mitch)
+
+`docs/scarlett-findings` is **~30 commits** ahead of `dev` with measurement doctrine, W1/V7 harnesses, skills, and AGENTS updates. **Merge to `dev` regardless of measurement outcome** — still outstanding.

--- a/docs/measurements/w1-instrumented-window-2026-08-21.md
+++ b/docs/measurements/w1-instrumented-window-2026-08-21.md
@@ -1,0 +1,91 @@
+# W1 — four-instrument window
+
+*Measured: 2026-08-21 (America/Toronto)*  
+*Pi artifacts: `/root/w1-20260821-214044`*  
+*Harness: `docs/scarlett-findings` @ `b5eee1a`*
+
+## Setup
+
+| item | value |
+|---|---|
+| Load | **Condition A** — 75-voice `midi-load.py` via `measure-latency-run.sh` (identical all cells) |
+| Card | **2** (live resolve — Scarlett 4i4 USB) |
+| Fill poller | 10 Hz, CPU1, `nice 19`, no fork loop |
+| Window | 60 s per cell, **n=1** per cell |
+| `throttled` | `0x0` all windows |
+
+## W0
+
+**1024×2 opens.** Confirmed earlier same evening (`jackd -p 1024 -n 2` UP); not re-measured.
+
+## Control — poller perturbation (1024×3, cond A)
+
+| run | meter xruns/min | probe xruns/min |
+|---|---|---|
+| poller OFF | 6 | 8 |
+| poller ON | 2 | 4 |
+
+Poller-on was **not** materially worse (fewer events in this pair). Treat poller as **transparent enough** for this session; W1 ladder cells used poller ON.
+
+## Four-instrument table
+
+| cell | #1 probe events/min | #2 ALSA count | #2 magnitudes (msec) | #3 fill min (frames) | #3 shape | #4 dsp_p99 |
+|---|---|---|---|---|---|---|
+| W1-a 1024×3 | 6 | **0** | — | 0* | flat high | 58.9% |
+| W1-b 512×3 | 2 | **0** | — | 0* | flat high | 62.4% |
+| W1-c 256×3 | 32 | **0** | — | 513 | flat high | 76.1% |
+
+\*Single-sample `min=0` on 1024/512 with `sanity_over_buf=0` — likely pointer-wrap edge at one 10 Hz sample, not sustained drain. p50 fill ≈ 83% of buffer all cells.
+
+Meter xruns/min (instrument cross-check): W1-a **4**, W1-b **0**, W1-c **28**.
+
+### Instrument 3 detail (10 Hz, n≈530 samples/cell)
+
+| cell | buf | p50 fill | p99 fill | mean fill | % of buf (p50) |
+|---|---|---|---|---|---|
+| W1-a | 3072 | 2547 | 3057 | 2553 | 83% |
+| W1-b | 1536 | 1279 | 1529 | 1276 | 83% |
+| W1-c | 768 | 635 | 764 | 634 | 83% |
+
+No multi-second drift toward zero. **10 Hz cannot resolve per-period sawtooth** (see PROMPT-W1 amendment); shape call is slow drift only.
+
+### Instrument 2 — post-hoc journal
+
+Harness `jackd_alsa_xrun_stats` hit **mawk** incompatibility during run (fixed after — gawk-style `match(..., arr)`). Post-hoc `journalctl` for each window: **zero** lines matching `ALSA: xrun of at least N msecs`.
+
+During W1-c the journal shows **`JackEngine::XRun: client = Surge XT was not finished`** and **`mpe-peak-meter was not finished`** — graph overruns, not ALSA underrun messages. Instrument 2 correctly reports **0 ALSA magnitudes** when failures are graph-side.
+
+## Interpretation row — **explicit**
+
+**Primary: `#1 = N`, `#2 = 0` → all counted xruns are graph overruns.** The cushion was never drained. Producer-lateness / IRQ-priority / ~600 µs stall levers are the **wrong term** for this symptom on this stack.
+
+**Secondary (256 cell): `#3 flat` + `#4 ≈ 76%` → compute-bound at small buffer** — steep dsp_p99 ladder (59% → 62% → 76%) reproduces Step 4 direction with matched load. Fixed per-callback costs dominate at 256×3.
+
+Fill trace shape per cell: **flat high fill, no sustained drain, xruns at 256 anyway** — consistent with **P3 (counter fires on graph overruns)** plus compute headroom collapse, not P2/P2′ drain or P1 giant stall.
+
+## What this retires
+
+| line of work | status |
+|---|---|
+| Producer lateness / cushion drain as xrun cause | **retired** (reinforces `cushion-model-2026-08-21.md`) |
+| `irq/30` FF 90, `isolcpus`, `nohz_full`, PREEMPT_RT for this crackle | **retired** (was parked; W1 adds evidence) |
+| ~600 µs cyclictest stall as binding term | **retired** for xrun mechanism (`find-600us-2026-08-21.md` Step 2 still true; not what empties buffer) |
+| Aligned period tables | **retired** (already dead pre-W1) |
+| URB rate / swap / major-fault hypotheses | **retired** (Steps 0–1) |
+
+**Not retired:** Surge/graph CPU at 256×3 — dsp_p99 76% with 28–32 xruns/min is the live problem.
+
+## Could not measure
+
+| item | why |
+|---|---|
+| Per-period fill waveform | 10 Hz poller by design; raising rate would perturb (PROMPT-W1 amendment) |
+| ALSA underrun magnitudes this run | No ALSA xrun lines in journal — failures were graph-side |
+| Distribution shape / confidence intervals | **n=1** per cell — rates are point estimates only |
+
+## Harness notes
+
+- Poller sanity passed (`sanity_over_buf=0`).
+- Post-run restore left jackd on **1024×3** with **`-s` softmode** — re-apply strict reporting before the next trusted count if needed.
+- Raw fill traces: `/root/w1-20260821-214044/*-fill-*.log`
+- Full cell logs: `/root/w1-20260821-214044/{control-no-fill,control-fill,W1-a,W1-b,W1-c}.log`

--- a/docs/measurements/xrun-counter-audit-2026-08-21.md
+++ b/docs/measurements/xrun-counter-audit-2026-08-21.md
@@ -68,4 +68,8 @@ That gap is exactly why fill-level telemetry (`appl_ptr − hw_ptr` from `/proc/
 
 ## Verdict for gate C
 
-**P3 not eliminated.** Counter semantics are understood and are not a no-op, but they do **not** prove “playback underrun from producer lateness.” Next: **fill telemetry (A)** and **nperiods sweep at fixed period (B)** per cushion model.
+**P3 not eliminated.** Counter semantics are understood and are not a no-op, but they do **not** prove “playback underrun from producer lateness.”
+
+**Type (b) — graph / callback overrun:** Under strict mode, JACK engine xrun events can correlate with **clients exceeding the period budget** (`jack_cpu_load` p99), not ALSA buffer drain. At dsp_p99 **63–89%** at 256 cond A (Step 4), **11% headroom at p99** — graph overruns are **expected**, not hypothetical. D+A (flat fill trace + high dsp_p99) would show **P3 counter semantics + compute-bound** in one picture.
+
+Next: **D+A** (fill telemetry folded into DSP ladder), then **B** per [`PLAN-2026-08-21-evening.md`](PLAN-2026-08-21-evening.md).

--- a/docs/measurements/xrun-counter-audit-2026-08-21.md
+++ b/docs/measurements/xrun-counter-audit-2026-08-21.md
@@ -1,98 +1,71 @@
-# Audit: what our xrun counter actually counts (2026-08-21)
+# Xrun counter semantics audit (2026-08-21)
 
-Offline audit of `native/mpe-xrun-probe/mpe-xrun-probe.c`. No Pi time used.
+*Offline — no Pi time. Feeds [`cushion-model-2026-08-21.md`](cushion-model-2026-08-21.md) gate C.*
 
-## What the probe does
+## What the harness reports as `xruns`
 
-```c
-jack_set_xrun_callback(g_client, on_xrun, NULL);
-...
-static int on_xrun(void *arg) { atomic_fetch_add(&g_xrun_count, 1UL); return 0; }
-```
-
-It is an **event counter on JACK's xrun callback**. Nothing more.
-
-## Finding 1 — we have no magnitude, only counts
-
-The probe's own header says it:
-
-> `Xrun callback: event count only (jack_get_xrun_delayed_usecs is 0 on JACK2/ALSA).`
-
-**Every "xruns/min" figure produced in this project is an undifferentiated event count.** A
-1 us overrun and a 40 ms underrun both increment by exactly 1. We have never had magnitude
-data, and the arithmetic in `cushion-model-2026-08-21.md` turns entirely on magnitude.
-
-## Finding 2 — the callback aggregates structurally different events
-
-JACK2 invokes the xrun callback for **at least two distinct conditions**:
-
-| # | condition | did the hardware buffer empty? |
+| layer | source | semantics |
 |---|---|---|
-| **a** | ALSA returns `EPIPE` — a genuine playback underrun | **yes** |
-| **b** | the client graph fails to complete within the period — "client too slow" | **no** |
+| **RESULT `xruns=`** | `mpe-peak-meter` → `/run/mpe/meter.state` | Delta of cumulative **`jack_set_xrun_callback`** count over the 60 s window |
+| **Per-second table** | same meter | Same counter, sampled each second |
+| **Probe `XRUN_COUNT`** | `mpe-xrun-probe` | Independent **`jack_set_xrun_callback`** on a passive client — should track engine events |
+| **Probe `frames_late_*`** | `jack_frames_since_cycle_start` in process callback | **In-cycle lateness** (µs into the period when probe runs) — **not** an underrun |
+| **Probe `jitter_*`** | monotonic inter-callback period error | Wakeup timing — **not** an underrun |
+| **Legacy `delay_*`** | deprecated path | Harness marks `(legacy, ignore)` |
 
-**These are not the same event and our counter cannot tell them apart.**
+**The primary metric is JACK engine xrun notifications, not ALSA `avail` or a driver underrun counter read directly.**
 
-**This is the reconciliation the cushion model needed.** A type-(b) xrun requires only that
-Surge overran its 21.3 ms compute deadline. **It does not require the 42.7 ms cushion to
-drain at all.** The factor-of-100 gap between the 42.7 ms cushion and the 429 us worst
-measured stall stops being a paradox the moment type (b) is on the table.
-
-It also resolves the T11 anomaly — *"at 64 frames the callback never missed its deadline
-while 6% of periods underran."* The probe measures **inter-callback period jitter and
-`frames_since_cycle_start`**, not whether the graph finished computing. "Callback woke on
-time" and "graph overran the period" are fully compatible. They were never in tension; we
-were reading two different quantities as if they were one.
-
-And it makes the `dsp_p99 ~= 92%` reading at 256 far more alarming: at 92% of deadline, type
-(b) events are *expected*, and they would be counted as xruns indistinguishably from drain.
-
-**Caveat:** this is reasoned from JACK2's documented behaviour, not from reading the
-installed jackd's source in this session. Confirm against the version on the appliance
-before treating the two-condition split as established.
-
-## Finding 3 — jackd already reports magnitudes and we discard them
-
-jackd's own stderr emits lines of the form:
+## Code paths (repo)
 
 ```
-ALSA: xrun of at least 0.123 msecs
+measure-latency-run.sh
+  _enable_strict_xrun_reporting  → MPE_JACK_SOFTMODE=0 in /etc/mpe/mpe.env, restart jackd
+  _meter_xruns                   → mpe_meter_xruns_read() from meter.state
+  _start_xrun_probe              → mpe-xrun-probe (parallel xrun + jitter + frames_late)
+
+native/mpe-peak-meter/mpe-peak-meter.c
+  jack_set_xrun_callback(on_xrun) → atomic ++g_xrun_count → meter.state xruns=
+
+native/mpe-xrun-probe/mpe-xrun-probe.c
+  jack_set_xrun_callback(on_xrun) → atomic ++g_xrun_count (logged as XRUN_COUNT)
+  comment: jack_get_xrun_delayed_usecs is 0 on JACK2/ALSA — no delay magnitude from JACK API
+
+scripts/start-jackd.sh
+  -s when MPE_JACK_SOFTMODE=1 (shipping default: softmode)
+  no -s when MPE_JACK_SOFTMODE=0 (strict — zombify late clients)
 ```
 
-That is a **type-(a) event with a magnitude attached** — exactly what we lack. Grep of
-`scripts/measure-latency-run.sh` shows **no capture of jackd's stderr or journal** anywhere
-in the harness. This data has existed all along and has been thrown away on every run.
+## Integrity gates already in place
 
-## The discriminator — free, and available from existing runs
+| gate | status |
+|---|---|
+| Softmode must be off during measurement | `_enable_strict_xrun_reporting` writes **env file**, not shell export (fixed 2026-08-17 bench bug) |
+| Meter must be live | `MPE_PEAK_METER=1`; harness **VOID** if meter stale or xruns go backwards mid-window |
+| Journal xrun lines | **Not used** for harness (journal has zero xrun lines on this appliance — documented in `looper_health.py`) |
 
-For any window, compare:
+## What JACK `xrun_callback` actually means (binding term)
 
-| probe `XRUN_COUNT` | jackd "xrun of at least" lines | reading |
-|---|---|---|
-| N | N, with magnitudes | genuine ALSA underruns — the drain model applies |
-| N | **0** | **all type (b)** — graph overruns; cushion size is irrelevant |
-| N | M < N | mixture — and the split is the number that matters |
+On JACK2 + ALSA backend, the engine invokes registered xrun callbacks when the **backend reports an xrun** — typically ALSA playback delay/underrun or a cycle that missed the hardware clock. It is **one counter per engine xrun event**, not per client.
 
-If past logs retained the journal, **this can be settled with no new measurement.**
+It is **not** the same as:
 
-## Actions
+- “playback buffer empty because producer was 600 µs late” (inferred)
+- probe `frames_late` (sub-period callback entry time)
+- DSP load % from `jack_cpu_load` (graph CPU time)
 
-1. **Harness change:** capture `journalctl -u mpe-jackd` for the window alongside the probe
-   log, and report **both** counts and the ALSA magnitudes. One-line addition; makes every
-   future run strictly more informative.
-2. **Re-read history:** if the journal survives for T5 / T11 / T13 / the Scarlett runs,
-   recompute the split retrospectively.
-3. **Reinterpret with care.** Do not retract prior findings wholesale — the comparisons were
-   internally consistent, since every cell used the same counter. But **any conclusion that
-   depended on xruns meaning "the buffer emptied" is now unsupported**, including parts of
-   the runway and alignment reasoning.
-4. Keep the fill-level telemetry (`/proc/asound/card<N>/pcm0p/sub0/status`) from
-   `cushion-model-2026-08-21.md`. It measures buffer state directly and is immune to this
-   entire class of ambiguity.
+**P3 (counter artifact) is not confirmed outright.** The counter reflects real JACK engine xrun events under strict mode. What remains unknown is **which backend condition** fired — genuine drain, clock mismatch, driver delay report, or a classification that does not match our cushion arithmetic.
 
-## Status of P3
+That gap is exactly why fill-level telemetry (`appl_ptr − hw_ptr` from `/proc/asound/.../status`) is the next measurement: correlate meter increments with buffer trace shape.
 
-`cushion-model-2026-08-21.md` listed P3 ("the counter increments on something that is not an
-underrun") as a candidate. **It is confirmed as a real mechanism** — type (b) exists and is
-counted. What remains unknown is the **split**: what fraction of our measured xruns are
-graph overruns rather than drains. Finding 3 gives that number for free.
+## Implications for session data
+
+| finding | effect on interpretation |
+|---|---|
+| Counter is engine-level, not raw ALSA | Cannot infer buffer fill from xruns alone — supports cushion-model pivot |
+| No delay magnitude from JACK on ALSA | Step 2’s 429 µs cyclictest and probe `frames_late_p99` (~300 µs at 256 in Step 4b partial) measure **different quantities** than the xrun event |
+| Strict mode during harness runs | Shipping softmode runs may **under-count or behave differently** — measurement windows are not identical to gig config |
+| Probe xrun count vs meter | Should match; if they diverge, investigate client registration / meter restart |
+
+## Verdict for gate C
+
+**P3 not eliminated.** Counter semantics are understood and are not a no-op, but they do **not** prove “playback underrun from producer lateness.” Next: **fill telemetry (A)** and **nperiods sweep at fixed period (B)** per cushion model.

--- a/docs/measurements/xrun-counter-audit-2026-08-21.md
+++ b/docs/measurements/xrun-counter-audit-2026-08-21.md
@@ -1,0 +1,98 @@
+# Audit: what our xrun counter actually counts (2026-08-21)
+
+Offline audit of `native/mpe-xrun-probe/mpe-xrun-probe.c`. No Pi time used.
+
+## What the probe does
+
+```c
+jack_set_xrun_callback(g_client, on_xrun, NULL);
+...
+static int on_xrun(void *arg) { atomic_fetch_add(&g_xrun_count, 1UL); return 0; }
+```
+
+It is an **event counter on JACK's xrun callback**. Nothing more.
+
+## Finding 1 — we have no magnitude, only counts
+
+The probe's own header says it:
+
+> `Xrun callback: event count only (jack_get_xrun_delayed_usecs is 0 on JACK2/ALSA).`
+
+**Every "xruns/min" figure produced in this project is an undifferentiated event count.** A
+1 us overrun and a 40 ms underrun both increment by exactly 1. We have never had magnitude
+data, and the arithmetic in `cushion-model-2026-08-21.md` turns entirely on magnitude.
+
+## Finding 2 — the callback aggregates structurally different events
+
+JACK2 invokes the xrun callback for **at least two distinct conditions**:
+
+| # | condition | did the hardware buffer empty? |
+|---|---|---|
+| **a** | ALSA returns `EPIPE` — a genuine playback underrun | **yes** |
+| **b** | the client graph fails to complete within the period — "client too slow" | **no** |
+
+**These are not the same event and our counter cannot tell them apart.**
+
+**This is the reconciliation the cushion model needed.** A type-(b) xrun requires only that
+Surge overran its 21.3 ms compute deadline. **It does not require the 42.7 ms cushion to
+drain at all.** The factor-of-100 gap between the 42.7 ms cushion and the 429 us worst
+measured stall stops being a paradox the moment type (b) is on the table.
+
+It also resolves the T11 anomaly — *"at 64 frames the callback never missed its deadline
+while 6% of periods underran."* The probe measures **inter-callback period jitter and
+`frames_since_cycle_start`**, not whether the graph finished computing. "Callback woke on
+time" and "graph overran the period" are fully compatible. They were never in tension; we
+were reading two different quantities as if they were one.
+
+And it makes the `dsp_p99 ~= 92%` reading at 256 far more alarming: at 92% of deadline, type
+(b) events are *expected*, and they would be counted as xruns indistinguishably from drain.
+
+**Caveat:** this is reasoned from JACK2's documented behaviour, not from reading the
+installed jackd's source in this session. Confirm against the version on the appliance
+before treating the two-condition split as established.
+
+## Finding 3 — jackd already reports magnitudes and we discard them
+
+jackd's own stderr emits lines of the form:
+
+```
+ALSA: xrun of at least 0.123 msecs
+```
+
+That is a **type-(a) event with a magnitude attached** — exactly what we lack. Grep of
+`scripts/measure-latency-run.sh` shows **no capture of jackd's stderr or journal** anywhere
+in the harness. This data has existed all along and has been thrown away on every run.
+
+## The discriminator — free, and available from existing runs
+
+For any window, compare:
+
+| probe `XRUN_COUNT` | jackd "xrun of at least" lines | reading |
+|---|---|---|
+| N | N, with magnitudes | genuine ALSA underruns — the drain model applies |
+| N | **0** | **all type (b)** — graph overruns; cushion size is irrelevant |
+| N | M < N | mixture — and the split is the number that matters |
+
+If past logs retained the journal, **this can be settled with no new measurement.**
+
+## Actions
+
+1. **Harness change:** capture `journalctl -u mpe-jackd` for the window alongside the probe
+   log, and report **both** counts and the ALSA magnitudes. One-line addition; makes every
+   future run strictly more informative.
+2. **Re-read history:** if the journal survives for T5 / T11 / T13 / the Scarlett runs,
+   recompute the split retrospectively.
+3. **Reinterpret with care.** Do not retract prior findings wholesale — the comparisons were
+   internally consistent, since every cell used the same counter. But **any conclusion that
+   depended on xruns meaning "the buffer emptied" is now unsupported**, including parts of
+   the runway and alignment reasoning.
+4. Keep the fill-level telemetry (`/proc/asound/card<N>/pcm0p/sub0/status`) from
+   `cushion-model-2026-08-21.md`. It measures buffer state directly and is immune to this
+   entire class of ambiguity.
+
+## Status of P3
+
+`cushion-model-2026-08-21.md` listed P3 ("the counter increments on something that is not an
+underrun") as a candidate. **It is confirmed as a real mechanism** — type (b) exists and is
+counted. What remains unknown is the **split**: what fraction of our measured xruns are
+graph overruns rather than drains. Finding 3 gives that number for free.

--- a/scripts/audit-storage-rt.sh
+++ b/scripts/audit-storage-rt.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# audit-storage-rt.sh — READ-ONLY audit of storage, swap, journald and RT scheduler config.
+#
+# Changes nothing. Safe to run on the appliance at any time EXCEPT inside an open
+# measurement window (see memory: no-pi-queries-during-measurement).
+#
+# Part of Step 0 of docs/measurements/PROMPT-find-the-600us.md.
+#
+# Usage:
+#   ./audit-storage-rt.sh              # single snapshot
+#   ./audit-storage-rt.sh --delta 60   # 60s delta on diskstats + swap counters
+#
+# Motivation: docs/STORAGE-ROBUSTNESS.md records that the appliance runs a full mutable
+# Raspberry Pi OS on ext4 with a persistent journal. IRQ 41 carries BOTH the SD card and
+# the SDIO WiFi, so every SD write shares an interrupt line with the network. If swap is
+# live, a cold page touched inside the audio callback becomes an SD-backed major fault --
+# device-independent, load-correlated, and invisible to callback-lateness instrumentation.
+
+set -uo pipefail
+DELTA=0
+[[ "${1:-}" == "--delta" ]] && DELTA="${2:-60}"
+
+h() { printf '\n=== %s ===\n' "$1"; }
+
+h "swap"
+swapon --show 2>/dev/null || echo "(swapon: none)"
+free -h 2>/dev/null | sed -n '1p;3p'
+echo "dphys-swapfile enabled: $(systemctl is-enabled dphys-swapfile 2>/dev/null || echo n/a)"
+echo "dphys-swapfile active:  $(systemctl is-active  dphys-swapfile 2>/dev/null || echo n/a)"
+echo "vm.swappiness = $(sysctl -n vm.swappiness 2>/dev/null || echo '?')"
+
+h "swap activity (cumulative since boot)"
+# pswpin/pswpout > 0 means swap has actually been used, not merely configured.
+grep -E '^(pswpin|pswpout|pgmajfault)' /proc/vmstat 2>/dev/null || echo "(unavailable)"
+
+h "major faults by audio processes"
+# maj_flt growing during play is the smoking gun. A one-shot value only tells you
+# about startup; use --delta to see whether it is still climbing.
+pids=$(pgrep -d, -f 'jackd|surge-xt|sooperlooper' 2>/dev/null)
+if [[ -n "$pids" ]]; then ps -o pid,comm,maj_flt,min_flt -p "$pids"; else echo "(audio stack not running)"; fi
+
+h "RT scheduler throttling"
+# Default 950000/1000000 throttles RT tasks at 95% of each period. -1 disables.
+for k in kernel.sched_rt_runtime_us kernel.sched_rt_period_us; do
+    echo "$k = $(sysctl -n "$k" 2>/dev/null || echo '?')"
+done
+
+h "journald"
+echo "disk usage: $(journalctl --disk-usage 2>/dev/null || echo '?')"
+grep -rhs '^[^#]*Storage=' /etc/systemd/journald.conf /etc/systemd/journald.conf.d/ 2>/dev/null \
+    || echo "Storage= not set explicitly -> defaults to 'auto' (persistent if /var/log/journal exists)"
+[[ -d /var/log/journal ]] && echo "/var/log/journal EXISTS -> journal is PERSISTENT (SD writes)" \
+                          || echo "/var/log/journal absent -> journal is volatile (tmpfs)"
+
+h "root filesystem mount options"
+findmnt -no SOURCE,FSTYPE,OPTIONS / 2>/dev/null || echo "(findmnt unavailable)"
+
+h "modprobe.d (untracked in repo -- record verbatim)"
+grep -rs . /etc/modprobe.d/ 2>/dev/null | grep -v '^\s*#' | grep -v '^\S*:\s*$' || echo "(empty)"
+
+h "snd_usb_audio module parameters"
+for f in /sys/module/snd_usb_audio/parameters/*; do
+    [[ -e "$f" ]] && echo "$(basename "$f") = $(cat "$f" 2>/dev/null)"
+done 2>/dev/null || echo "(module not loaded)"
+
+h "IRQ 41 (mmc0/mmc1 -- SD card AND SDIO WiFi share this line)"
+grep -E '^\s*41:' /proc/interrupts 2>/dev/null || echo "(not found)"
+echo "effective_affinity: $(cat /proc/irq/41/effective_affinity 2>/dev/null || echo '?')"
+
+if (( DELTA > 0 )); then
+    h "SD write delta over ${DELTA}s"
+    r() { grep -w mmcblk0 /proc/diskstats | awk '{print $6, $10}'; }   # sectors read, sectors written
+    before=$(r); sw_b=$(grep -E '^pswpin|^pswpout' /proc/vmstat | awk '{print $2}' | paste -sd,)
+    sleep "$DELTA"
+    after=$(r);  sw_a=$(grep -E '^pswpin|^pswpout' /proc/vmstat | awk '{print $2}' | paste -sd,)
+    echo "sectors (read written) before: $before"
+    echo "sectors (read written) after:  $after"
+    awk -v b="$before" -v a="$after" -v d="$DELTA" \
+        'BEGIN{split(b,B," ");split(a,A," ");
+         printf "delta: read %d sectors (%.1f KB/s), written %d sectors (%.1f KB/s)\n",
+            A[1]-B[1], (A[1]-B[1])*512/1024/d, A[2]-B[2], (A[2]-B[2])*512/1024/d}'
+    echo "pswpin,pswpout before: $sw_b"
+    echo "pswpin,pswpout after:  $sw_a   <-- any increase means swap is live in this window"
+fi
+
+h "verdict inputs"
+cat <<'TXT'
+Decide on these numbers, not on whether swap is merely configured:
+  * pswpin/pswpout increasing, or audio-process maj_flt climbing during play
+        -> swap is live in the audio path. Escalate above Steps 1-2.
+  * both flat and swap off
+        -> ruled out. Record it and drop it from the list.
+Run once idle and once with a stream up (in its own window, NOT inside a counted one).
+TXT

--- a/scripts/detect-jack-device.sh
+++ b/scripts/detect-jack-device.sh
@@ -79,6 +79,8 @@ _device_name_hint() {
         *" on "*) name="${name##* on }" ;;
     esac
     name="${name#ALSA.}"
+    name="${name%%, USB Audio*}"
+    name="${name%%;*}"
     printf '%s' "$name"
 }
 

--- a/scripts/measure-capacity-ramp.sh
+++ b/scripts/measure-capacity-ramp.sh
@@ -91,7 +91,8 @@ _xruns_delta() {
 }
 
 _confirm_window() {
-    local voices="$1" raw="/tmp/capacity-confirm-${TAG}-${voices}.raw"
+    local voices="$1"
+    local raw="/tmp/capacity-confirm-${TAG}-${voices}.raw"
     local period_ms jcl
     period_ms="$(awk -v b="$BUFFER" -v r="$RATE" 'BEGIN { printf "%.6f", b * 1000 / r }')"
     : >"$raw"

--- a/scripts/measure-capacity-ramp.sh
+++ b/scripts/measure-capacity-ramp.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Ramp voice count to first graph overrun at one buffer size (V7 cell).
+#
+# Usage: sudo ./scripts/measure-capacity-ramp.sh --buffer 1024 --periods 3 \
+#            --patch-name Crystals --output /path/log --tag V7-a
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+# shellcheck source=lib/paths.sh
+source "$SCRIPT_DIR/lib/paths.sh"
+# shellcheck source=lib/mpe-services.sh
+source "$SCRIPT_DIR/lib/mpe-services.sh"
+# shellcheck source=lib/audio-engine.sh
+source "$SCRIPT_DIR/lib/audio-engine.sh"
+
+BUFFER=""
+PERIODS=3
+TAG=""
+OUTPUT=""
+PATCH_NAME=""
+PROBE_SEC=12
+CONFIRM_SEC=20
+STEP=2
+MAX_VOICES=32
+RATE=48000
+ENV_FILE="/etc/mpe/mpe.env"
+RUN_AS_USER="${MPE_PI_USER:-mitch}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --buffer) BUFFER="${2:?}"; shift 2 ;;
+        --periods) PERIODS="${2:?}"; shift 2 ;;
+        --tag) TAG="${2:?}"; shift 2 ;;
+        --output) OUTPUT="${2:?}"; shift 2 ;;
+        --patch-name) PATCH_NAME="${2:?}"; shift 2 ;;
+        -h | --help) sed -n '2,8p' "$0"; exit 0 ;;
+        *) echo "Unknown: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$BUFFER" ] && [ -n "$TAG" ] && [ -n "$OUTPUT" ] || {
+    echo "ERROR: --buffer --tag --output required" >&2
+    exit 2
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: run with sudo" >&2
+    exit 1
+fi
+
+_as_user() { sudo -u "$RUN_AS_USER" -- "$@"; }
+
+_set_env_var() {
+    local key="$1" value="$2" tmp
+    tmp="$(mktemp)"
+    if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+        sed "s|^${key}=.*|${key}=${value}|" "$ENV_FILE" >"$tmp"
+    else
+        cat "$ENV_FILE" >"$tmp" 2>/dev/null || true
+        printf '\n%s=%s\n' "$key" "$value" >>"$tmp"
+    fi
+    install -m 0644 "$tmp" "$ENV_FILE"
+    rm -f "$tmp"
+}
+
+_enable_strict() {
+    _set_env_var MPE_JACK_SOFTMODE 0
+    systemctl restart mpe-jackd.service
+    sleep 4
+    mpe_wait_for_jack_server 30
+    systemctl restart surge-xt-cli.service
+    sleep 6
+}
+
+_xruns_delta() {
+    local voices="$1" secs="$2"
+    local start end
+    if ! systemctl is-active --quiet mpe-peak-meter.service 2>/dev/null; then
+        systemctl start mpe-peak-meter.service
+        sleep 2
+    fi
+    start="$(mpe_meter_xruns_read)" || start=0
+    _as_user python3 "$SCRIPT_DIR/midi-load-hold.py" "$secs" "$voices" \
+        >/tmp/midi-load-hold-$$.log 2>&1 &
+    local pid=$!
+    sleep "$secs"
+    wait "$pid" 2>/dev/null || true
+    end="$(mpe_meter_xruns_read)" || end=0
+    echo $((end - start))
+}
+
+_confirm_window() {
+    local voices="$1" raw="/tmp/capacity-confirm-${TAG}-${voices}.raw"
+    local period_ms jcl
+    period_ms="$(awk -v b="$BUFFER" -v r="$RATE" 'BEGIN { printf "%.6f", b * 1000 / r }')"
+    : >"$raw"
+    _as_user python3 "$SCRIPT_DIR/midi-load-hold.py" "$((CONFIRM_SEC + 2))" "$voices" \
+        >/tmp/midi-load-hold-confirm-$$.log 2>&1 &
+    local load_pid=$!
+    sleep 2
+    _as_user stdbuf -oL jack_cpu_load >"$raw" 2>/dev/null &
+    jcl=$!
+    sleep "$CONFIRM_SEC"
+    kill -9 "$jcl" 2>/dev/null || true
+    wait "$jcl" 2>/dev/null || true
+    wait "$load_pid" 2>/dev/null || true
+    awk -v pms="$period_ms" '
+        /[0-9]+\.[0-9]+/ { v = $NF + 0; if (v > 0 && v <= 200) a[++n] = v }
+        END {
+            if (n == 0) { print "0 0 0 0 0 0"; exit }
+            for (i = 1; i <= n; i++) for (j = i + 1; j <= n; j++)
+                if (a[i] > a[j]) { t = a[i]; a[i] = a[j]; a[j] = t }
+            p999_i = int(n * 0.999); if (p999_i < 1) p999_i = 1
+            p9999_i = int(n * 0.9999); if (p9999_i < 1) p9999_i = 1
+            printf "%d %.4f %.4f %.4f %.4f %.4f %.4f\n", n, a[int((n+1)/2)], a[int(n*0.99)], a[p999_i], a[p9999_i], a[n], a[int((n+1)/2)]*pms/100, a[p999_i]*pms/100
+        }
+    ' "$raw"
+}
+
+mpe_source_appliance_env
+_set_env_var MPE_POLY_GOVERNOR 0
+_set_env_var MPE_POLY_CEILING 64
+_set_env_var MPE_POLY_FLOOR 64
+systemctl stop surge-poly-governor.service 2>/dev/null || true
+_enable_strict
+"$SCRIPT_DIR/set-surge-audio.sh" --buffer "$BUFFER" --periods "$PERIODS"
+sleep 6
+
+{
+    echo "=== capacity-ramp tag=${TAG} buffer=${BUFFER}x${PERIODS} patch=${PATCH_NAME:-unknown} $(date -Is) ==="
+    echo "CARD=$("$SCRIPT_DIR/resolve-alsa-playback-status.sh" 2>/dev/null | awk -F= '/^CARD=/{print $2}')"
+
+    last_clean=0
+    first_overrun=""
+    v=$STEP
+    while [ "$v" -le "$MAX_VOICES" ]; do
+        xr="$(_xruns_delta "$v" "$PROBE_SEC")"
+        echo "PROBE voices=${v} sec=${PROBE_SEC} xruns_delta=${xr}"
+        if [ "$xr" -gt 0 ]; then
+            first_overrun=$v
+            break
+        fi
+        last_clean=$v
+        v=$((v + STEP))
+    done
+
+    if [ -z "$first_overrun" ]; then
+        echo "RESULT tag=${TAG} first_overrun=none_below_${MAX_VOICES} sustained_clean=${last_clean}"
+    else
+        echo "RESULT tag=${TAG} first_overrun=${first_overrun} sustained_clean=${last_clean}"
+    fi
+
+    if [ "$last_clean" -gt 0 ]; then
+        read -r cn cmed cp99 cp999 cp9999 cmax cms_med cms_p999 < <(_confirm_window "$last_clean")
+        echo "RESULT tag=${TAG} confirm_voices=${last_clean} dsp_n=${cn} dsp_ms_median=${cms_med} dsp_ms_p999=${cms_p999} dsp_p999=${cp999} dsp_max=${cmax}"
+    fi
+    echo "SENTINEL capacity-ramp-end tag=${TAG}"
+} >>"$OUTPUT"
+
+echo "Appended capacity ramp to $OUTPUT"

--- a/scripts/measure-cyclictest-under-load.sh
+++ b/scripts/measure-cyclictest-under-load.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# cyclictest under live audio stack — Scarlett Step 2 (2026-08-21)
+#
+# Re-runs cyclictest with JACK's real-time priority (70) on a pinned CPU while
+# the audio stack is up. Xruns during these windows are VOID (wakeup latency only).
+#
+# Usage:
+#   ./scripts/measure-cyclictest-under-load.sh [--output FILE] [--label TAG] [--cpu N] [--seconds N]
+#
+# Default: CPU 3, priority 70, 300 s (5 min), 200 µs interval.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+# shellcheck source=lib/paths.sh
+source "$SCRIPT_DIR/lib/paths.sh"
+
+OUTPUT="${MPE_CYCLICTEST_LOG:-$HOME/latency-cyclictest.log}"
+LABEL="under-load-cpu3"
+CPU=3
+PRIORITY=70
+INTERVAL=200
+SECONDS=300
+LOOPS=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --output) OUTPUT="${2:?}"; shift 2 ;;
+        --label) LABEL="${2:?}"; shift 2 ;;
+        --cpu) CPU="${2:?}"; shift 2 ;;
+        --priority) PRIORITY="${2:?}"; shift 2 ;;
+        --seconds) SECONDS="${2:?}"; shift 2 ;;
+        -h | --help) sed -n '2,12p' "$0"; exit 0 ;;
+        *) echo "Unknown: $1" >&2; exit 2 ;;
+    esac
+done
+
+if ! command -v cyclictest >/dev/null 2>&1; then
+    echo "ERROR: cyclictest not found" >&2
+    exit 1
+fi
+
+LOOPS=$(( (SECONDS * 1000000) / INTERVAL ))
+
+echo "=== cyclictest under load label=${LABEL} cpu=${CPU} p=${PRIORITY} ${SECONDS}s loops=${LOOPS} $(date -Is) ==="
+echo "NOTE: xruns during this window are VOID — measuring wakeup latency only."
+
+if ! systemctl is-active --quiet mpe-jackd.service 2>/dev/null; then
+    echo "WARNING: mpe-jackd not active — run under real audio load for valid comparison" >&2
+fi
+
+RAW="$(taskset -c "$CPU" cyclictest -m -t1 -p "$PRIORITY" -i "$INTERVAL" -l "$LOOPS" -a "$CPU" 2>&1)"
+RC=$?
+
+if [ "$RC" -ne 0 ]; then
+    echo "ERROR: cyclictest exited $RC" >&2
+    printf '%s\n' "$RAW" | head -10 >&2
+    exit 1
+fi
+
+if ! grep -qE 'Min:[[:space:]]*[0-9]+.*Max:[[:space:]]*[0-9]+' <<<"$RAW"; then
+    echo "ERROR: no Min/Max line in cyclictest output" >&2
+    printf '%s\n' "$RAW" | head -10 >&2
+    exit 1
+fi
+
+MAXUS="$(grep -oE 'Max:[[:space:]]*[0-9]+' <<<"$RAW" | grep -oE '[0-9]+' | sort -n | tail -1)"
+AVGUS="$(grep -oE 'Avg:[[:space:]]*[0-9]+' <<<"$RAW" | grep -oE '[0-9]+' | sort -n | tail -1)"
+
+{
+    echo "=== cyclictest under-load label=${LABEL} $(date -Is) ==="
+    echo "cpu=${CPU} priority=${PRIORITY} interval_us=${INTERVAL} seconds=${SECONDS}"
+    echo "jack_active=$(systemctl is-active mpe-jackd.service 2>/dev/null || echo unknown)"
+    echo "SENTINEL cyclictest-start"
+    uname -r
+    tr '\0' ' ' < /proc/cmdline 2>/dev/null || true
+    echo
+    printf '%s\n' "$RAW"
+    echo "WORST_CASE_USEC=${MAXUS}"
+    echo "AVG_USEC=${AVGUS}"
+    echo "SENTINEL cyclictest-end"
+    echo
+} >>"$OUTPUT"
+
+echo "Appended to $OUTPUT — worst case ${MAXUS} us, avg ${AVGUS} us"
+echo "SENTINEL cyclictest-logged"

--- a/scripts/measure-dsp-sample.sh
+++ b/scripts/measure-dsp-sample.sh
@@ -94,18 +94,23 @@ _dsp_stats() {
         }
         END {
             if (n == 0) { print "0 0 0 0 0 0 0 0 0 0"; exit }
-            for (i = 1; i <= n; i++) for (j = i + 1; j <= n; j++)
-                if (a[i] > a[j]) { t = a[i]; a[i] = a[j]; a[j] = t }
-            function pct(p,   i) {
-                i = int(n * p); if (i < 1) i = 1; if (i > n) i = n; return a[i]
+            for (i = 1; i <= n; i++) {
+                for (j = i + 1; j <= n; j++) {
+                    if (a[i] > a[j]) { t = a[i]; a[i] = a[j]; a[j] = t }
+                }
             }
-            med = pct(0.50)
-            p999 = pct(0.999)
-            p9999 = pct(0.9999)
+            med_i = int((n + 1) / 2)
+            p99_i = int(n * 0.99); if (p99_i < 1) p99_i = 1
+            p999_i = int(n * 0.999); if (p999_i < 1) p999_i = 1
+            p9999_i = int(n * 0.9999); if (p9999_i < 1) p9999_i = 1
+            med = a[med_i]
+            p99 = a[p99_i]
+            p999 = a[p999_i]
+            p9999 = a[p9999_i]
             mx = a[n]
             printf "%d %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f\n", \
-                n, med, pct(0.99), p999, p9999, mx, \
-                med * pms / 100, pct(0.99) * pms / 100, p999 * pms / 100, mx * pms / 100
+                n, med, p99, p999, p9999, mx, \
+                med * pms / 100, p99 * pms / 100, p999 * pms / 100, mx * pms / 100
         }
     ' "$raw"
 }

--- a/scripts/measure-dsp-sample.sh
+++ b/scripts/measure-dsp-sample.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Sample jack_cpu_load and report DSP percentiles + absolute ms per period.
+#
+# Usage:
+#   sudo ./scripts/measure-dsp-sample.sh --buffer 1024 --periods 3 --seconds 30 --runs 3 \
+#       --tag V1-silence-1024 --output /path/log --surge on
+#   sudo ./scripts/measure-dsp-sample.sh ... --surge off   # V2 engine baseline
+#
+# Requires strict mode (disables softmode for the session). Does not start midi-load.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+# shellcheck source=lib/paths.sh
+source "$SCRIPT_DIR/lib/paths.sh"
+# shellcheck source=lib/mpe-services.sh
+source "$SCRIPT_DIR/lib/mpe-services.sh"
+# shellcheck source=lib/audio-engine.sh
+source "$SCRIPT_DIR/lib/audio-engine.sh"
+
+BUFFER=""
+PERIODS=""
+SECONDS_PER_RUN=30
+RUNS=3
+TAG=""
+OUTPUT=""
+SURGE="on"
+RATE=48000
+_SOFTMODE_CHANGED=0
+ENV_FILE="/etc/mpe/mpe.env"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --buffer) BUFFER="${2:?}"; shift 2 ;;
+        --periods) PERIODS="${2:?}"; shift 2 ;;
+        --seconds) SECONDS_PER_RUN="${2:?}"; shift 2 ;;
+        --runs) RUNS="${2:?}"; shift 2 ;;
+        --tag) TAG="${2:?}"; shift 2 ;;
+        --output) OUTPUT="${2:?}"; shift 2 ;;
+        --surge) SURGE="${2:?}"; shift 2 ;;
+        -h | --help) sed -n '2,12p' "$0"; exit 0 ;;
+        *) echo "Unknown: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$BUFFER" ] && [ -n "$PERIODS" ] && [ -n "$TAG" ] && [ -n "$OUTPUT" ] || {
+    echo "ERROR: --buffer --periods --tag --output required" >&2
+    exit 2
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: run with sudo" >&2
+    exit 1
+fi
+
+RUN_AS_USER="${MPE_PI_USER:-mitch}"
+_as_user() { sudo -u "$RUN_AS_USER" -- "$@"; }
+
+_set_env_var() {
+    local key="$1" value="$2" tmp
+    tmp="$(mktemp)"
+    if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+        sed "s|^${key}=.*|${key}=${value}|" "$ENV_FILE" >"$tmp"
+    else
+        cat "$ENV_FILE" >"$tmp" 2>/dev/null || true
+        printf '\n%s=%s\n' "$key" "$value" >>"$tmp"
+    fi
+    install -m 0644 "$tmp" "$ENV_FILE"
+    rm -f "$tmp"
+}
+
+_enable_strict() {
+    _set_env_var MPE_JACK_SOFTMODE 0
+    _SOFTMODE_CHANGED=1
+    systemctl restart mpe-jackd.service
+    sleep 4
+    mpe_wait_for_jack_server 30
+}
+
+_restore_softmode() {
+    if [ "$_SOFTMODE_CHANGED" = 1 ]; then
+        _set_env_var MPE_JACK_SOFTMODE 1
+        _SOFTMODE_CHANGED=0
+    fi
+}
+trap _restore_softmode EXIT INT TERM
+
+_dsp_stats() {
+    local raw="$1" period_ms="$2"
+    awk -v pms="$period_ms" '
+        /[0-9]+\.[0-9]+/ {
+            v = $NF + 0
+            if (v > 0 && v <= 200) { a[++n] = v }
+        }
+        END {
+            if (n == 0) { print "0 0 0 0 0 0 0 0 0 0"; exit }
+            for (i = 1; i <= n; i++) for (j = i + 1; j <= n; j++)
+                if (a[i] > a[j]) { t = a[i]; a[i] = a[j]; a[j] = t }
+            function pct(p,   i) {
+                i = int(n * p); if (i < 1) i = 1; if (i > n) i = n; return a[i]
+            }
+            med = pct(0.50)
+            p999 = pct(0.999)
+            p9999 = pct(0.9999)
+            mx = a[n]
+            printf "%d %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f\n", \
+                n, med, pct(0.99), p999, p9999, mx, \
+                med * pms / 100, pct(0.99) * pms / 100, p999 * pms / 100, mx * pms / 100
+        }
+    ' "$raw"
+}
+
+_state_stamp() {
+    local card
+    card="$("$SCRIPT_DIR/resolve-alsa-playback-status.sh" 2>/dev/null | awk -F= '/^CARD=/{print $2}' || echo '?')"
+    echo "STATE period=${BUFFER} nperiods=${PERIODS} rate=${RATE} card=${card} \
+governor=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null) \
+mhz=$(( $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq 2>/dev/null || echo 0) / 1000 )) \
+softmode=$(grep ^MPE_JACK_SOFTMODE= "$ENV_FILE" 2>/dev/null | cut -d= -f2) \
+poly_governor=$(grep ^MPE_POLY_GOVERNOR= "$ENV_FILE" 2>/dev/null | cut -d= -f2 || echo unset) \
+poly_ceiling=$(grep ^MPE_POLY_CEILING= "$ENV_FILE" 2>/dev/null | cut -d= -f2 || echo unset) \
+surge=$(systemctl is-active surge-xt-cli 2>/dev/null) \
+sha=$(git -C "$MPE_MODULE_REPO" rev-parse --short HEAD 2>/dev/null || echo unknown) \
+throttled=$(vcgencmd get_throttled 2>/dev/null) \
+temp=$(vcgencmd measure_temp 2>/dev/null)"
+}
+
+mpe_source_appliance_env
+_enable_strict
+
+if [ "$SURGE" = off ]; then
+    systemctl stop surge-xt-cli.service 2>/dev/null || true
+    sleep 2
+else
+    systemctl start surge-xt-cli.service 2>/dev/null || true
+    sleep 6
+fi
+
+"$SCRIPT_DIR/set-surge-audio.sh" --buffer "$BUFFER" --periods "$PERIODS"
+sleep 6
+
+period_ms="$(awk -v b="$BUFFER" -v r="$RATE" 'BEGIN { printf "%.6f", b * 1000 / r }')"
+
+{
+    echo "=== measure-dsp-sample tag=${TAG} buffer=${BUFFER} periods=${PERIODS} surge=${SURGE} runs=${RUNS} seconds=${SECONDS_PER_RUN} $(date -Is) ==="
+    _state_stamp
+    echo "period_deadline_ms=${period_ms}"
+
+    run=1
+    while [ "$run" -le "$RUNS" ]; do
+        rtag="${TAG}-run${run}"
+        raw="/tmp/dsp-${rtag}-$(date +%s).raw"
+        : >"$raw"
+        _as_user stdbuf -oL jack_cpu_load >"$raw" 2>/dev/null &
+        jcl=$!
+        sleep "$SECONDS_PER_RUN"
+        kill -9 "$jcl" 2>/dev/null || true
+        wait "$jcl" 2>/dev/null || true
+
+        read -r n med p99 p999 p9999 mx med_ms p99_ms p999_ms mx_ms < <(_dsp_stats "$raw" "$period_ms")
+        temp="$(vcgencmd measure_temp 2>/dev/null || echo '?')"
+        thr="$(vcgencmd get_throttled 2>/dev/null || echo '?')"
+        echo "RESULT tag=${rtag} dsp_n=${n} dsp_median=${med} dsp_p99=${p99} dsp_p999=${p999} dsp_p9999=${p9999} dsp_max=${mx}"
+        echo "RESULT tag=${rtag} dsp_ms_median=${med_ms} dsp_ms_p99=${p99_ms} dsp_ms_p999=${p999_ms} dsp_ms_max=${mx_ms} period_ms=${period_ms} ${temp} ${thr}"
+        run=$((run + 1))
+        [ "$run" -le "$RUNS" ] && sleep 3
+    done
+    echo "SENTINEL dsp-sample-end tag=${TAG}"
+} >>"$OUTPUT"
+
+echo "Appended to $OUTPUT"

--- a/scripts/measure-latency-run.sh
+++ b/scripts/measure-latency-run.sh
@@ -43,6 +43,8 @@ _PROBE_PID=""
 PROBE_BIN="${MPE_MODULE_REPO}/native/mpe-xrun-probe/mpe-xrun-probe"
 
 SKIP_BUFFER_RESTORE=false
+FILL_LOG=""
+_FILL_PID=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -52,6 +54,7 @@ while [ $# -gt 0 ]; do
         --runs) RUNS="${2:?--runs requires a value}"; shift 2 ;;
         --seconds) SECONDS_PER_RUN="${2:?--seconds requires a value}"; shift 2 ;;
         --output) OUTPUT="${2:?--output requires a path}"; shift 2 ;;
+        --fill-log) FILL_LOG="${2:?--fill-log requires a path}"; shift 2 ;;
         --self-test) SELF_TEST=true; SECONDS_PER_RUN=10; RUNS=1; shift ;;
         --restart-between) RESTART_BETWEEN="${2:?--restart-between requires a run index}"; shift 2 ;;
         --playing-loops) PLAYING_LOOPS="${2:?--playing-loops requires 0|4|8|16}"; shift 2 ;;
@@ -140,8 +143,70 @@ _stop_xrun_probe() {
     sleep 0.2
 }
 
+_stop_fill_poller() {
+    if [ -n "$_FILL_PID" ] && kill -0 "$_FILL_PID" 2>/dev/null; then
+        kill -TERM "$_FILL_PID" 2>/dev/null || true
+        wait "$_FILL_PID" 2>/dev/null || true
+    fi
+    _FILL_PID=""
+}
+
+_start_fill_poller() {
+    local logpath="$1"
+    local status_file="$2"
+    local seconds="$3"
+    _stop_fill_poller
+    rm -f "$logpath"
+    taskset -c 1 nice -n 19 "$SCRIPT_DIR/mpe-fill-poller.sh" \
+        "$status_file" "$logpath" "$seconds" &
+    _FILL_PID=$!
+    sleep 0.2
+    if ! kill -0 "$_FILL_PID" 2>/dev/null; then
+        echo "ERROR: mpe-fill-poller failed to start" >&2
+        return 1
+    fi
+    return 0
+}
+
+# Instrument 2 — jackd ALSA xrun magnitudes (post-window journal only).
+_jackd_alsa_xrun_stats() {
+    local since="$1"
+    local until="$2"
+    if ! command -v journalctl >/dev/null 2>&1; then
+        echo "0 0 0 0 0"
+        return 0
+    fi
+    journalctl -u mpe-jackd.service --since "$since" --until "$until" --no-pager 2>/dev/null \
+        | awk '
+            /xrun of at least/ {
+                if (match($0, /at least ([0-9.]+) msecs/, m)) {
+                    v = m[1] + 0
+                    n++
+                    s += v
+                    vals[n] = v
+                    if (n == 1 || v < min) min = v
+                    if (n == 1 || v > max) max = v
+                }
+            }
+            END {
+                if (n == 0) {
+                    printf "0 0 0 0 0\n"
+                    exit
+                }
+                for (i = 1; i <= n; i++) {
+                    for (j = i + 1; j <= n; j++) {
+                        if (vals[i] > vals[j]) { t = vals[i]; vals[i] = vals[j]; vals[j] = t }
+                    }
+                }
+                med = vals[int((n + 1) / 2)]
+                printf "%d %.6f %.6f %.6f %.6f\n", n, min, med, max, s / n
+            }
+        '
+}
+
 _restore_all() {
     _stop_midi_load
+    _stop_fill_poller
     _stop_xrun_probe
     _restore_softmode
     if [ "$SKIP_BUFFER_RESTORE" = true ]; then
@@ -388,7 +453,12 @@ _run_window() {
     local run_file="$2"
     local dsp_raw="$3"
     local xrun_events="$4"
+    local fill_log="${5:-}"
+    local status_file="${6:-}"
     local i dsp prev_xr start_xr cur_xr delta samples=0
+    local window_since window_until
+    local jackd_alsa_n jackd_alsa_min jackd_alsa_med jackd_alsa_max jackd_alsa_mean
+    local probe_xrun_n
 
     _meter_max_age_s=0
 
@@ -400,16 +470,25 @@ _run_window() {
         return 1
     fi
 
+    if [ -n "$fill_log" ] && [ -n "$status_file" ]; then
+        if ! _start_fill_poller "$fill_log" "$status_file" "$SECONDS_PER_RUN"; then
+            _stop_xrun_probe "$xrun_events"
+            return 1
+        fi
+    fi
+
     _as_user stdbuf -oL jack_cpu_load >"$dsp_raw" 2>/dev/null &
     local jcl=$!
     _kill_jcl() { kill -9 "$jcl" 2>/dev/null || true; wait "$jcl" 2>/dev/null || true; }
 
     if ! prev_xr="$(_meter_xruns)"; then
         _kill_jcl
+        _stop_fill_poller
         _stop_xrun_probe "$xrun_events"
         return 1
     fi
     start_xr="$prev_xr"
+    window_since="$(date -Is)"
 
     printf '  %4s %8s %8s %7s\n' "t" "dsp%" "xruns" "delta" >>"$run_file"
 
@@ -419,12 +498,14 @@ _run_window() {
         dsp="$(tail -1 "$dsp_raw" 2>/dev/null | grep -oP '[0-9]+\.[0-9]+' | head -1 || echo '?')"
         if ! cur_xr="$(_meter_xruns)"; then
             _kill_jcl
+            _stop_fill_poller
             _stop_xrun_probe "$xrun_events"
             return 1
         fi
         if [ "$cur_xr" -lt "$prev_xr" ]; then
             echo "ERROR: meter restarted mid-run (xruns ${prev_xr} -> ${cur_xr}) — window VOID" >&2
             _kill_jcl
+            _stop_fill_poller
             _stop_xrun_probe "$xrun_events"
             return 1
         fi
@@ -435,7 +516,9 @@ _run_window() {
         prev_xr="$cur_xr"
     done
 
+    window_until="$(date -Is)"
     _kill_jcl
+    _stop_fill_poller
     _stop_xrun_probe "$xrun_events"
 
     if [ "$samples" -ne "$SECONDS_PER_RUN" ]; then
@@ -484,6 +567,11 @@ _run_window() {
         return 1
     fi
 
+    read -r jackd_alsa_n jackd_alsa_min jackd_alsa_med jackd_alsa_max jackd_alsa_mean < <(
+        _jackd_alsa_xrun_stats "$window_since" "$window_until"
+    )
+    probe_xrun_n="$(grep '^XRUN_COUNT ' "$xrun_events" 2>/dev/null | awk '{print $2}' || echo 0)"
+
     {
         echo "RESULT tag=${tag} xruns=${total_xr} meter_live=1 meter_max_age_s=${_meter_max_age_s} dsp_median=${dsp_median} dsp_p99=${dsp_p99} dsp_max=${dsp_max}"
         echo "RESULT tag=${tag} jitter_n=${jitter_n} jitter_median_usec=${jitter_med} jitter_p99_usec=${jitter_p99} jitter_p99_9_usec=${jitter_p999} jitter_max_usec=${jitter_max}"
@@ -491,6 +579,10 @@ _run_window() {
         echo "RESULT tag=${tag} delay_events=${delay_n} delay_nonzero=${delay_nz} (legacy, ignore)"
         echo "RESULT tag=${tag} samples=${samples} ${temp} ${throttle}"
         echo "RESULT tag=${tag} file=${run_file} xrun_events=${xrun_events}"
+        echo "RESULT tag=${tag} probe_xrun_count=${probe_xrun_n} jackd_alsa_xrun_count=${jackd_alsa_n} jackd_alsa_msec_min=${jackd_alsa_min} jackd_alsa_msec_median=${jackd_alsa_med} jackd_alsa_msec_max=${jackd_alsa_max} jackd_alsa_msec_mean=${jackd_alsa_mean} window_since=${window_since} window_until=${window_until}"
+        if [ -n "$fill_log" ]; then
+            echo "RESULT tag=${tag} fill_log=${fill_log}"
+        fi
     }
 
     echo "SENTINEL run-complete tag=${tag} xruns=${total_xr}"
@@ -529,6 +621,16 @@ _run_window() {
     _assert_jack_periods "$PERIODS_EFFECTIVE" || exit 1
     echo "=== provenance after strict restart ==="
     _record_provenance
+
+    ALSA_STATUS=""
+    if [ -n "$FILL_LOG" ]; then
+        if ! RESOLVE="$("$SCRIPT_DIR/resolve-alsa-playback-status.sh")"; then
+            echo "ERROR: resolve-alsa-playback-status failed (fill-log requested)" >&2
+            exit 1
+        fi
+        ALSA_STATUS="$(printf '%s\n' "$RESOLVE" | awk -F= '/^STATUS=/{print $2}')"
+        echo "=== fill telemetry card $(printf '%s\n' "$RESOLVE" | awk -F= '/^CARD=/{print $2}') status=${ALSA_STATUS} ==="
+    fi
 
     if [ "$PLAYING_LOOPS" -gt 0 ]; then
         case "$PLAYING_LOOPS" in
@@ -575,17 +677,28 @@ _run_window() {
         run_file="/tmp/latency-${tag}-${stamp}.out"
         dsp_raw="/tmp/latency-${tag}-${stamp}.dsp"
         xev="/tmp/latency-${tag}-${stamp}.xruns"
+        fill_file=""
+        if [ -n "$FILL_LOG" ]; then
+            fill_file="${FILL_LOG}-${tag}.log"
+        fi
 
         _as_user python3 "$SCRIPT_DIR/midi-load.py" "$((SECONDS_PER_RUN + 20))" \
             >"/tmp/latency-midi-load-${stamp}.log" 2>&1 &
         _LOAD_PID=$!
         sleep 8
 
-        if ! _run_window "$tag" "$run_file" "$dsp_raw" "$xev"; then
+        if ! _run_window "$tag" "$run_file" "$dsp_raw" "$xev" "$fill_file" "$ALSA_STATUS"; then
             _stop_midi_load
             exit 1
         fi
         _stop_midi_load
+
+        if [ -n "$fill_file" ] && [ -s "$fill_file" ]; then
+            if ! "$SCRIPT_DIR/summarize-fill-trace.sh" "$fill_file" "$BUFFER" "$PERIODS_EFFECTIVE" >>"$OUTPUT"; then
+                echo "ERROR: fill trace sanity check failed for ${fill_file}" >&2
+                exit 1
+            fi
+        fi
 
         if [ ! -s "$run_file" ]; then
             echo "ERROR: empty run file $run_file" >&2

--- a/scripts/measure-latency-run.sh
+++ b/scripts/measure-latency-run.sh
@@ -179,8 +179,8 @@ _jackd_alsa_xrun_stats() {
     journalctl -u mpe-jackd.service --since "$since" --until "$until" --no-pager 2>/dev/null \
         | awk '
             /xrun of at least/ {
-                if (match($0, /at least ([0-9.]+) msecs/, m)) {
-                    v = m[1] + 0
+                if (match($0, /at least [0-9.]+ msecs/)) {
+                    v = substr($0, RSTART + 9, RLENGTH - 15) + 0
                     n++
                     s += v
                     vals[n] = v

--- a/scripts/measure-plan-v.sh
+++ b/scripts/measure-plan-v.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Plan V — V0 pre-checks + V1 silence + V2 client-count (~35 min).
+#
+# Usage: sudo ./scripts/measure-plan-v.sh [--artifact-dir DIR]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+ARTIFACT_DIR="${HOME}/plan-v-$(date +%Y%m%d-%H%M%S)"
+ENV_FILE="/etc/mpe/mpe.env"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --artifact-dir) ARTIFACT_DIR="${2:?}"; shift 2 ;;
+        -h | --help) sed -n '2,8p' "$0"; exit 0 ;;
+        *) echo "Unknown: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: run with sudo" >&2
+    exit 1
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+MASTER="${ARTIFACT_DIR}/plan-v.log"
+exec > >(tee -a "$MASTER") 2>&1
+
+_set_env_var() {
+    local key="$1" value="$2" tmp
+    tmp="$(mktemp)"
+    if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+        sed "s|^${key}=.*|${key}=${value}|" "$ENV_FILE" >"$tmp"
+    else
+        cat "$ENV_FILE" >"$tmp" 2>/dev/null || true
+        printf '\n%s=%s\n' "$key" "$value" >>"$tmp"
+    fi
+    install -m 0644 "$tmp" "$ENV_FILE"
+    rm -f "$tmp"
+}
+
+echo "=== Plan V V0+V1+V2 $(date -Is) artifacts=$ARTIFACT_DIR ==="
+
+echo ""
+echo "=== V0-a governor ==="
+echo "MPE_CPU_GOVERNOR=$(grep ^MPE_CPU_GOVERNOR= "$ENV_FILE" 2>/dev/null || echo 'unset (commented in example)')"
+for cpu in /sys/devices/system/cpu/cpu[0-9]*; do
+    [ -f "$cpu/cpufreq/scaling_governor" ] || continue
+    echo "$(basename "$cpu") governor=$(cat "$cpu/cpufreq/scaling_governor") mhz=$(( $(cat "$cpu/cpufreq/scaling_cur_freq") / 1000 ))"
+done
+if grep -q '^arm_boost=1' /boot/firmware/config.txt 2>/dev/null || grep -q '^arm_boost=1' /boot/config.txt 2>/dev/null; then
+    echo "config.txt: arm_boost=1 already set (V6 baseline may already be active)"
+fi
+
+echo ""
+echo "=== V0-b poly governor ==="
+echo "surge-poly-governor: $(systemctl is-active surge-poly-governor 2>/dev/null || echo inactive)"
+echo "MPE_POLY_GOVERNOR=$(grep ^MPE_POLY_GOVERNOR= "$ENV_FILE" 2>/dev/null || echo unset)"
+echo "MPE_POLY_CEILING=$(grep ^MPE_POLY_CEILING= "$ENV_FILE" 2>/dev/null || echo unset)"
+echo "MPE_POLY_FLOOR=$(grep ^MPE_POLY_FLOOR= "$ENV_FILE" 2>/dev/null || echo unset)"
+
+echo ""
+echo "=== V0-c softmode ==="
+echo "MPE_JACK_SOFTMODE=$(grep ^MPE_JACK_SOFTMODE= "$ENV_FILE" 2>/dev/null || echo unset)"
+pgrep -a jackd | head -1 || true
+
+echo ""
+echo "=== V0 actions: disable poly governor, pin poly, stop governor unit ==="
+_set_env_var MPE_POLY_GOVERNOR 0
+_set_env_var MPE_POLY_CEILING 16
+_set_env_var MPE_POLY_FLOOR 16
+systemctl stop surge-poly-governor.service 2>/dev/null || true
+systemctl disable surge-poly-governor.service 2>/dev/null || true
+echo "poly governor stopped; MPE_POLY_GOVERNOR=0 MPE_POLY_CEILING=16 MPE_POLY_FLOOR=16"
+echo "NOTE: CPU governor unchanged for V0 (V5 is separate). softmode reverted by measure-dsp-sample strict restart."
+
+V1_LOG="${ARTIFACT_DIR}/v1-silence.log"
+: >"$V1_LOG"
+
+echo ""
+echo "=== V1 silence test (Surge on, zero notes, n=3 x 30s per buffer) ==="
+for buf in 1024 512 256; do
+    "$SCRIPT_DIR/measure-dsp-sample.sh" \
+        --buffer "$buf" --periods 3 --seconds 30 --runs 3 \
+        --tag "V1-silence-${buf}" --output "$V1_LOG" --surge on
+done
+
+V2_LOG="${ARTIFACT_DIR}/v2-client-count.log"
+: >"$V2_LOG"
+
+echo ""
+echo "=== V2 client-count @ 1024x3 (n=3 x 30s) ==="
+echo "--- surge OFF (engine baseline) ---"
+"$SCRIPT_DIR/measure-dsp-sample.sh" \
+    --buffer 1024 --periods 3 --seconds 30 --runs 3 \
+    --tag "V2-no-clients" --output "$V2_LOG" --surge off
+
+echo "--- surge ON (Surge alone) ---"
+"$SCRIPT_DIR/measure-dsp-sample.sh" \
+    --buffer 1024 --periods 3 --seconds 30 --runs 3 \
+    --tag "V2-surge-only" --output "$V2_LOG" --surge on
+
+systemctl start surge-xt-cli.service 2>/dev/null || true
+sleep 4
+"$SCRIPT_DIR/set-surge-audio.sh" --buffer 1024 --periods 3
+sleep 4
+
+echo ""
+echo "=== restore softmode for shipping ==="
+_set_env_var MPE_JACK_SOFTMODE 1
+systemctl restart mpe-jackd.service
+sleep 4
+systemctl restart surge-xt-cli.service 2>/dev/null || true
+sleep 4
+
+echo "SENTINEL plan-v-v0-v1-v2-complete $(date -Is)"
+echo "artifacts=$ARTIFACT_DIR"

--- a/scripts/measure-plan-v7.sh
+++ b/scripts/measure-plan-v7.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Plan V7 capacity curve + V3 1024x2.
+#
+# Usage: sudo ./scripts/measure-plan-v7.sh [--artifact-dir DIR] [--patch-name NAME]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+ARTIFACT_DIR="${HOME}/plan-v7-$(date +%Y%m%d-%H%M%S)"
+PATCH_NAME="Crystals"
+ENV_FILE="/etc/mpe/mpe.env"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --artifact-dir) ARTIFACT_DIR="${2:?}"; shift 2 ;;
+        --patch-name) PATCH_NAME="${2:?}"; shift 2 ;;
+        -h | --help) sed -n '2,6p' "$0"; exit 0 ;;
+        *) echo "Unknown: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: run with sudo" >&2
+    exit 1
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+exec > >(tee -a "${ARTIFACT_DIR}/plan-v7.log") 2>&1
+
+_set_env_var() {
+    local key="$1" value="$2" tmp
+    tmp="$(mktemp)"
+    if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+        sed "s|^${key}=.*|${key}=${value}|" "$ENV_FILE" >"$tmp"
+    else
+        cat "$ENV_FILE" >"$tmp" 2>/dev/null || true
+        printf '\n%s=%s\n' "$key" "$value" >>"$tmp"
+    fi
+    install -m 0644 "$tmp" "$ENV_FILE"
+    rm -f "$tmp"
+}
+
+echo "=== Plan V7 + V3 $(date -Is) artifacts=$ARTIFACT_DIR patch=${PATCH_NAME} ==="
+echo "poly_state=$(cat /home/mitch/.patch_browser_poly_state.json 2>/dev/null || echo missing)"
+
+# Standing conditions
+_set_env_var MPE_POLY_GOVERNOR 0
+_set_env_var MPE_POLY_CEILING 64
+_set_env_var MPE_POLY_FLOOR 64
+systemctl stop surge-poly-governor.service 2>/dev/null || true
+systemctl disable surge-poly-governor.service 2>/dev/null || true
+
+V7_LOG="${ARTIFACT_DIR}/v7-capacity.log"
+: >"$V7_LOG"
+
+echo ""
+echo "=== V7 capacity curve ==="
+for buf in 1024 512 256; do
+    tag="V7-${buf}"
+    "$SCRIPT_DIR/measure-capacity-ramp.sh" \
+        --buffer "$buf" --periods 3 --tag "$tag" \
+        --output "$V7_LOG" --patch-name "$PATCH_NAME"
+    sleep 5
+done
+
+echo ""
+echo "=== V3 1024x2 (n=3, cond A, 60s) ==="
+V3_LOG="${ARTIFACT_DIR}/v3-1024x2.log"
+"$SCRIPT_DIR/measure-latency-run.sh" \
+    --buffer 1024 --periods 2 --condition A --runs 3 --seconds 60 \
+    --output "$V3_LOG" --no-restore-buffer
+
+echo ""
+echo "=== V3 baseline 1024x3 (n=3, same session) ==="
+V3_BASE="${ARTIFACT_DIR}/v3-baseline-1024x3.log"
+"$SCRIPT_DIR/measure-latency-run.sh" \
+    --buffer 1024 --periods 3 --condition A --runs 3 --seconds 60 \
+    --output "$V3_BASE"
+
+echo ""
+echo "=== restore shipping softmode ==="
+_set_env_var MPE_JACK_SOFTMODE 1
+systemctl restart mpe-jackd.service
+sleep 4
+systemctl restart surge-xt-cli.service
+sleep 4
+
+echo "SENTINEL plan-v7-complete $(date -Is)"

--- a/scripts/measure-w1-window.sh
+++ b/scripts/measure-w1-window.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# W1 — four-instrument window (PROMPT-W1-instrumented-window.md).
+#
+# Order: poller sanity → control (1024x3 with/without poller) → W1-a/b/c ladder.
+# Load: condition A only (75-voice midi-load via measure-latency-run.sh default).
+#
+# Usage: sudo ./scripts/measure-w1-window.sh [--artifact-dir DIR]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+ARTIFACT_DIR="${HOME}/w1-$(date +%Y%m%d-%H%M%S)"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --artifact-dir) ARTIFACT_DIR="${2:?}"; shift 2 ;;
+        -h | --help)
+            sed -n '2,12p' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: run with sudo" >&2
+    exit 1
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+MASTER="${ARTIFACT_DIR}/w1-run.log"
+exec > >(tee -a "$MASTER") 2>&1
+
+echo "=== W1 instrumented window $(date -Is) artifacts=$ARTIFACT_DIR ==="
+echo "load=condition_A midi_load_voices=75 (measure-latency-run default)"
+
+RESOLVE="$("$SCRIPT_DIR/resolve-alsa-playback-status.sh")"
+CARD="$(printf '%s\n' "$RESOLVE" | awk -F= '/^CARD=/{print $2}')"
+STATUS="$(printf '%s\n' "$RESOLVE" | awk -F= '/^STATUS=/{print $2}')"
+echo "resolved CARD=$CARD STATUS=$STATUS"
+
+echo ""
+echo "=== poller sanity (10 s idle stream) ==="
+SANITY_LOG="${ARTIFACT_DIR}/sanity-fill.log"
+if ! pgrep -x jackd >/dev/null; then
+    echo "ERROR: jackd not running — start stack before W1" >&2
+    exit 1
+fi
+PERIOD="$(pgrep -a jackd | head -1 | sed -n 's/.*-p \([0-9][0-9]*\).*/\1/p')"
+NPER="$(pgrep -a jackd | head -1 | sed -n 's/.*-n \([0-9][0-9]*\).*/\1/p')"
+PERIOD="${PERIOD:-1024}"
+NPER="${NPER:-3}"
+taskset -c 1 nice -n 19 "$SCRIPT_DIR/mpe-fill-poller.sh" "$STATUS" "$SANITY_LOG" 10
+if ! "$SCRIPT_DIR/summarize-fill-trace.sh" "$SANITY_LOG" "$PERIOD" "$NPER"; then
+    echo "ERROR: fill poller sanity check failed — fix wrap arithmetic before W1" >&2
+    exit 1
+fi
+echo "sanity ok period=$PERIOD nperiods=$NPER"
+
+_run_cell() {
+    local label="$1"
+    local buffer="$2"
+    local periods="${3:-3}"
+    local use_fill="$4"
+    local log="${ARTIFACT_DIR}/${label}.log"
+    rm -f "$log"
+    local args=(
+        --buffer "$buffer"
+        --periods "$periods"
+        --condition A
+        --runs 1
+        --seconds 60
+        --output "$log"
+        --no-restore-buffer
+    )
+    if [ "$use_fill" = 1 ]; then
+        args+=(--fill-log "${ARTIFACT_DIR}/${label}-fill")
+    fi
+    echo "--- cell ${label} buffer=${buffer} periods=${periods} fill=${use_fill} ---"
+    "$SCRIPT_DIR/measure-latency-run.sh" "${args[@]}"
+    grep '^RESULT tag=' "$log" | tail -6
+    if [ "$use_fill" = 1 ]; then
+        fill_log="${ARTIFACT_DIR}/${label}-fill-A-b${buffer}-p${periods}-l0-run1.log"
+        if [ -f "$fill_log" ]; then
+            "$SCRIPT_DIR/summarize-fill-trace.sh" "$fill_log" "$buffer" "$periods" || true
+        fi
+    fi
+}
+
+echo ""
+echo "=== W0 (report only — prior run) ==="
+echo "W0: 1024x2 opened on Pi 2026-08-21 (jackd -p 1024 -n 2 UP). Not re-run."
+
+echo ""
+echo "=== control: 1024x3 poller OFF ==="
+_run_cell "control-no-fill" 1024 3 0
+CTRL_NO_XR="$(grep 'RESULT tag=.* xruns=' "${ARTIFACT_DIR}/control-no-fill.log" | tail -1 | sed -n 's/.* xruns=\([0-9]*\).*/\1/p')"
+
+echo ""
+echo "=== control: 1024x3 poller ON ==="
+_run_cell "control-fill" 1024 3 1
+CTRL_FILL_XR="$(grep 'RESULT tag=.* xruns=' "${ARTIFACT_DIR}/control-fill.log" | tail -1 | sed -n 's/.* xruns=\([0-9]*\).*/\1/p')"
+echo "control xruns: no_fill=${CTRL_NO_XR} fill_on=${CTRL_FILL_XR}"
+
+echo ""
+echo "=== W1 ladder (poller ON) ==="
+_run_cell "W1-a" 1024 3 1
+_run_cell "W1-b" 512 3 1
+_run_cell "W1-c" 256 3 1
+
+echo ""
+echo "=== restore shipping 1024x3 ==="
+"$SCRIPT_DIR/set-surge-audio.sh" --buffer 1024 --periods 3
+sleep 4
+pgrep -a jackd | head -1
+
+echo "SENTINEL w1-complete $(date -Is) artifacts=$ARTIFACT_DIR"

--- a/scripts/midi-load-hold.py
+++ b/scripts/midi-load-hold.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Hold N simultaneous MPE voices — for capacity-curve ramp tests.
+
+Usage: midi-load-hold.py SECONDS VOICES
+
+Sends note-on on channels 1..VOICES at start, holds with deterministic MPE
+modulation, then all-notes-off. No staggered retrigger — voice count is exact.
+"""
+import math
+import sys
+import time
+
+import rtmidi
+
+SECS = float(sys.argv[1]) if len(sys.argv) > 1 else 15.0
+VOICES = int(sys.argv[2]) if len(sys.argv) > 2 else 8
+if VOICES < 1 or VOICES > 15:
+    print(f"VOICES must be 1..15 (got {VOICES})", file=sys.stderr)
+    sys.exit(1)
+
+BASE_NOTE = 48
+CTRL_HZ = 50
+
+out = rtmidi.MidiOut()
+ports = out.get_ports()
+idx = next((i for i, p in enumerate(ports) if "Midi Through" in p), None)
+if idx is None:
+    print(f"no Surge MIDI port in {ports}", file=sys.stderr)
+    sys.exit(1)
+out.open_port(idx)
+print(f"midi-load-hold: -> {ports[idx]}  {VOICES} voices held, {SECS:.0f}s", flush=True)
+
+notes = [BASE_NOTE + (v * 2) % 24 for v in range(VOICES)]
+try:
+    for v in range(VOICES):
+        ch = v + 1
+        out.send_message([0x90 | ch, notes[v], 100])
+    t0 = time.monotonic()
+    while True:
+        el = time.monotonic() - t0
+        if el >= SECS:
+            break
+        for v in range(VOICES):
+            ch = v + 1
+            pres = int(64 + 60 * math.sin(el * 2.0 + v))
+            out.send_message([0xD0 | ch, max(0, min(127, pres))])
+            bend = int(8192 + 3000 * math.sin(el * 1.3 + v * 0.7))
+            out.send_message([0xE0 | ch, bend & 0x7F, (bend >> 7) & 0x7F])
+        time.sleep(1.0 / CTRL_HZ)
+finally:
+    for v in range(VOICES):
+        ch = v + 1
+        out.send_message([0x80 | ch, notes[v], 0])
+        out.send_message([0xB0 | ch, 123, 0])
+    out.close_port()
+    print("midi-load-hold: done", flush=True)

--- a/scripts/mpe-fill-poller.sh
+++ b/scripts/mpe-fill-poller.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Instrument 3 — ALSA playback fill telemetry (W1 / permanent harness).
+#
+# One persistent process; no per-sample subprocess forks. Logs raw pointers only;
+# convert to fill_frames / ms in summarize-fill-trace.sh.
+#
+# Usage:
+#   taskset -c 1 nice -n 19 ./scripts/mpe-fill-poller.sh STATUS_FILE LOG SECONDS
+#
+# Poll rate: 10 Hz (sleep 0.1). Pin/off-audio-core per PROMPT-W1-instrumented-window.md.
+
+set -euo pipefail
+
+STATUS_FILE="${1:?status file required}"
+LOG="${2:?log path required}"
+DURATION="${3:?duration seconds required}"
+
+if [ ! -r "$STATUS_FILE" ]; then
+    echo "mpe-fill-poller: unreadable $STATUS_FILE" >&2
+    exit 1
+fi
+
+: >"$LOG"
+printf 'FILL_POLL_START status=%s duration=%ss hz=10\n' "$STATUS_FILE" "$DURATION" >>"$LOG"
+
+end=$((SECONDS + DURATION))
+while [ "$SECONDS" -lt "$end" ]; do
+    ts="${EPOCHREALTIME:-$SECONDS}"
+    state=""
+    appl=""
+    hw=""
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            state:*)
+                state="${line#state:}"
+                state="${state#"${state%%[![:space:]]*}"}"
+                ;;
+            *appl_ptr*)
+                appl="${line##*:}"
+                appl="${appl#"${appl%%[![:space:]]*}"}"
+                ;;
+            *hw_ptr*)
+                hw="${line##*:}"
+                hw="${hw#"${hw%%[![:space:]]*}"}"
+                ;;
+        esac
+    done <"$STATUS_FILE"
+    printf '%s %s %s %s\n' "$ts" "$state" "$appl" "$hw" >>"$LOG"
+    sleep 0.1
+done
+
+printf 'FILL_POLL_END\n' >>"$LOG"

--- a/scripts/resolve-alsa-playback-status.sh
+++ b/scripts/resolve-alsa-playback-status.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Resolve live ALSA playback status path for the tier-selected JACK device.
+# Usage: ./scripts/resolve-alsa-playback-status.sh
+# Prints: CARD=N STATUS=/proc/asound/cardN/pcm0p/sub0/status
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+
+if ! DETECT="$("$SCRIPT_DIR/detect-jack-device.sh" 2>/dev/null)"; then
+    echo "ERROR: detect-jack-device failed" >&2
+    exit 1
+fi
+
+CARD="$(printf '%s\n' "$DETECT" | awk -F= '/^JACK_DEVICE=/{gsub(/hw:/,"",$2); print $2}')"
+if [ -z "$CARD" ]; then
+    echo "ERROR: could not parse JACK_DEVICE from detect output" >&2
+    exit 1
+fi
+
+STATUS="/proc/asound/card${CARD}/pcm0p/sub0/status"
+if [ ! -r "$STATUS" ]; then
+    echo "ERROR: status not readable: $STATUS (jackd may be down)" >&2
+    exit 1
+fi
+
+printf 'CARD=%s\n' "$CARD"
+printf 'STATUS=%s\n' "$STATUS"
+printf 'JACK_CARD_ID=%s\n' "$(printf '%s\n' "$DETECT" | awk -F= '/^JACK_CARD_ID=/{print $2}')"

--- a/scripts/summarize-fill-trace.sh
+++ b/scripts/summarize-fill-trace.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Post-process mpe-fill-poller.sh output — wrap-safe fill_frames and sanity check.
+#
+# Usage:
+#   ./scripts/summarize-fill-trace.sh FILL_LOG PERIOD NPERIODS
+#
+# Exits 1 if any fill_frames > period * nperiods (pointer arithmetic bug).
+
+set -euo pipefail
+
+LOG="${1:?fill log}"
+PERIOD="${2:?period frames}"
+NPERIODS="${3:?nperiods}"
+
+BUF=$((PERIOD * NPERIODS))
+
+awk -v buf="$BUF" '
+    /^FILL_POLL_/ { next }
+    NF >= 4 && $3 ~ /^[0-9]+$/ && $4 ~ /^[0-9]+$/ {
+        appl = $3 + 0
+        hw = $4 + 0
+        fill = (appl - hw) % buf
+        if (fill < 0) fill += buf
+        n++
+        s += fill
+        vals[n] = fill
+        if (n == 1 || fill < min) min = fill
+        if (n == 1 || fill > max) max = fill
+        if (fill > buf) {
+            bad++
+            if (bad <= 3) printf "SANITY_FAIL fill=%d > buf=%d appl=%d hw=%d\n", fill, buf, appl, hw > "/dev/stderr"
+        }
+    }
+    END {
+        if (n == 0) {
+            print "FILL_SUMMARY n=0 buf=" buf
+            exit 2
+        }
+        for (i = 1; i <= n; i++) {
+            for (j = i + 1; j <= n; j++) {
+                if (vals[i] > vals[j]) { t = vals[i]; vals[i] = vals[j]; vals[j] = t }
+            }
+        }
+        p50 = vals[int((n + 1) / 2)]
+        p1i = int(n * 0.01); if (p1i < 1) p1i = 1
+        p1 = vals[p1i]
+        p99i = int(n * 0.99); if (p99i < 1) p99i = 1; if (p99i > n) p99i = n
+        p99 = vals[p99i]
+        printf "FILL_SUMMARY n=%d buf=%d min=%d p1=%d p50=%d p99=%d max=%d mean=%.0f sanity_over_buf=%d\n", \
+            n, buf, min, p1, p50, p99, max, s / n, bad + 0
+        if (bad > 0) exit 1
+    }
+' "$LOG"


### PR DESCRIPTION
## Summary

Promote the Scarlett/compute-bound measurement arc from `docs/scarlett-findings` into `dev`: measurement doctrine, agent skills, W1/V/Plan-V/V7 harnesses, and the full findings chain (Steps 0–4 → W1 → Plan V → V7).

**No product/runtime behavior change on merge** — docs, harness scripts, and agent orientation only. Pi remains on shipping config until follow-up work lands separately.

### What lands

- **Measurement discipline:** `MEASUREMENT-DISCIPLINE.md`, `measurement-design` skill, AGENTS.md instrument/shortest-useful-version rules
- **Findings & verdicts:** W1 (graph overruns only), V1 (no fixed-ms term), V7 capacity curve (Crystals), V3 1024×2 latency win
- **Harness:** fill poller, jackd journal capture, `measure-w1-window`, `measure-dsp-sample`, `measure-capacity-ramp`, `midi-load-hold`, Plan V/V7 orchestrators
- **Plans/prompts:** evening plan amendments, Plan V, PROMPT-W1/V/V7, poly-governor design notes (document-only)

### Key measured outcomes (2026-08-21 Pi)

| result | implication |
|---|---|
| W1: zero ALSA underrun magnitudes; fill flat ~83% | xruns are **graph overruns**, not buffer drain |
| V1: silence cost scales with buffer, not flat ~1.1 ms | **no fixed per-callback constant** to chase |
| V2: Surge adds ~35 µs over empty graph | **single-client refactor dead** |
| V7 (Crystals): sustained clean **4 / 2 / 2** voices @ 1024/512/256 | replaces `MPE_POLY_CEILING=12` guess |
| V3: 1024×2 accepted | **42.7 ms** shipping latency candidate (same Surge deadline) |

### Merge note

~35 commits; branch was measurement-only. Independent work on `fix/ci-calibrate-midi-test` and `yolo/poly-governor-instrumentation` is **not** included.

## Test plan

- [ ] Review doc-only diff; no accidental runtime/unit changes intended
- [ ] After merge: `git checkout dev && git pull` on laptop + Pi when ready to use new harness paths
- [ ] Pi can stay on current branch until Mitch promotes; no soak required for this merge
