### PR TITLE
Fix C0 unittest failures on Pi

### DIFF
--- a/scripts/instrument-conformance.sh
+++ b/scripts/instrument-conformance.sh
@@ -12,18 +12,27 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")/.." && pwd)"
 START=$SECONDS
 MODE="${1:-all}"
+RUN_AS_USER="${MPE_PI_USER:-mitch}"
+
+_run_unittests() {
+    local py=python3
+    if [ -x "${ROOT}/.venv/bin/python" ]; then
+        py="${ROOT}/.venv/bin/python"
+    fi
+    # chmod-based write tests are meaningless as root (root bypasses 0555).
+    if [ "$(id -u)" -eq 0 ] && id "$RUN_AS_USER" >/dev/null 2>&1; then
+        sudo -u "$RUN_AS_USER" env MPE_MODULE_REPO="$ROOT" "$py" -m unittest \
+            tests.test_audio_engine tests.test_periodic_loop_lint -q
+    else
+        "$py" -m unittest tests.test_audio_engine tests.test_periodic_loop_lint -q
+    fi
+}
 
 run_offline() {
     echo "=== instrument-conformance OFFLINE $(date -Is) ==="
     bash "${ROOT}/tests/test_instrument_conformance_offline.sh"
     bash "${ROOT}/tests/test_meter_harness.sh"
-
-    if [ -x "${ROOT}/.venv/bin/python" ]; then
-        "${ROOT}/.venv/bin/python" -m unittest tests.test_audio_engine tests.test_periodic_loop_lint -q 2>/dev/null \
-            || python3 -m unittest tests.test_audio_engine tests.test_periodic_loop_lint -q
-    else
-        python3 -m unittest tests.test_audio_engine tests.test_periodic_loop_lint -q
-    fi
+    _run_unittests
 }
 
 run_live() {

--- a/scripts/measure-instrument-conformance-live.sh
+++ b/scripts/measure-instrument-conformance-live.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")/.." && pwd)"
 # shellcheck source=lib/paths.sh
 source "$ROOT/scripts/lib/paths.sh"
+# shellcheck source=lib/mpe-services.sh
+source "$ROOT/scripts/lib/mpe-services.sh"
 # shellcheck source=lib/audio-engine.sh
 source "$ROOT/scripts/lib/audio-engine.sh"
 # shellcheck source=lib/measurement-result.sh
@@ -28,6 +30,9 @@ if [ ! -r /run/mpe/meter.state ]; then
     echo "ERROR: measure-instrument-conformance-live: no /run/mpe/meter.state (not on Pi?)" >&2
     exit 1
 fi
+
+MPE_METER_STATE_FILE="/run/mpe/meter.state"
+export MPE_METER_STATE_FILE
 
 if ! mpe_meter_assert_live; then
     echo "ERROR: measure-instrument-conformance-live: meter not live" >&2

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -513,6 +513,23 @@ mpe_state_get "{state}" state
 class JackLspProbeTests(unittest.TestCase):
     """M4 — both probes treat missing jack_lsp as not-ready."""
 
+    @staticmethod
+    def _jack_lsp_env(tmp: str, *, bin_dir: Path | None = None) -> dict[str, str]:
+        env = _bash_env(tmp)
+        if bin_dir is not None:
+            env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+        else:
+            env["PATH"] = isolated_path_only(Path(tmp))
+        return env
+
+    @staticmethod
+    def _force_jack_lsp_fallback() -> str:
+        """Hermetic run dir has no meter.state; still force the jack_lsp path under test."""
+        return """
+_mpe_surge_on_graph_via_meter() { return 2; }
+export -f _mpe_surge_on_graph_via_meter
+"""
+
     def test_server_ready_fails_without_jack_lsp_even_if_jackd_running(self) -> None:
         body = f"""
 pgrep() {{ [ "$2" = jackd ] && return 0; return 1; }}
@@ -522,8 +539,7 @@ if mpe_jack_server_ready; then exit 9; fi
 echo ok
 """
         with tempfile.TemporaryDirectory() as tmp:
-            env = _bash_env()
-            env["PATH"] = isolated_path_only(Path(tmp))
+            env = self._jack_lsp_env(tmp)
             result = _run_bash_script(body, env=env)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "ok")
@@ -531,12 +547,12 @@ echo ok
     def test_surge_on_graph_fails_without_jack_lsp(self) -> None:
         body = f"""
 source {AUDIO_ENGINE_SH}
+{self._force_jack_lsp_fallback()}
 if mpe_surge_on_jack_graph; then exit 9; fi
 echo ok
 """
         with tempfile.TemporaryDirectory() as tmp:
-            env = _bash_env()
-            env["PATH"] = isolated_path_only(Path(tmp))
+            env = self._jack_lsp_env(tmp)
             result = _run_bash_script(body, env=env)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "ok")
