### PR TITLE
Soak harness: aborted sentinel, stderr in log, loop marker

### DIFF
--- a/.claude/skills/measurement-design/SKILL.md
+++ b/.claude/skills/measurement-design/SKILL.md
@@ -269,3 +269,9 @@ Standing constraints to restate in every prompt:
 | a number that looks plausible, accepted because it looks plausible | plausibility is what all nine failures had in common |
 | "the instrument worked last week" | a new kernel/JACK/build changes this; conformance is per-session |
 | a result that violates arithmetic, explained rather than rejected | check the instrument **first**; V11's 1% DSP with 23 xruns was impossible, not interesting |
+
+---
+
+## After the session (labour evidence)
+
+Invoke **`sred-daily-capture`** (`.claude/skills/sred-daily-capture/SKILL.md`) and append to [`docs/SRED-DAILY-LOG.md`](../../docs/SRED-DAILY-LOG.md). Conditions before the run; labour after — same session, not Friday.

--- a/.claude/skills/sred-daily-capture/SKILL.md
+++ b/.claude/skills/sred-daily-capture/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: sred-daily-capture
+description: Append contemporaneous SR&ED labour evidence to docs/SRED-DAILY-LOG.md. Use at end of investigation sessions, after measurement runs, after instrument build/fix/retraction, when closing SR&ED-relevant PRs, or when Mitch says log SR&ED hours. Prevents G1-style backfill.
+---
+
+# SR&ED daily capture (MPE-Module)
+
+**Goal:** One append per **work session** so labour evidence exists when the claim is filed. G1 proved git timestamps and memory are not enough.
+
+**Canon:** [`docs/SRED-EVIDENCE-2026.md`](../../docs/SRED-EVIDENCE-2026.md) (phases §4, uncertainties) · [`docs/SRED-EFFORT-LOG.md`](../../docs/SRED-EFFORT-LOG.md) (reconstruction baseline only — do not append there).
+
+**Output file:** [`docs/SRED-DAILY-LOG.md`](../../docs/SRED-DAILY-LOG.md) — **append-only** table under `## Log`.
+
+---
+
+## When to run (mandatory triggers)
+
+Invoke this skill and append **before ending the agent session** when any of:
+
+1. **Pi measurement** finished or abandoned (soak, ladder, confirm cell, instrument conformance).
+2. **Instrument work** — built, fixed, audited, or retracted (categories 1–3 in effort log).
+3. **Investigation doc** landed in `docs/measurements/` (hypothesis → result → verdict).
+4. **SR&ED-relevant PR** opened or merged (latency, instruments, refuted line, not pure README/deploy).
+5. **Mitch states hours** or describes a session — capture verbatim ranges.
+6. **Cross-midnight push** — still one session row; note sleep gap and calendar split.
+
+**Do not wait for Friday.** Per-session is the habit (same cadence as recording measurement conditions).
+
+**Skip** when the session was **only** routine (G5): README polish, deploy scripts, touch UX with no investigation — unless Mitch says log it as routine.
+
+---
+
+## Before appending
+
+1. **Time:** MCP `get_current_time` with `America/Toronto` → `date` column (`YYYY-MM-DD`).
+2. **Phase:** Pick from §4 chronology in `SRED-EVIDENCE-2026.md`. If multiple, pick dominant or use `mixed (Ph.9+10)` in note.
+3. **Hours:** Mitch's words only — ranges OK (`3–4`, `~2`, `4–8 low confidence`). If unknown, ask one bounded question anchored to git ("commits 13:16–22:59 — full evening or ~4 h hands-on?"). If session ends without answer, use `?` and note *hours pending*.
+4. **Split columns** (optional but preferred when known):
+   - `meas` — running/measuring/monitoring Pi
+   - `instrument` — building or fixing probes/harnesses/parsers
+   - `review` — AI output review, retraction interpretation, doc write-up
+   - Sum is **not required** to equal `hands-on`; overlaps are normal.
+5. **Anchor:** commit hash, PR #, or `docs/measurements/foo.md` path.
+6. **G5:** `eligible` | `routine` | `admissibility-pending` | `mixed`.
+
+---
+
+## How to append
+
+**Preferred:** `scripts/sred-log-append.sh` (keeps table columns aligned).
+
+```bash
+scripts/sred-log-append.sh \
+  --date 2026-08-22 \
+  --session '16:40–18:06' \
+  --phase '11 V11 + C0' \
+  --hands-on '~1.5' \
+  --meas 0 --instrument 1 --review 0.5 \
+  --cat 1 \
+  --g5 eligible \
+  --anchor '6e98af0, docs/measurements/...' \
+  --note 'Peak meter blind graph fix; harness repair dominated.'
+```
+
+**Manual:** Add one row to the table in `docs/SRED-DAILY-LOG.md` under `## Log`. Do not edit prior rows.
+
+---
+
+## Row template
+
+| column | content |
+|---|---|
+| date | `YYYY-MM-DD` (Toronto) |
+| session | Wall-clock span `HH:MM–HH:MM` or `continues from prior day` |
+| phase (§4) | e.g. `9 V9/V10-b`, `instrumentation cat 3` |
+| hands-on | Mitch's range or `?` |
+| meas / instrument / review | Sub-hours if known; `-` if N/A |
+| cat | `1`, `2`, `3`, `1+2`, or `-` |
+| g5 | tag |
+| anchor | git / doc / PR |
+| note | One line; cross-midnight; unattended soak; retraction |
+
+---
+
+## Agent rules
+
+- **Never inflate.** An honest `?` beats a fabricated `6`.
+- **Never average ranges** Mitch gave (`4–8` stays `4–8`, not `6`).
+- **Commit timestamps ≠ session duration** — effort log standing caveat applies; daily log captures Mitch's hands-on estimate.
+- **Instrumentation fixes are SR&ED analysis** — tag cat 2 when a blind instrument was found; cat 3 when Rule −1 / C0 / mechanism work ships.
+- **Unattended soaks are normal** — log `meas: 0` (or monitoring %) and note mechanism 5 / header-only risk in `note`; not a lapse.
+- After append, mention in session handoff: *"SR&ED daily row added for &lt;date&gt;."*
+
+---
+
+## Mitch-only (agents ask, do not guess)
+
+- Hands-on hours for the session
+- Whether a block was `eligible` vs `routine` when mixed
+- Admissibility when unsure (use `admissibility-pending`)
+
+---
+
+## Related skills
+
+| skill | when |
+|---|---|
+| `measurement-design` | before Pi measurement (conditions) |
+| **`sred-daily-capture`** | after session (labour) |
+| G1 backfill | **historical only** — [`PROMPT-G1-effort-reconstruction.md`](../../docs/measurements/PROMPT-G1-effort-reconstruction.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # MPE-Module — agent orientation
 
-*Last updated: 2026-08-17 (America/Toronto)*
+*Last updated: 2026-08-22 (America/Toronto)*
 
 **Product:** Raspberry Pi MPE sound module (Surge XT headless + patch browser UI).
 
@@ -292,3 +292,20 @@ results.
 before the run), claim classes and minimum n, and the requirement that the harness stamp
 **actual** state into every result rather than intended state. Read it before designing a
 measurement.
