### PR TITLE
Fix C0 live DSP sampler (jack_cpu_load format + SIGKILL)

### DIFF
--- a/scripts/lib/measurement-result.sh
+++ b/scripts/lib/measurement-result.sh
@@ -83,12 +83,19 @@ _mpe_result_resolve_buffer() {
     mpe_result_buffer_from_tag "${MPE_R_tag-}"
 }
 
-# Median of jack_cpu_load samples in a capture file (same awk as measure-latency-run.sh).
+# Median of jack_cpu_load samples in a capture file.
+# Accepts formatted run rows (measure-latency-run) or raw "jack DSP load N.NNNNNN" lines.
 mpe_result_jack_cpu_load_median() {
     local run_file="$1"
     awk '
+        function take(v) {
+            if (v != "?" && v+0 > 0 && v+0 <= 200) { a[++n]=v+0 }
+        }
         /^[[:space:]]+[0-9]+/ {
-            v=$2; if (v != "?") { a[++n]=v+0 }
+            take($2)
+        }
+        /^jack DSP load / {
+            take($NF)
         }
         END {
             if (n==0) { exit 1 }

--- a/scripts/measure-instrument-conformance-live.sh
+++ b/scripts/measure-instrument-conformance-live.sh
@@ -113,7 +113,8 @@ _conformance_dsp_median_under_load() {
     _as_user stdbuf -oL jack_cpu_load >"$dsp_raw" 2>/dev/null &
     dsp_pid=$!
     sleep "$secs"
-    kill "$dsp_pid" 2>/dev/null || true
+    # jack_cpu_load ignores SIGTERM (see measure-latency-run _kill_jcl).
+    kill -9 "$dsp_pid" 2>/dev/null || true
     wait "$dsp_pid" 2>/dev/null || true
     kill "$load_pid" 2>/dev/null || true
     wait "$load_pid" 2>/dev/null || true

--- a/tests/test_instrument_conformance_offline.sh
+++ b/tests/test_instrument_conformance_offline.sh
@@ -153,4 +153,15 @@ if mpe_result_physics_assert 512 2>/dev/null; then
 fi
 ok "jitter_n numeric guard without EXPECT (S8)"
 
+# --- jack_cpu_load raw capture (Pi stdbuf path) ---
+tmp="$(mktemp)"
+printf '%s\n' \
+    'jack DSP load 9.729879' \
+    'jack DSP load 9.711891' \
+    'jack DSP load 9.640977' >"$tmp"
+med="$(mpe_result_jack_cpu_load_median "$tmp")"
+rm -f "$tmp"
+[ "$med" = "9.711891" ] || fail "raw jack_cpu_load median got ${med}"
+ok "jack_cpu_load median parses raw DSP load lines"
+
 echo "test_instrument_conformance_offline.sh: all checks passed"


### PR DESCRIPTION
## Summary
- `mpe_result_jack_cpu_load_median` now parses raw `jack DSP load N.NNNNNN` lines (Pi `stdbuf jack_cpu_load` output), not only formatted run rows
- Live conformance uses `kill -9` on `jack_cpu_load` (ignores SIGTERM)
- Offline test covers raw capture median

## Test plan
- [x] `bash tests/test_instrument_conformance_offline.sh`
- [ ] Pi: `sudo ./scripts/instrument-conformance.sh` → `SENTINEL conformance-pass`