@@ -554,6 +570,7 @@ echo ok
                     jack_stub.chmod(jack_stub.stat().st_mode | stat.S_IXUSR)
                     body = f"""
 source {AUDIO_ENGINE_SH}
+{self._force_jack_lsp_fallback()}
 pgrep() {{ [ "$1" = "-x" ] && [ "$2" = "jackd" ] && return 0; return 1; }}
 export -f pgrep
 timeout() {{ shift; "$@"; }}
@@ -561,7 +578,7 @@ export -f timeout
 export PATH="{bin_dir}:$PATH"
 if mpe_surge_on_jack_graph; then echo yes; else echo no; fi
 """
-                    result = _run_bash_script(body)
+                    result = _run_bash_script(body, env=self._jack_lsp_env(tmp, bin_dir=bin_dir))
                     self.assertEqual(result.returncode, 0, result.stderr)
                     self.assertEqual(result.stdout.strip(), "yes")
 
@@ -576,6 +593,7 @@ if mpe_surge_on_jack_graph; then echo yes; else echo no; fi
             jack_stub.chmod(jack_stub.stat().st_mode | stat.S_IXUSR)
             body = f"""
 source {AUDIO_ENGINE_SH}
+{self._force_jack_lsp_fallback()}
 pgrep() {{ [ "$1" = "-x" ] && [ "$2" = "jackd" ] && return 0; return 1; }}
 export -f pgrep
 timeout() {{ shift; "$@"; }}
@@ -584,7 +602,7 @@ export PATH="{bin_dir}:$PATH"
 if mpe_surge_on_jack_graph; then exit 9; fi
 echo ok
 """
-            result = _run_bash_script(body)
+            result = _run_bash_script(body, env=self._jack_lsp_env(tmp, bin_dir=bin_dir))
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip(), "ok")
 
@@ -606,6 +624,7 @@ printf 'surge-xt\n'
             jack_stub.chmod(jack_stub.stat().st_mode | stat.S_IXUSR)
             body = f"""
 source {AUDIO_ENGINE_SH}
+{self._force_jack_lsp_fallback()}
 pgrep() {{ [ "$1" = "-x" ] && [ "$2" = "jackd" ] && return 0; return 1; }}
 export -f pgrep
 timeout() {{ shift; "$@"; }}
@@ -614,7 +633,7 @@ export PATH="{bin_dir}:$PATH"
 if mpe_surge_on_jack_graph; then echo yes; else echo no; fi
 cat "{count_file}"
 """
-            result = _run_bash_script(body)
+            result = _run_bash_script(body, env=self._jack_lsp_env(tmp, bin_dir=bin_dir))
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip().splitlines()[0], "yes")
             self.assertEqual(result.stdout.strip().splitlines()[1], "1")
@@ -628,6 +647,7 @@ cat "{count_file}"
             jack_stub.chmod(jack_stub.stat().st_mode | stat.S_IXUSR)
             body = f"""
 source {AUDIO_ENGINE_SH}
+{self._force_jack_lsp_fallback()}
 pgrep() {{ [ "$1" = "-x" ] && [ "$2" = "jackd" ] && return 0; return 1; }}
 export -f pgrep
 timeout() {{ shift; "$@"; }}
@@ -636,7 +656,7 @@ export PATH="{bin_dir}:$PATH"
 if mpe_surge_on_jack_graph; then exit 9; fi
 echo ok
 """
-            result = _run_bash_script(body)
+            result = _run_bash_script(body, env=self._jack_lsp_env(tmp, bin_dir=bin_dir))
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip(), "ok")
 

--- a/tests/test_instrument_conformance_live.sh
+++ b/tests/test_instrument_conformance_live.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../scripts/lib/paths.sh
 source "${ROOT}/scripts/lib/paths.sh"
+# shellcheck source=../scripts/lib/mpe-services.sh
+source "${ROOT}/scripts/lib/mpe-services.sh"
 # shellcheck source=../scripts/lib/audio-engine.sh
 source "${ROOT}/scripts/lib/audio-engine.sh"
 
@@ -61,6 +63,7 @@ ok "negative: meter removed mid-cell halts"
 
 # --- 2a positive: live appliance meter (Pi only) ---
 REAL_METER="/run/mpe/meter.state"
+MPE_METER_STATE_FILE="$REAL_METER"
 if [ ! -r "$REAL_METER" ] || ! mpe_meter_assert_live 2>/dev/null; then
     echo "LIVE SKIP: no live meter at ${REAL_METER} — Pi positive controls run via measure-instrument-conformance-live.sh" >&2
     echo "test_instrument_conformance_live.sh: negative controls passed (Pi deferred)"


### PR DESCRIPTION
## Summary

Fixes Pi C0 offline gate failures (5 `test_audio_engine` tests):

1. **JackLspProbeTests** — use hermetic `MPE_RUN_DIR` (no live `/run/mpe/meter.state`) and force `_mpe_surge_on_graph_via_meter → 2` so jack_lsp stubs are exercised.
2. **instrument-conformance.sh** — run `test_audio_engine` as `MPE_PI_USER` when invoked via `sudo` (root bypasses chmod 0555 write tests).

## Test plan

- [x] Pi: `sudo ./scripts/instrument-conformance.sh --offline` → all unittest green
- [ ] Pi: full `./scripts/instrument-conformance.sh` (offline + live)