+
+---
+
+## SR&ED daily labour capture (mandatory going forward)
+
+Historical labour through 2026-08-22 lives in [`docs/SRED-EFFORT-LOG.md`](docs/SRED-EFFORT-LOG.md) (G1 reconstruction). **Do not backfill that way again.**
+
+| when | do |
+|---|---|
+| End of investigation / measurement / instrument session | Invoke **`sred-daily-capture`** (`.claude/skills/sred-daily-capture/SKILL.md`) |
+| Append row | [`docs/SRED-DAILY-LOG.md`](docs/SRED-DAILY-LOG.md) via `scripts/sred-log-append.sh` |
+| Phase names | [`docs/SRED-EVIDENCE-2026.md`](docs/SRED-EVIDENCE-2026.md) §4 only |
+| Hours | Mitch's ranges only — never invent; use `?` if session ends without answer |
+
+**Log instrumentation work explicitly** (build / discover wrong / derive rule — see effort log §Instrumentation). Unattended soaks are normal; note monitoring fraction and mechanism references in the daily row.
+
+**Pair with `measurement-design`:** conditions before the Pi run; **labour after the session**.

--- a/docs/SRED-DAILY-LOG.md
+++ b/docs/SRED-DAILY-LOG.md
@@ -1,0 +1,31 @@
+# SR&ED daily log — contemporaneous labour capture
+
+**Not a timesheet for payroll.** Evidence of eligible investigation labour for whoever prepares the claim. **Not tax advice.**
+
+| doc | role |
+|---|---|
+| [`SRED-EVIDENCE-2026.md`](SRED-EVIDENCE-2026.md) | What was investigated (uncertainties, chronology §4) |
+| [`SRED-EFFORT-LOG.md`](SRED-EFFORT-LOG.md) | **Reconstruction** through 2026-08-22 (G1 backfill — do not duplicate here) |
+| **This file** | **Going forward:** append at end of each work session |
+
+**Agents:** invoke [`.claude/skills/sred-daily-capture/SKILL.md`](../.claude/skills/sred-daily-capture/SKILL.md) or run `scripts/sred-log-append.sh`. Use MCP time (`America/Toronto`) for dates. **Never invent hours** — ask Mitch or leave `?` with a note.
+
+**Phase names:** must match §4 in `SRED-EVIDENCE-2026.md` (do not invent new phases).
+
+**Instrumentation (when applicable):** cat **1** build · **2** discover wrong · **3** derive rule (Rule −1, C0, etc.) — see effort log §Instrumentation.
+
+**G5 tag:** `eligible` · `routine` · `admissibility-pending` · `mixed` (note split in text).
+
+**Cross-midnight sessions:** one row; put wall-clock span in `session` column; note calendar split in `note`.
+
+---
+
+## Log
+
+| date | session | phase (§4) | hands-on | meas | instrument | review | cat | g5 | anchor | note |
+|---|---|---|---:|---:|---:|---:|---|---|---|---|
+| 2026-08-22 | starting daily capture | — | — | — | — | — | — | — | [`SRED-EFFORT-LOG.md`](SRED-EFFORT-LOG.md) | **Backfill complete through today.** From next session onward, append here — do not rely on G1-style reconstruction. |
+| 2026-08-22 | 16:40–18:10 | SR&ED evidence (G1/G3) | ~1.5 | - | 0 | 1 | 3 | eligible | docs/SRED-DAILY-LOG.md, AGENTS.md, sred-daily-capture skill | Daily capture stack: skill, append script, AGENTS rule; G1 effort log closed; G3 archive committed. |
+---
+
+*Daily capture started: 2026-08-22 (America/Toronto)*

