### PR TITLE
Fix reference suite TSV and probe preflight

### DIFF
--- a/scripts/lib/measurement-result.sh
+++ b/scripts/lib/measurement-result.sh
@@ -13,9 +13,12 @@ MPE_RESULT_STRICT="${MPE_RESULT_STRICT:-1}"
 #   512:  W1-b 512×3 — 62.4% (docs/measurements/w1-instrumented-window-2026-08-21.md)
 #   256:  W1-c 256×3 — 76.1% (docs/measurements/w1-instrumented-window-2026-08-21.md)
 # V11 idle/mistimed signatures (0.9%, 1.6%) sit far below these floors.
-readonly MPE_DSP_FLOOR_1024="7.6"
-readonly MPE_DSP_FLOOR_512="12.5"
-readonly MPE_DSP_FLOOR_256="15.2"
+if [ -z "${_MPE_MEASUREMENT_RESULT_SOURCED:-}" ]; then
+    readonly MPE_DSP_FLOOR_1024="7.6"
+    readonly MPE_DSP_FLOOR_512="12.5"
+    readonly MPE_DSP_FLOOR_256="15.2"
+    _MPE_MEASUREMENT_RESULT_SOURCED=1
+fi
 
 _mpe_result_die() {
     echo "ERROR: measurement-result: $*" >&2

--- a/scripts/measure-reference-suite.sh
+++ b/scripts/measure-reference-suite.sh
@@ -149,7 +149,7 @@ _parse_last_run() {
                 for (i = 1; i <= NF; i++) {
                     if ($i ~ /^xruns=/) xr = substr($i, 7)
                     if ($i ~ /^dsp_median=/) dm = substr($i, 12)
-                    if ($i ~ /^dsp_p99=/) dp = substr($i, 8)
+                    if ($i ~ /^dsp_p99=/) dp = substr($i, 9)
                     if ($i ~ /^dsp_max=/) dx = substr($i, 9)
                     if ($i ~ /^samples=/) sm = substr($i, 9)
                     if ($i ~ /^temp=/) tp = $i
@@ -199,7 +199,7 @@ _run_cell() {
 
     IFS=$'\t' read -r xr dsp_med dsp_p99 dsp_max samples temp thr < <(_parse_last_run "$log" "$relaxed")
 
-    printf '%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    printf '%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
         "$PLATFORM" "$PASS" "$cell_id" "${patch:-silence}" "$voices" "$buffer" "$periods" \
         "$xr" "$dsp_med" "$dsp_p99" "$dsp_max" "$samples" "$temp" "$thr" "$log" \
         >>"$TSV_OUT"
@@ -255,6 +255,11 @@ echo "artifacts=${ARTIFACT_DIR}"
 if [ "$RUN_CONFORMANCE" -eq 1 ]; then
     echo "=== C0 preflight (full gate) ==="
     "$SCRIPT_DIR/instrument-conformance.sh"
+fi
+
+if [ ! -x "${MPE_MODULE_REPO}/native/mpe-xrun-probe/mpe-xrun-probe" ]; then
+    echo "=== building mpe-xrun-probe ==="
+    "$SCRIPT_DIR/build-mpe-xrun-probe.sh" --required
 fi
 
 _set_env_var MPE_POLY_GOVERNOR 0


### PR DESCRIPTION
## Summary
- Fix `%d` → `%s` for patch column in TSV (silence is not numeric)
- Fix relaxed awk `substr` for `dsp_p99` / `dsp_max`
- Guard readonly floor constants on re-source
- Build `mpe-xrun-probe` at suite start

## Test plan
- [x] Pilot S1 on Pi after probe rebuild
- [ ] Full A2 pass 1 completes with JSON