--- a/docs/SRED-EFFORT-LOG.md
+++ b/docs/SRED-EFFORT-LOG.md
@@ -172,9 +172,9 @@ Written on `docs/v9-review`; merged **`2b78339` 12:37**. Sits in **07:56–12:37
 
 ---
 
-## Ongoing capture (proposal)
+## Ongoing capture
 
-One dated line per work session: calendar date, phase, **measurement h**, **instrument-building h**, **review h**, one-line note. Same habit as recording measurement conditions. Prevents reconstructing G1 from memory again.
+**Implemented 2026-08-22.** Append per session to [`SRED-DAILY-LOG.md`](SRED-DAILY-LOG.md). Skill: [`.claude/skills/sred-daily-capture/SKILL.md`](../.claude/skills/sred-daily-capture/SKILL.md). CLI: `scripts/sred-log-append.sh`. See `AGENTS.md` §SR&ED daily labour capture.
 
 ---
 

--- a/docs/SRED-EVIDENCE-2026.md
+++ b/docs/SRED-EVIDENCE-2026.md
@@ -213,7 +213,9 @@ so it costs nothing the discipline does not already demand. **Start with V11.**
 | Methodology | `docs/measurements/MEASUREMENT-DISCIPLINE.md`, `AGENTS.md`, `measurement-design` skill | Rules 0–7, pre-registration, instrument audit |
 | Current thread and queue | `PROGRESS.md` | Goal, state, ordered queue, standing rules |
 | Measurement harnesses | 34 scripts in `scripts/` | Reproducible; conditions parameterised |
-| Raw run logs | On appliance (`~/*.log`), referenced by path in each doc | **See gap G3** |
+| Raw run logs | [`docs/measurements/raw-logs/`](measurements/raw-logs/MANIFEST.md) (G3 archive) + appliance | Manifest + SHA256SUMS in-repo |
+| **Daily labour (contemporaneous)** | [`docs/SRED-DAILY-LOG.md`](SRED-DAILY-LOG.md) | **From 2026-08-22 onward** — skill `sred-daily-capture` |
+| Reconstructed labour (G1) | [`docs/SRED-EFFORT-LOG.md`](SRED-EFFORT-LOG.md) | Through 2026-08-22 backfill only |
 | Chronology | Git history, ~770 commits, dated | Commit messages state the finding, not just the change |
 | Peer review | PRs #86, #88, #90–#95 | Review comments are contemporaneous critique |
 
@@ -223,9 +225,9 @@ so it costs nothing the discipline does not already demand. **Start with V11.**
 
 | # | gap | why it matters | effort |
 |---|---|---|---|
-| **G1** | **Person-hours are not recorded.** Git timestamps show *when* commits landed, not effort expended. Claims are computed from labour. | Highest-value gap | **In progress** — [`SRED-EFFORT-LOG.md`](SRED-EFFORT-LOG.md) (interactive reconstruction 2026-08-22). [`PROMPT-G1-effort-reconstruction.md`](measurements/PROMPT-G1-effort-reconstruction.md) |
+| **G1** | **Person-hours are not recorded.** Git timestamps show *when* commits landed, not effort expended. Claims are computed from labour. | Highest-value gap | **Backfill done** — [`SRED-EFFORT-LOG.md`](SRED-EFFORT-LOG.md). **Ongoing:** [`SRED-DAILY-LOG.md`](SRED-DAILY-LOG.md) + skill **`sred-daily-capture`** |
 | **G2** | **Prior-art searches are undocumented.** §5 is reconstructed after the fact, not contemporaneous. | Directly answers the reviewer's first question | Adopt the prompt paragraph going forward; §5 covers the past |
-| **G3** | **Raw logs live on the appliance**, referenced by path but not archived in-repo. An SD card failure destroys the underlying data behind every number. | Evidence durability, and this is an audio appliance whose SD card shares IRQ 41 with WiFi | [`PROMPT-G3-archive-raw-logs.md`](measurements/PROMPT-G3-archive-raw-logs.md) — **only when the Pi is idle** |
+| **G3** | **Raw logs live on the appliance**, referenced by path but not archived in-repo. An SD card failure destroys the underlying data behind every number. | Evidence durability, and this is an audio appliance whose SD card shares IRQ 41 with WiFi | **Archive done** — [`docs/measurements/raw-logs/`](measurements/raw-logs/MANIFEST.md) (627 files, MANIFEST + SHA256SUMS). Re-run [`PROMPT-G3`](measurements/PROMPT-G3-archive-raw-logs.md) after major measurement pushes when Pi idle. |
 | **G4** | **Uncertainties were never stated as such at the time.** They are inferred here from what the experiments tested. | Reviewers look for uncertainty stated up front | This document establishes them; carry the framing forward into new prompts |
 | **G5** | **No separation of eligible from routine work.** Packaging, docs, CLI ergonomics, and deploy tooling are interleaved in the same history. | Overclaiming weakens the whole submission | Tag or list the routine commits |
 

--- a/docs/measurements/README.md
+++ b/docs/measurements/README.md
@@ -53,8 +53,10 @@ Queued prompts: [`PROMPT-P7`](PROMPT-P7-overclock-diagnostic.md),
 [`HANDOVER-census-unison-fix`](HANDOVER-census-unison-fix.md).
 
 Evidence-record tasks (offline, not measurements): [`PROMPT-G1`](PROMPT-G1-effort-reconstruction.md)
-effort reconstruction, [`PROMPT-G3`](PROMPT-G3-archive-raw-logs.md) raw-log archival — both
-from [`SRED-EVIDENCE-2026.md`](../SRED-EVIDENCE-2026.md).
+effort reconstruction (historical — see [`SRED-EFFORT-LOG.md`](../SRED-EFFORT-LOG.md)),
+[`PROMPT-G3`](PROMPT-G3-archive-raw-logs.md) raw-log archival, and ongoing
+[`SRED-DAILY-LOG.md`](../SRED-DAILY-LOG.md) via skill `sred-daily-capture` — all from
+[`SRED-EVIDENCE-2026.md`](../SRED-EVIDENCE-2026.md).
 
 ## Archive
 

--- a/scripts/measure-soak-instrument.sh
+++ b/scripts/measure-soak-instrument.sh
@@ -52,6 +52,18 @@ PATCH_PATH="${QUICK_SELECT}/${PATCH_NAME}.fxp"
 
 _as_user() { sudo -u "$RUN_AS_USER" -- "$@"; }
 
+STAGE=init
+SOAK_COMPLETE=0
+
+_cleanup() {
+    local rc=$?
+    [ -n "${LOAD_PID:-}" ] && kill "$LOAD_PID" 2>/dev/null || true
+    if [ "${SOAK_COMPLETE:-0}" -eq 0 ] && [ -n "${OUTPUT:-}" ]; then
+        echo "SENTINEL soak-aborted stage=${STAGE:-unknown} rc=${rc}" >>"$OUTPUT" 2>/dev/null || true
+    fi
+}
+trap _cleanup EXIT INT TERM
+
 _set_env_var() {
     local key="$1" value="$2" tmp
     tmp="$(mktemp)"
@@ -65,11 +77,6 @@ _set_env_var() {
     rm -f "$tmp"
 }
 
-_cleanup() {
-    [ -n "$LOAD_PID" ] && kill "$LOAD_PID" 2>/dev/null || true
-}
-trap _cleanup EXIT INT TERM
-
 TOTAL_MIN=$((HOURS * 60))
 FINISH_EPOCH=$(( $(date +%s) + TOTAL_MIN * 60 ))
 FINISH_ISO="$(date -d "@${FINISH_EPOCH}" -Is 2>/dev/null || date -r "$FINISH_EPOCH" -Is 2>/dev/null || echo "in ${HOURS}h")"
@@ -79,6 +86,7 @@ echo "Started: $(date -Is)"
 echo "Expected finish: ${FINISH_ISO}"
 echo "Log: ${OUTPUT}"
 
+STAGE=header
 {
     echo
     echo "=== measure-soak-instrument buffer=${BUFFER} periods=${PERIODS} patch=${PATCH_NAME} voices=${VOICES} hours=${HOURS} $(date -Is) ==="
@@ -87,38 +95,54 @@ echo "Log: ${OUTPUT}"
     echo "expected_finish=${FINISH_ISO}"
 } >>"$OUTPUT"
 
+# Rule −1: stderr must land in the log — header-only silence is indistinguishable from "still warming up".
+exec 2> >(tee -a "$OUTPUT" >&2)
+
+STAGE=env-config
 _set_env_var MPE_POLY_GOVERNOR 0
 _set_env_var MPE_JACK_SOFTMODE 0
+STAGE=services-stop
 systemctl stop surge-poly-governor.service 2>/dev/null || true
 systemctl stop mpe-looper-session.service sl-watchdog.service mpe-sooperlooper.service 2>/dev/null || true
 
+STAGE=set-surge-audio
 if ! "$SCRIPT_DIR/set-surge-audio.sh" --buffer "$BUFFER" --periods "$PERIODS"; then
     echo "ERROR: set-surge-audio failed" >&2
     exit 1
 fi
 sleep 8
 
+STAGE=jack-restart
 systemctl restart mpe-jackd.service
 sleep 4
+STAGE=jack-wait
 mpe_wait_for_jack_server 30
+STAGE=surge-restart
 systemctl restart surge-xt-cli.service
 sleep 6
+STAGE=meter-start
 systemctl start mpe-peak-meter.service 2>/dev/null || true
 sleep 2
 
+STAGE=load-patch
 _as_user python3 "$SCRIPT_DIR/load-patch-osc.py" "$PATCH_PATH"
 sleep 1
 
+STAGE=start-hold-load
 SOAK_SEC=$((HOURS * 3600 + 120))
 _as_user python3 "$SCRIPT_DIR/midi-load-hold.py" "$SOAK_SEC" "$VOICES" \
     >"/tmp/instrument-soak-midi.log" 2>&1 &
 LOAD_PID=$!
 sleep 2
 
+STAGE=meter-baseline
 if ! START_XR="$(mpe_meter_xruns_read)"; then
     echo "ERROR: meter blind at soak start" >&2
     exit 1
 fi
+
+STAGE=soak-loop
+echo "SENTINEL soak-loop-entered" >>"$OUTPUT"
 
 hour=1
 minute=0
@@ -127,6 +151,7 @@ prev_xr="$START_XR"
 HOUR_START="$START_XR"
 
 while [ "$minute" -lt "$TOTAL_MIN" ]; do
+    STAGE=soak-loop-minute
     sleep 60
     minute=$((minute + 1))
     if ! cur="$(mpe_meter_xruns_read)"; then
@@ -137,6 +162,7 @@ while [ "$minute" -lt "$TOTAL_MIN" ]; do
         continue
     fi
     if [ "$cur" -lt "$prev_xr" ]; then
+        STAGE=soak-loop-meter-reset
         echo "ERROR: meter restarted mid-soak" >&2
         exit 1
     fi
@@ -160,6 +186,8 @@ while [ "$minute" -lt "$TOTAL_MIN" ]; do
 done
 
 FINAL=$((prev_xr - START_XR))
+STAGE=soak-complete
+SOAK_COMPLETE=1
 {
     echo "RESULT soak_hours=${HOURS} buffer=${BUFFER} periods=${PERIODS} patch=${PATCH_NAME} voices=${VOICES} xruns_total=${FINAL} invalid_windows=${invalid_windows}"
     echo "SENTINEL soak-complete"

--- a/scripts/sred-log-append.sh
+++ b/scripts/sred-log-append.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Append one row to docs/SRED-DAILY-LOG.md (SR&ED daily capture).
+# See .claude/skills/sred-daily-capture/SKILL.md
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG="$REPO_ROOT/docs/SRED-DAILY-LOG.md"
+MARKER='| date | session | phase (§4) | hands-on | meas | instrument | review | cat | g5 | anchor | note |'
+
+date= session= phase= hands_on= meas=- instrument=- review=- cat=- g5= anchor= note=
+
+usage() {
+  echo "Usage: scripts/sred-log-append.sh --date YYYY-MM-DD --session SPAN --phase PHASE --note TEXT"
+  echo "Optional: --hands-on --meas --instrument --review --cat --g5 --anchor"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date) date="$2"; shift 2 ;;
+    --session) session="$2"; shift 2 ;;
+    --phase) phase="$2"; shift 2 ;;
+    --hands-on) hands_on="$2"; shift 2 ;;
+    --meas) meas="$2"; shift 2 ;;
+    --instrument) instrument="$2"; shift 2 ;;
+    --review) review="$2"; shift 2 ;;
+    --cat) cat="$2"; shift 2 ;;
+    --g5) g5="$2"; shift 2 ;;
+    --anchor) anchor="$2"; shift 2 ;;
+    --note) note="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "Unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[[ -n "$date" && -n "$session" && -n "$phase" && -n "$note" ]] || usage
+[[ -f "$LOG" ]] || { echo "Missing $LOG" >&2; exit 1; }
+
+esc() { printf '%s' "$1" | tr '\n' ' ' | sed 's/|/\\|/g'; }
+session_e=$(esc "$session")
+phase_e=$(esc "$phase")
+hands_on_e=$(esc "${hands_on:-?}")
+note_e=$(esc "$note")
+anchor_e=$(esc "${anchor:--}")
+g5_e="${g5:-admissibility-pending}"
+
+row="| $date | $session_e | $phase_e | $hands_on_e | $meas | $instrument | $review | $cat | $g5_e | $anchor_e | $note_e |"
+
+tmp=$(mktemp)
+found_header=0
+inserted=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ "$inserted" -eq 0 && "$line" == "---" && "$found_header" -eq 1 ]]; then
+    printf '%s\n' "$row" >>"$tmp"
+    inserted=1
+  fi
+  if [[ "$line" == "$MARKER" ]]; then
+    found_header=1
+  fi
+  printf '%s\n' "$line" >>"$tmp"
+done <"$LOG"
+
+if [[ "$found_header" -eq 0 ]]; then
+  rm -f "$tmp"
+  echo "Could not find log table header in $LOG" >&2
+  exit 1
+fi
+if [[ "$inserted" -eq 0 ]]; then
+  rm -f "$tmp"
+  echo "Could not find log section footer (---) in $LOG" >&2
+  exit 1
+fi
+
+mv "$tmp" "$LOG"
+echo "Appended SR&ED daily row: $date $session_e"


### PR DESCRIPTION
## Summary
- `STAGE` tracked through setup; EXIT trap writes `SENTINEL soak-aborted stage=<X> rc=<n>` when `soak-complete` never lands
- stderr teed into `$OUTPUT` after `soak-start` (Rule −1 time dimension)
- `SENTINEL soak-loop-entered` before the minute loop

## Test plan
- [x] `bash -n scripts/measure-soak-instrument.sh`
- [ ] Pi: induce setup failure → log shows `soak-aborted` + ERROR lines
- [ ] Pi: successful short soak → `soak-loop-entered` then `soak-complete`, no `soak-aborted`