### PR TITLE
MIDI connect + audio recovery toast UX; poly governor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Something broken on the Pi appliance or touch UI
+title: ''
+labels: bug
+assignees: ''
+type: Bug
+---
+
+**Describe the bug**
+What happened, in plain language. Include the patch or screen if it matters.
+
+**To Reproduce**
+Steps to reproduce:
+1. 
+2. 
+3. 
+
+**Expected behavior**
+What you expected instead.
+
+**Screenshots / video**
+For touch UI glitches, toasts, or layout issues — attach if you can.
+
+**Appliance**
+
+- [ ] Pi 4
+- [ ] Pi 5
+- [ ] Other (describe)
+- UI: [ ] Touch (Freenove DSI)  [ ] Encoder + OLED
+- Audio profile: [ ] Standalone (analog/USB DAC)  [ ] USB host  [ ] USB host session
+- MPE controller (if relevant): [e.g. Roli LUMI, Seaboard Block]
+- Buffer / rate (if you changed them): e.g. 128×2 @ 48 kHz
+
+**Diagnostics (optional but helps)**
+
+Paste output if you can SSH in:
+
+```bash
+mpe status          # or: systemctl status surge-xt-cli touch-patch-browser mpe-jackd
+mpe diagnose        # read-only snapshot
+journalctl -u surge-xt-cli -n 30 --no-pager
+journalctl -u touch-patch-browser -n 30 --no-pager
+cat /run/mpe/engine.state
+```
+
+Git commit on the Pi (`cd ~/MPE-Module && git log -1 --oneline`) if you know it.
+
+**Additional context**
+Power supply, recent config changes, hot-plug timing, anything else that might matter.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Full command reference: **[COMMANDS.md](COMMANDS.md)**
 
 | Doc                                                                  | For                                                  |
 | -------------------------------------------------------------------- | ---------------------------------------------------- |
+| [docs/POLY-GOVERNOR.md](docs/POLY-GOVERNOR.md)                       | Dynamic voice limit (poly governor) behaviour and env |
 | [docs/BUILD-FROM-ZERO.md](docs/BUILD-FROM-ZERO.md)                   | Full walkthrough: blank Pi → working module          |
 | [REFERENCE_BOM.md](REFERENCE_BOM.md)                                 | Building the hardware                                |
 | [docs/HARDWARE_WIRING.md](docs/HARDWARE_WIRING.md)                   | Wiring the OLED + encoder                            |
@@ -236,6 +237,13 @@ Full command reference: **[COMMANDS.md](COMMANDS.md)**
 | [docs/SURGE_CLI_HEADLESS_SETUP.md](docs/SURGE_CLI_HEADLESS_SETUP.md) | Full technical deep dive                             |
 | [docs/WHATS-NEW.md](docs/WHATS-NEW.md)                               | Recent feature updates, in plain English             |
 | [CHANGELOG.md](CHANGELOG.md)                                         | Full engineering log                                 |
+
+
+## Reporting bugs
+
+Something broken? Check **[FAQ.md](FAQ.md)** first — a lot of "bugs" are config or wiring gotchas with a known fix.
+
+If it's still wrong, [open a bug report](https://github.com/MitchSchwartz/MPE-Sound-Module/issues/new?template=bug_report.md). The template asks for Pi model, UI mode, audio profile, and repro steps so we can actually chase it.
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Every patch is fully editable and MPE-assignable from your computer, across all 
 - **Selectable audio buffer** — `MPE_JACK_BUFFER` / `MPE_JACK_PERIODS` (defaults 256 × 3), server-side under JACK, the only audio engine. Restarts the audio graph when changed
 - **Per-patch volume normalization** — calibrate once (strike + sustain anchors, peak-safe closed loop); every patch loads at a matched level. The same run sets **Touch** pressure floors for light vs full press on favorites.
 - **Reuse Single on load** — patches are rewritten at load so restrikes on the same key reuse the voice instead of stacking new ones (lighter CPU on dense patches)
-- **Dynamic voice limit** — a background governor watches CPU and steps Surge's poly limit down under sustained load, then recovers when headroom returns; Surge's built-in softkill handles voice stealing (no MIDI panic)
+- **Dynamic voice limit** — background governor (`surge-poly-governor.service`) tracks JACK deadline load and moves Surge's poly limit on a continuous curve under sustained playing, then recovers when headroom returns; Surge softkill handles voice stealing (no MIDI panic). See **[docs/POLY-GOVERNOR.md](docs/POLY-GOVERNOR.md)**.
 
 ### UI
 
@@ -77,7 +77,7 @@ Every patch is fully editable and MPE-assignable from your computer, across all 
 - **Per-patch mixer (touch)** — vertical faders on the patch detail pane: **Vol** (level), **Tail** (envelope length; **0** = patch-as-loaded), **Touch** (MPE pressure floor; **cal value** = default handle position on **−50…+50**). See **[docs/TOUCH_PATCH_BROWSER.md](docs/TOUCH_PATCH_BROWSER.md)** §Mixer faders.
 - **Theming** — light/dark base themes with custom accent colors
 - **CPU meter** — live engine headroom while playing
-- **Dynamic voice limit toggle (touch)** — System settings → turn CPU-aware poly limiting on or off (default on). No in-Surge output limiter — loudness headroom comes from per-patch normalization at calibration time; use host/USB gain staging if you need a safety ceiling live.
+- **Dynamic voice limit toggle (touch)** — System settings → turn poly limiting on or off (default on). v2 uses jack deadline load when `MPE_POLY_GOVERNOR_METER=jack`. Full behaviour: **[docs/POLY-GOVERNOR.md](docs/POLY-GOVERNOR.md)**.
 
 **Status:** 
 
@@ -179,14 +179,15 @@ Toggle **Norm.** on the patch detail pane to bypass normalization for one patch;
 
 ### Playback policy (Pi)
 
-On every patch load, **Reuse Single** is applied automatically (XML rewrite — not an OSC toggle). A static poly **ceiling** is applied via Surge OSC; the **dynamic voice limit** governor (`surge-poly-governor.service`) can step that limit down further when CPU stays high.
+On every patch load, **Reuse Single** is applied automatically (XML rewrite — not an OSC toggle). A static poly **ceiling** is applied via Surge OSC; the **dynamic voice limit** governor can lower and raise that limit under load.
 
 | Control | Where |
 | -------- | ----- |
-| Dynamic voice limit on/off | Touch UI → System settings |
-| Poly ceiling / floor / emergency | `/etc/mpe/mpe.env` — `MPE_POLY_CEILING` (12), `MPE_POLY_FLOOR` (4), `MPE_POLY_EMERGENCY` (3 at ≥90% CPU) |
+| Dynamic voice limit on/off | Touch UI → System settings → Audio… |
+| Mode, baseline, rest cap, ramp | `/etc/mpe/mpe.env` — see **[docs/POLY-GOVERNOR.md](docs/POLY-GOVERNOR.md)** and `config/mpe.env.example` |
+| Poly ceiling / floor / emergency | `MPE_POLY_CEILING`, `MPE_POLY_FLOOR`, `MPE_POLY_EMERGENCY` |
 | Disable Reuse Single | `MPE_REUSE_SINGLE=0` in `mpe.env` |
-| Disable governor entirely | `MPE_POLY_GOVERNOR=0` or turn off in touch settings |
+| Disable governor entirely | `MPE_POLY_GOVERNOR=0` or touch settings |
 
 Manual OSC smoke test: `python3 scripts/manual/test-poly-governor-osc.py`
 
@@ -249,6 +250,11 @@ The **3,192 bundled patches** are Surge XT's own stock library, not custom conte
 Optional **CC0 / permissive community packs** (drums and more) curated in the private [MPE-Library](https://github.com/MitchSchwartz/MPE-Library) assets repo — Italo Disco Drum Pack (CC0), ironcross32/Surge-XT-Patches (CC0-1.0), Phasor Space Vol. 1 (CC0), Hefxthoth collection (DWTFYWPL). See that repo's README §Third-party patch credits.
 
 Surge XT itself is licensed **GPL-3.0**. Sounds/patches you make or perform with it are yours to use freely, commercially or otherwise — see the [Surge XT license FAQ](https://github.com/surge-synthesizer/surge) for specifics. This repo's own code (Pi setup, wiring, UI, deploy scripts) is licensed separately below.
+
+MPE-Module drives Surge as a **separate process** over OSC, MIDI and JACK — it does not link
+Surge as a library or host it in-process. That arms-length boundary is what lets this repo
+carry a different license from Surge's GPL-3.0. Full component list, corresponding-source
+pointers, and distribution obligations: [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md).
 
 ## License
 

--- a/docs/POLY-GOVERNOR.md
+++ b/docs/POLY-GOVERNOR.md
@@ -1,0 +1,84 @@
+# Dynamic voice limit (poly governor)
+
+*Last updated: 2026-08-23 (America/Toronto)*
+
+Surge's polyphony ceiling is not fixed at boot. A background service (`surge-poly-governor.service`) watches real-time DSP load and moves Surge's voice limit up and down so dense playing stays inside JACK's deadline. Surge's built-in softkill (`uber_release`) steals voices when the limit bites — there is no MIDI panic.
+
+**Toggle:** Touch UI → System settings → **Sound → Audio…** → **Dynamic voice limit** (default on).  
+**Disable entirely:** turn off in settings, or `MPE_POLY_GOVERNOR=0` in `/etc/mpe/mpe.env`.
+
+---
+
+## What it measures (v2)
+
+With **`MPE_POLY_GOVERNOR_V2=1`** (default on current builds):
+
+| Meter | Source | Used when |
+|---|---|---|
+| **Jack deadline load** | `mpe-peak-meter` → `dsp_percent` in `/run/mpe/meter.state` | `MPE_POLY_GOVERNOR_METER=jack` (Pi 5 tune path) |
+| **Process CPU** | `/proc` sample for `surge-xt-cli` | Fallback / legacy threshold mode |
+
+The v2 controller prefers **jack deadline stress** — how close Surge is to missing its audio callback — not raw CPU percent alone. That matches what you hear as crackle vs a clean voice steal.
+
+---
+
+## Control modes
+
+Set in `/etc/mpe/mpe.env` via **`MPE_POLY_LIMIT_MODE`**:
+
+### `always_on` (Pi 5 ear tune)
+
+A **continuous curve** maps normalized jack load → voice limit between a rest top and **`MPE_POLY_FLOOR`**.
+
+| Knob | Role |
+|---|---|
+| `MPE_POLY_JACK_BASELINE` | Platform idle load (%); stress = meter − baseline |
+| `MPE_POLY_MIN_HEADROOM` | At zero stress, limit = ceiling − headroom (when rest cap off) |
+| `MPE_POLY_REST_CAP` | **Pre-engaged cap** — fixed rest limit from boot (experiment); overrides headroom when > 0 |
+| `MPE_POLY_LIMIT_HARD` | Load % where curve reaches floor |
+| `MPE_POLY_RAMP_APPLY` | While load is rising, OSC limit tracks the curve immediately (no deferral) |
+| `MPE_POLY_RISE_*` | Rate-of-rise bias — lead the curve on fast attacks |
+| `MPE_POLY_LIMIT_MAX_STEP_DOWN` / `MPE_POLY_LIMIT_STEP_INTERVAL_S` | Rate-limit OSC steps so steals are gradual |
+| `MPE_POLY_STEP_UP=0` | Hold engaged cap — no recovery bumps (pairs with rest cap experiment) |
+
+**Static bounds** (still applied on patch load): `MPE_POLY_CEILING`, `MPE_POLY_FLOOR`, emergency floor at very high load / xruns (`MPE_POLY_EMERGENCY`, `MPE_POLY_EMERGENCY_XRUN_ONLY`).
+
+### `progressive` (threshold-gated A/B)
+
+Separate soft/hard load thresholds; limit steps down in bands. See `MPE_POLY_LIMIT_SOFT_START` / `MPE_POLY_LIMIT_HARD` in `config/mpe.env.example`.
+
+---
+
+## Static vs dynamic limit
+
+On every patch load the browser:
+
+1. Rewrites the patch for **Reuse Single** (same-key restrikes reuse a voice).
+2. Sends Surge OSC **`/param/global/polyphony_limit`** to the configured **ceiling**.
+
+The governor then **lowers** that limit under load and **raises** it when headroom returns (unless `MPE_POLY_STEP_UP=0`). The CPU meter in the touch header reflects engine headroom; orange/red is semantic load, not “governor off.”
+
+---
+
+## Platform notes
+
+| Platform | Status |
+|---|---|
+| **Pi 4** | G2 recalibration closed 2026-08-23 — governor thresholds aligned to jack meter; see [`docs/measurements/PI4-CLOSEOUT-2026-08-23.md`](measurements/PI4-CLOSEOUT-2026-08-23.md) |
+| **Pi 5** | Ear tune **paused** — best tune 97/3/7 + ramp apply; step-attack crackle open; pre-engaged cap @ 48 under test. Cooler + 27 W PSU gate before promotion. See [`docs/measurements/poly-governor-v2-always-on-pi5-2026-08-23.md`](measurements/poly-governor-v2-always-on-pi5-2026-08-23.md) |
+
+Do not copy Pi 5 experimental env wholesale to Pi 4 player images until Gate B closes on stable hardware.
+
+---
+
+## Service and debugging
+
+```bash
+systemctl status surge-poly-governor
+journalctl -u surge-poly-governor -n 30 --no-pager
+cat /run/mpe/meter.state    # dsp_percent, xruns
+python3 scripts/manual/test-poly-governor-osc.py   # OSC smoke (laptop or Pi)
+```
+
+**Spec:** [`Documents/specs/poly-governor-v2-progressive-spec.md`](../Documents/specs/poly-governor-v2-progressive-spec.md)  
+**Env reference:** [`config/mpe.env.example`](../config/mpe.env.example) (search `MPE_POLY_`)

--- a/docs/TOUCH_PATCH_BROWSER.md
+++ b/docs/TOUCH_PATCH_BROWSER.md
@@ -273,7 +273,7 @@ Sections are grouped top-to-bottom:
   - **USB Audio** profile toggle (Analog vs USB host); header badge matches. Background switch with overlay — see **[USB-AUDIO-HOST.md](USB-AUDIO-HOST.md)**.
   - **Buffer** — preset picker (32–2048 samples) + approximate latency; restarts Surge ([#44](https://github.com/MitchSchwartz/MPE-Sound-Module/issues/44)).
   - **Sample rate** — **44.1 kHz / 48 kHz** picker; persists to `/etc/mpe/mpe.env` and restarts Surge (+ USB gadget when **usb-host**) ([#39](https://github.com/MitchSchwartz/MPE-Sound-Module/issues/39)).
-  - **Dynamic voice limit** — poly governor toggle.
+  - **Dynamic voice limit** — poly governor toggle. Reads jack deadline load in v2; see **[POLY-GOVERNOR.md](POLY-GOVERNOR.md)**.
   - **Patch normalization** — master toggle for all per-patch Norm controls.
   - **Calibrate missing patches** / **Force full re-calibration** — confirm modal → loader on DSI. See **[PATCH_NORMALIZATION.md](PATCH_NORMALIZATION.md)**.
 

--- a/patch_browser/audio_engine.py
+++ b/patch_browser/audio_engine.py
@@ -135,30 +135,34 @@ def audio_switch_progress_message(
                 f"Recovery paused — wait {COOLDOWN_SEC}s or replug DAC",
                 5.0,
             )
+        last_restart = _parse_epoch(reconcile.get("last_restart"))
+        restart_count = _parse_epoch(reconcile.get("restarts"))
+        if restart_count > 0 and last_restart > 0:
+            since = now_ts - last_restart
+            if since < COOLDOWN_SEC:
+                remaining = COOLDOWN_SEC - since
+                hint = f"Waiting to retry ({remaining}s)…"
+                toast = f"Recovery paused — {remaining}s until retry"
+                return hint, toast, min(float(remaining + 1), 8.0)
         return "Audio failed", "Audio failed — check connection", 4.0
 
-    last_restart = _parse_epoch(reconcile.get("last_restart"))
-    restart_count = _parse_epoch(reconcile.get("restarts"))
-    if restart_count > 0 and last_restart > 0:
-        since = now_ts - last_restart
-        if since < COOLDOWN_SEC:
-            remaining = COOLDOWN_SEC - since
-            hint = f"Waiting to retry ({remaining}s)…"
-            toast = f"Recovery paused — {remaining}s until retry"
-            return hint, toast, min(float(remaining + 1), 8.0)
+    if state == "recovering":
+        jack_started = _parse_epoch(jack.get("started"))
+        if jack_started > 0 and (now_ts - jack_started) < JACKD_SETTLE_SEC:
+            return "JACK server starting…", "Reconnecting audio…", 3.0
 
-    jack_started = _parse_epoch(jack.get("started"))
-    if jack_started > 0 and (now_ts - jack_started) < JACKD_SETTLE_SEC:
-        return "JACK server starting…", "Restarting audio engine…", 3.0
+        if reason == "promote-planned":
+            return "Reconnecting Surge…", "Reconnecting Surge…", 3.0
+        if reason in {"settings-change", "profile-change"}:
+            return "Restarting JACK server…", "Applying audio settings…", 3.0
+        if reason == "promote-timeout":
+            return "Surge reconnect slow — still trying…", "Still reconnecting Surge…", 3.0
+        if reason in {"jackd-starting", "jackd-down", "graph-restart"}:
+            return "Reconnecting audio…", "Reconnecting audio…", 3.0
 
-    if reason == "promote-planned":
-        return "Reconnecting Surge…", "Reconnecting Surge to JACK…", 3.0
-    if reason in {"settings-change", "profile-change"}:
-        return "Restarting JACK server…", "Applying audio settings…", 3.0
-    if reason == "promote-timeout":
-        return "Surge reconnect slow — still trying…", "Still reconnecting Surge…", 3.0
+        return "Reconnecting audio…", "Reconnecting audio…", 3.0
 
-    return "Restarting audio…", "Applying audio settings…", 3.0
+    return "Restarting audio…", "Reconnecting audio…", 3.0
 
 
 def read_engine_state(path: Path | None = None) -> dict[str, str]:

--- a/patch_browser/audio_engine.py
+++ b/patch_browser/audio_engine.py
@@ -175,18 +175,38 @@ def toast_loader_base(message: str | None) -> str | None:
     return base or None
 
 
-def recovery_loader_suppressed(engine: dict[str, str] | None) -> bool:
-    """True when engine.state says recovering but JACK + Surge meter still look healthy."""
+LOADER_DOT_WIDTH = 3
+
+
+def loader_dots_suffix(*, tick: int, width: int = LOADER_DOT_WIDTH) -> str:
+    """Fixed-width dot animation so centered toasts do not shift."""
+    if width <= 0:
+        return ""
+    count = (tick % width) + 1
+    return ("." * count) + (" " * (width - count))
+
+
+def recovery_loader_suppressed(
+    engine: dict[str, str] | None,
+    *,
+    toast_base: str | None = None,
+) -> bool:
+    """True when engine.state says recovering but the audio graph still looks healthy."""
     engine = engine or {}
     if engine.get("state") != "recovering":
         return False
-    reason = engine.get("reason") or ""
-    if reason not in {"promote-to-jack", "promote-planned", "promote-timeout"}:
+
+    jack_live = jack_reachable_via_meter()
+    if jack_live is not True:
         return False
-    if jack_reachable_via_meter() is not True:
-        return False
-    surge_wired = _meter_flag(read_meter_state(), "online")
-    return surge_wired is True
+
+    base = (toast_base or "").lower()
+    if "surge" in base:
+        surge_wired = _meter_flag(read_meter_state(), "online")
+        return surge_wired is True
+
+    # JACK is up — generic "Reconnecting audio" is a false positive (e.g. MIDI unplug).
+    return True
 
 
 def read_engine_state(path: Path | None = None) -> dict[str, str]:

--- a/patch_browser/audio_engine.py
+++ b/patch_browser/audio_engine.py
@@ -165,6 +165,30 @@ def audio_switch_progress_message(
     return "Restarting audio…", "Reconnecting audio…", 3.0
 
 
+def toast_loader_base(message: str | None) -> str | None:
+    """Strip trailing ellipsis for animated loader toasts."""
+    if not message:
+        return None
+    base = message.rstrip()
+    while base and base[-1] in "…. ":
+        base = base[:-1].rstrip()
+    return base or None
+
+
+def recovery_loader_suppressed(engine: dict[str, str] | None) -> bool:
+    """True when engine.state says recovering but JACK + Surge meter still look healthy."""
+    engine = engine or {}
+    if engine.get("state") != "recovering":
+        return False
+    reason = engine.get("reason") or ""
+    if reason not in {"promote-to-jack", "promote-planned", "promote-timeout"}:
+        return False
+    if jack_reachable_via_meter() is not True:
+        return False
+    surge_wired = _meter_flag(read_meter_state(), "online")
+    return surge_wired is True
+
+
 def read_engine_state(path: Path | None = None) -> dict[str, str]:
     """Parse ``engine.state``; tolerate missing, empty, or partially-written files."""
     target = path or ENGINE_STATE_FILE

--- a/patch_browser/audio_engine.py
+++ b/patch_browser/audio_engine.py
@@ -178,11 +178,16 @@ def toast_loader_base(message: str | None) -> str | None:
 LOADER_DOT_WIDTH = 3
 
 
-def loader_dots_suffix(*, tick: int, width: int = LOADER_DOT_WIDTH) -> str:
-    """Fixed-width dot animation so centered toasts do not shift."""
+def loader_dot_count(*, tick: int, width: int = LOADER_DOT_WIDTH) -> int:
+    """Dot count 1..width for loader animation."""
     if width <= 0:
-        return ""
-    count = (tick % width) + 1
+        return 0
+    return (tick % width) + 1
+
+
+def loader_dots_suffix(*, tick: int, width: int = LOADER_DOT_WIDTH) -> str:
+    """Deprecated — use loader_dot_count + fixed layout in draw."""
+    count = loader_dot_count(tick=tick, width=width)
     return ("." * count) + (" " * (width - count))
 
 
@@ -191,22 +196,14 @@ def recovery_loader_suppressed(
     *,
     toast_base: str | None = None,
 ) -> bool:
-    """True when engine.state says recovering but the audio graph still looks healthy."""
+    """True only when Surge is still on the JACK graph despite recovering state."""
     engine = engine or {}
     if engine.get("state") != "recovering":
         return False
-
-    jack_live = jack_reachable_via_meter()
-    if jack_live is not True:
+    if jack_reachable_via_meter() is not True:
         return False
-
-    base = (toast_base or "").lower()
-    if "surge" in base:
-        surge_wired = _meter_flag(read_meter_state(), "online")
-        return surge_wired is True
-
-    # JACK is up — generic "Reconnecting audio" is a false positive (e.g. MIDI unplug).
-    return True
+    surge_wired = _meter_flag(read_meter_state(), "online")
+    return surge_wired is True
 
 
 def read_engine_state(path: Path | None = None) -> dict[str, str]:

--- a/patch_browser/midi_connect_progress.py
+++ b/patch_browser/midi_connect_progress.py
@@ -1,0 +1,42 @@
+"""ROLI / MIDI keyboard hot-plug progress written by roli-connect-debounce.sh."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+CONNECT_STATE_PATH = Path(
+    os.environ.get("MPE_MIDI_CONNECT_STATE", "/run/mpe/midi-connect.state")
+)
+STALE_SECONDS = 30.0
+
+
+def _parse_since(text: str) -> float:
+    parts = text.split()
+    if len(parts) >= 2:
+        try:
+            return float(parts[1])
+        except ValueError:
+            pass
+    return CONNECT_STATE_PATH.stat().st_mtime
+
+
+def is_connecting() -> bool:
+    """True while udev debounce is wiring the pressure remapper to a new controller."""
+    if not CONNECT_STATE_PATH.is_file():
+        return False
+    try:
+        text = CONNECT_STATE_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return False
+    if not text.startswith("connecting"):
+        return False
+    since = _parse_since(text)
+    return (time.time() - since) < STALE_SECONDS
+
+
+def connecting_toast() -> str | None:
+    if is_connecting():
+        return "Connecting keyboard…"
+    return None

--- a/patch_browser/midi_connect_progress.py
+++ b/patch_browser/midi_connect_progress.py
@@ -37,6 +37,11 @@ def is_connecting() -> bool:
 
 
 def connecting_toast() -> str | None:
+    base = connecting_toast_base()
+    return f"{base}…" if base else None
+
+
+def connecting_toast_base() -> str | None:
     if is_connecting():
-        return "Connecting keyboard…"
+        return "Connecting keyboard"
     return None

--- a/patch_browser/midi_connect_progress.py
+++ b/patch_browser/midi_connect_progress.py
@@ -9,7 +9,14 @@ from pathlib import Path
 CONNECT_STATE_PATH = Path(
     os.environ.get("MPE_MIDI_CONNECT_STATE", "/run/mpe/midi-connect.state")
 )
+COOLDOWN_STATE_PATH = Path(
+    os.environ.get(
+        "MPE_MIDI_HOTPLUG_COOLDOWN",
+        str(CONNECT_STATE_PATH.parent / "midi-hotplug-cooldown"),
+    )
+)
 STALE_SECONDS = 30.0
+HOTPLUG_COOLDOWN_S = float(os.environ.get("MPE_MIDI_HOTPLUG_COOLDOWN_S", "20"))
 
 
 def _read_state_text() -> str | None:
@@ -21,21 +28,48 @@ def _read_state_text() -> str | None:
         return None
 
 
-def _parse_since(text: str) -> float:
+def _parse_since(text: str, *, path: Path) -> float:
     parts = text.split()
     if len(parts) >= 2:
         try:
             return float(parts[1])
         except ValueError:
             pass
-    return CONNECT_STATE_PATH.stat().st_mtime
+    return path.stat().st_mtime
 
 
 def _state_fresh(text: str, prefix: str) -> bool:
     if not text.startswith(prefix):
         return False
-    since = _parse_since(text)
+    since = _parse_since(text, path=CONNECT_STATE_PATH)
     return (time.time() - since) < STALE_SECONDS
+
+
+def _cooldown_age_s() -> float | None:
+    if not COOLDOWN_STATE_PATH.is_file():
+        return None
+    try:
+        raw = COOLDOWN_STATE_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    parts = raw.split()
+    if len(parts) >= 2:
+        try:
+            since = float(parts[1])
+        except ValueError:
+            since = COOLDOWN_STATE_PATH.stat().st_mtime
+    else:
+        try:
+            since = float(raw)
+        except ValueError:
+            since = COOLDOWN_STATE_PATH.stat().st_mtime
+    age = time.time() - since
+    return age if age >= 0 else None
+
+
+def hotplug_cooldown_active() -> bool:
+    age = _cooldown_age_s()
+    return age is not None and age < HOTPLUG_COOLDOWN_S
 
 
 def is_connecting() -> bool:
@@ -55,8 +89,8 @@ def is_disconnecting() -> bool:
 
 
 def blocks_audio_recovery_toast() -> bool:
-    """Only unplug debounce — connect may coincide with a real Surge promote."""
-    return is_disconnecting()
+    """MIDI hot-plug window — keyboard toast only, or silence on unplug."""
+    return is_connecting() or is_disconnecting() or hotplug_cooldown_active()
 
 
 def suppress_audio_recovery_toast() -> bool:

--- a/patch_browser/midi_connect_progress.py
+++ b/patch_browser/midi_connect_progress.py
@@ -55,8 +55,12 @@ def is_disconnecting() -> bool:
 
 
 def blocks_audio_recovery_toast() -> bool:
-    """MIDI hot-plug work must not surface audio-reconnect toasts."""
-    return is_connecting() or is_disconnecting()
+    """Only unplug debounce — connect may coincide with a real Surge promote."""
+    return is_disconnecting()
+
+
+def suppress_audio_recovery_toast() -> bool:
+    return blocks_audio_recovery_toast()
 
 
 def connecting_toast() -> str | None:

--- a/patch_browser/midi_connect_progress.py
+++ b/patch_browser/midi_connect_progress.py
@@ -89,8 +89,8 @@ def is_disconnecting() -> bool:
 
 
 def blocks_audio_recovery_toast() -> bool:
-    """MIDI hot-plug window — keyboard toast only, or silence on unplug."""
-    return is_connecting() or is_disconnecting() or hotplug_cooldown_active()
+    """Active MIDI phase only — cooldown is watchdog-only (see mpe_midi_hotplug_busy)."""
+    return is_connecting() or is_disconnecting()
 
 
 def suppress_audio_recovery_toast() -> bool:

--- a/patch_browser/midi_connect_progress.py
+++ b/patch_browser/midi_connect_progress.py
@@ -12,6 +12,15 @@ CONNECT_STATE_PATH = Path(
 STALE_SECONDS = 30.0
 
 
+def _read_state_text() -> str | None:
+    if not CONNECT_STATE_PATH.is_file():
+        return None
+    try:
+        return CONNECT_STATE_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
 def _parse_since(text: str) -> float:
     parts = text.split()
     if len(parts) >= 2:
@@ -22,18 +31,32 @@ def _parse_since(text: str) -> float:
     return CONNECT_STATE_PATH.stat().st_mtime
 
 
-def is_connecting() -> bool:
-    """True while udev debounce is wiring the pressure remapper to a new controller."""
-    if not CONNECT_STATE_PATH.is_file():
-        return False
-    try:
-        text = CONNECT_STATE_PATH.read_text(encoding="utf-8").strip()
-    except OSError:
-        return False
-    if not text.startswith("connecting"):
+def _state_fresh(text: str, prefix: str) -> bool:
+    if not text.startswith(prefix):
         return False
     since = _parse_since(text)
     return (time.time() - since) < STALE_SECONDS
+
+
+def is_connecting() -> bool:
+    """True while udev debounce is wiring the pressure remapper to a new controller."""
+    text = _read_state_text()
+    if not text:
+        return False
+    return _state_fresh(text, "connecting")
+
+
+def is_disconnecting() -> bool:
+    """True while udev debounce is restarting the remapper after unplug."""
+    text = _read_state_text()
+    if not text:
+        return False
+    return _state_fresh(text, "disconnecting")
+
+
+def blocks_audio_recovery_toast() -> bool:
+    """MIDI hot-plug work must not surface audio-reconnect toasts."""
+    return is_connecting() or is_disconnecting()
 
 
 def connecting_toast() -> str | None:

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -393,8 +393,10 @@ class TouchPatchBrowser(
         if "paused" in base.lower():
             self.toast_message = base
             return
-        phase = int(time.monotonic() * 2.5) % 4
-        self.toast_message = f"{base}{'.' * phase}"
+        from patch_browser.audio_engine import loader_dots_suffix
+
+        tick = int(time.monotonic() * 2.5)
+        self.toast_message = f"{base}{loader_dots_suffix(tick=tick)}"
 
     def _handle_screen_recorder_signals(self) -> None:
         if self._recorder_stop_requested:

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -191,6 +191,8 @@ class TouchPatchBrowser(
         self.brightness_percent = self.backlight.get_percent()
         self.toast_message = ""
         self.toast_until = 0.0
+        self._loader_toast_active = False
+        self._loader_toast_base = ""
         self.power_action: str | None = None
         self._pending_calibrate_mode: CalibrateMode = CalibrateMode.MISSING_ONLY
         self._slider_dragging = False
@@ -357,8 +359,43 @@ class TouchPatchBrowser(
     def _pressed(self, target_id: str) -> bool:
         return self._touch_press.is_pressed(target_id)
     def _toast(self, message: str, seconds: float = 2.0) -> None:
+        self._loader_toast_active = False
+        self._loader_toast_base = ""
         self.toast_message = message
         self.toast_until = time.time() + seconds
+
+    def _clear_toast(self) -> None:
+        self.toast_message = ""
+        self.toast_until = 0.0
+
+    def _start_loader_toast(self, base: str) -> None:
+        from patch_browser.audio_engine import toast_loader_base
+
+        normalized = toast_loader_base(base)
+        if not normalized:
+            return
+        self._loader_toast_base = normalized
+        self._loader_toast_active = True
+        self.toast_until = time.time() + 86400.0
+        self._tick_loader_toast()
+
+    def _stop_loader_toast(self) -> None:
+        if not self._loader_toast_active:
+            return
+        self._loader_toast_active = False
+        self._loader_toast_base = ""
+        self._clear_toast()
+
+    def _tick_loader_toast(self) -> None:
+        if not self._loader_toast_active:
+            return
+        base = self._loader_toast_base
+        if "paused" in base.lower():
+            self.toast_message = base
+            return
+        phase = int(time.monotonic() * 2.5) % 4
+        self.toast_message = f"{base}{'.' * phase}"
+
     def _handle_screen_recorder_signals(self) -> None:
         if self._recorder_stop_requested:
             self._recorder_stop_requested = False
@@ -416,6 +453,7 @@ class TouchPatchBrowser(
             self._poll_audio_profile_switch()
             self._poll_surge_audio_switch()
             self._poll_engine_recovery_toast()
+            self._tick_loader_toast()
             self._poll_midi_sync_switch()
             self._poll_wifi_work()
             self._handle_screen_recorder_signals()

--- a/patch_browser/touch_browser_app.py
+++ b/patch_browser/touch_browser_app.py
@@ -392,11 +392,9 @@ class TouchPatchBrowser(
         base = self._loader_toast_base
         if "paused" in base.lower():
             self.toast_message = base
-            return
-        from patch_browser.audio_engine import loader_dots_suffix
-
-        tick = int(time.monotonic() * 2.5)
-        self.toast_message = f"{base}{loader_dots_suffix(tick=tick)}"
+        else:
+            # Dots rendered in _draw_toast at fixed width — keep message stable.
+            self.toast_message = base
 
     def _handle_screen_recorder_signals(self) -> None:
         if self._recorder_stop_requested:

--- a/patch_browser/touch_browser_draw.py
+++ b/patch_browser/touch_browser_draw.py
@@ -1530,7 +1530,12 @@ class TouchBrowserDrawMixin:
             pressed=self._pressed("cal:start"),
         )
     def _draw_toast(self) -> None:
-        if time.time() > self.toast_until or not self.toast_message:
+        if time.time() > self.toast_until:
+            return
+        if getattr(self, "_loader_toast_active", False) and self._loader_toast_base:
+            self._draw_loader_toast()
+            return
+        if not self.toast_message:
             return
         max_w = min(560, self.width - 48)
         lines = wrap_text_lines(self.font_sm, self.toast_message, max_w, max_lines=3)
@@ -1550,3 +1555,32 @@ class TouchBrowserDrawMixin:
             self.theme.text,
             line_spacing=2,
         )
+
+    def _draw_loader_toast(self) -> None:
+        from patch_browser.audio_engine import LOADER_DOT_WIDTH, loader_dot_count
+
+        base = self._loader_toast_base
+        pad_x, pad_y = 16, 10
+        color = self.theme.text
+        if "paused" in base.lower():
+            base_surf = self.font_sm.render(base, True, color)
+            w = base_surf.get_width() + pad_x * 2
+            h = base_surf.get_height() + pad_y * 2
+            rect = pygame.Rect((self.width - w) // 2, self.height - 80, w, h)
+            pygame.draw.rect(self.screen, self.theme.surface_alt, rect, border_radius=10)
+            self.screen.blit(base_surf, (rect.x + pad_x, rect.y + pad_y))
+            return
+
+        tick = int(time.monotonic() * 2.5)
+        dot_count = loader_dot_count(tick=tick, width=LOADER_DOT_WIDTH)
+        layout_w = self.font_sm.size(f"{base}{'.' * LOADER_DOT_WIDTH}")[0]
+        base_surf = self.font_sm.render(base, True, color)
+        dots_surf = self.font_sm.render("." * dot_count, True, color)
+        w = layout_w + pad_x * 2
+        h = max(base_surf.get_height(), dots_surf.get_height()) + pad_y * 2
+        rect = pygame.Rect((self.width - w) // 2, self.height - 80, w, h)
+        pygame.draw.rect(self.screen, self.theme.surface_alt, rect, border_radius=10)
+        text_y = rect.y + pad_y
+        text_x = rect.x + pad_x
+        self.screen.blit(base_surf, (text_x, text_y))
+        self.screen.blit(dots_surf, (text_x + base_surf.get_width(), text_y))

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -323,11 +323,31 @@ class TouchBrowserPrefsMixin:
             self, "_audio_profile_switching", False
         ):
             return
+
+        from patch_browser.midi_connect_progress import connecting_toast
+
+        midi_toast = connecting_toast()
+        if midi_toast:
+            now = time.monotonic()
+            last_midi = getattr(self, "_last_midi_connect_toast_at", 0.0)
+            first_midi = not getattr(self, "_midi_connect_toast_active", False)
+            if first_midi or now - last_midi >= 2.0:
+                self._toast(midi_toast, 3.0)
+                self._last_midi_connect_toast_at = now
+                self._midi_connect_toast_active = True
+            return
+
+        self._midi_connect_toast_active = False
+
         monitor = getattr(self, "engine_monitor", None)
         if monitor is None:
             return
         snap = monitor.snapshot()
-        if snap.get("state") not in {"recovering", "failed"}:
+        state = snap.get("state") or ""
+        prev = getattr(self, "_last_engine_recovery_state", "ok")
+        self._last_engine_recovery_state = state
+
+        if state not in {"recovering", "failed"}:
             return
         from patch_browser.audio_engine import audio_switch_progress_message, read_jack_state, read_reconcile_state
 
@@ -339,7 +359,9 @@ class TouchBrowserPrefsMixin:
         if not toast:
             return
         now = time.monotonic()
-        if now - getattr(self, "_last_audio_switch_toast_at", 0.0) >= 2.0:
+        entered_recovery = prev not in {"recovering", "failed"}
+        last_toast = getattr(self, "_last_audio_switch_toast_at", 0.0)
+        if entered_recovery or now - last_toast >= 2.0:
             self._toast(toast, toast_sec)
             self._last_audio_switch_toast_at = now
 

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -333,8 +333,8 @@ class TouchBrowserPrefsMixin:
         snap = monitor.snapshot() if monitor is not None else {}
         state = snap.get("state") or ""
 
-        loader_base: str | None = connecting_toast_base()
-        if loader_base is None and not blocks_audio_recovery_toast() and state in {"recovering", "failed"}:
+        loader_base: str | None = None
+        if not blocks_audio_recovery_toast() and state in {"recovering", "failed"}:
             from patch_browser.audio_engine import (
                 audio_switch_progress_message,
                 read_jack_state,
@@ -348,9 +348,12 @@ class TouchBrowserPrefsMixin:
                 read_reconcile_state(),
                 jack=read_jack_state(),
             )
-            loader_base = toast_loader_base(toast)
-            if loader_base and recovery_loader_suppressed(snap, toast_base=loader_base):
-                loader_base = None
+            candidate = toast_loader_base(toast)
+            if candidate and not recovery_loader_suppressed(snap, toast_base=candidate):
+                loader_base = candidate
+
+        if loader_base is None:
+            loader_base = connecting_toast_base()
 
         if loader_base:
             self._start_loader_toast(loader_base)

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -327,6 +327,7 @@ class TouchBrowserPrefsMixin:
         from patch_browser.midi_connect_progress import (
             blocks_audio_recovery_toast,
             connecting_toast_base,
+            is_disconnecting,
         )
 
         monitor = getattr(self, "engine_monitor", None)
@@ -334,7 +335,11 @@ class TouchBrowserPrefsMixin:
         state = snap.get("state") or ""
 
         loader_base: str | None = None
-        if not blocks_audio_recovery_toast() and state in {"recovering", "failed"}:
+        if is_disconnecting():
+            loader_base = None
+        elif connecting_toast_base():
+            loader_base = connecting_toast_base()
+        elif not blocks_audio_recovery_toast() and state in {"recovering", "failed"}:
             from patch_browser.audio_engine import (
                 audio_switch_progress_message,
                 read_jack_state,
@@ -351,9 +356,6 @@ class TouchBrowserPrefsMixin:
             candidate = toast_loader_base(toast)
             if candidate and not recovery_loader_suppressed(snap, toast_base=candidate):
                 loader_base = candidate
-
-        if loader_base is None:
-            loader_base = connecting_toast_base()
 
         if loader_base:
             self._start_loader_toast(loader_base)

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -318,52 +318,43 @@ class TouchBrowserPrefsMixin:
                 self._last_audio_switch_toast_at = now
 
     def _poll_engine_recovery_toast(self) -> None:
-        """Surface unplanned recovery / cooldown while the user is not in a settings overlay."""
+        """Surface unplanned recovery with a loader toast; clear when idle."""
         if getattr(self, "_surge_audio_switching", False) or getattr(
             self, "_audio_profile_switching", False
         ):
             return
 
-        from patch_browser.midi_connect_progress import connecting_toast
-
-        midi_toast = connecting_toast()
-        if midi_toast:
-            now = time.monotonic()
-            last_midi = getattr(self, "_last_midi_connect_toast_at", 0.0)
-            first_midi = not getattr(self, "_midi_connect_toast_active", False)
-            if first_midi or now - last_midi >= 2.0:
-                self._toast(midi_toast, 3.0)
-                self._last_midi_connect_toast_at = now
-                self._midi_connect_toast_active = True
-            return
-
-        self._midi_connect_toast_active = False
+        from patch_browser.midi_connect_progress import connecting_toast_base
 
         monitor = getattr(self, "engine_monitor", None)
-        if monitor is None:
-            return
-        snap = monitor.snapshot()
+        snap = monitor.snapshot() if monitor is not None else {}
         state = snap.get("state") or ""
-        prev = getattr(self, "_last_engine_recovery_state", "ok")
+
+        loader_base: str | None = connecting_toast_base()
+        if loader_base is None and state in {"recovering", "failed"}:
+            from patch_browser.audio_engine import (
+                audio_switch_progress_message,
+                read_jack_state,
+                read_reconcile_state,
+                recovery_loader_suppressed,
+                toast_loader_base,
+            )
+
+            _, toast, _ = audio_switch_progress_message(
+                snap,
+                read_reconcile_state(),
+                jack=read_jack_state(),
+            )
+            loader_base = toast_loader_base(toast)
+            if loader_base and recovery_loader_suppressed(snap):
+                loader_base = None
+
+        if loader_base:
+            self._start_loader_toast(loader_base)
+        elif getattr(self, "_loader_toast_active", False):
+            self._stop_loader_toast()
+
         self._last_engine_recovery_state = state
-
-        if state not in {"recovering", "failed"}:
-            return
-        from patch_browser.audio_engine import audio_switch_progress_message, read_jack_state, read_reconcile_state
-
-        _, toast, toast_sec = audio_switch_progress_message(
-            snap,
-            read_reconcile_state(),
-            jack=read_jack_state(),
-        )
-        if not toast:
-            return
-        now = time.monotonic()
-        entered_recovery = prev not in {"recovering", "failed"}
-        last_toast = getattr(self, "_last_audio_switch_toast_at", 0.0)
-        if entered_recovery or now - last_toast >= 2.0:
-            self._toast(toast, toast_sec)
-            self._last_audio_switch_toast_at = now
 
     def _finish_audio_profile_switch(self, ok: bool, message: str) -> None:
         self._audio_profile_switching = False

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -324,14 +324,17 @@ class TouchBrowserPrefsMixin:
         ):
             return
 
-        from patch_browser.midi_connect_progress import connecting_toast_base
+        from patch_browser.midi_connect_progress import (
+            blocks_audio_recovery_toast,
+            connecting_toast_base,
+        )
 
         monitor = getattr(self, "engine_monitor", None)
         snap = monitor.snapshot() if monitor is not None else {}
         state = snap.get("state") or ""
 
         loader_base: str | None = connecting_toast_base()
-        if loader_base is None and state in {"recovering", "failed"}:
+        if loader_base is None and not blocks_audio_recovery_toast() and state in {"recovering", "failed"}:
             from patch_browser.audio_engine import (
                 audio_switch_progress_message,
                 read_jack_state,
@@ -346,7 +349,7 @@ class TouchBrowserPrefsMixin:
                 jack=read_jack_state(),
             )
             loader_base = toast_loader_base(toast)
-            if loader_base and recovery_loader_suppressed(snap):
+            if loader_base and recovery_loader_suppressed(snap, toast_base=loader_base):
                 loader_base = None
 
         if loader_base:

--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -510,6 +510,27 @@ mpe_planned_promote_flag_clear() {
     rm -f "$(mpe_planned_promote_flag_file)" 2>/dev/null || true
 }
 
+# ROLI udev debounce writes /run/mpe/midi-connect.state while remapper restarts.
+# Skip passive Surge reconcile — remapper-only work must not restart Surge.
+mpe_midi_hotplug_busy() {
+    local file="${MPE_MIDI_CONNECT_STATE:-$(mpe_run_dir)/midi-connect.state}"
+    local text since age
+    [ -f "$file" ] || return 1
+    text=$(head -1 "$file" 2>/dev/null) || return 1
+    case "$text" in
+        connecting*|disconnecting*) ;;
+        *) return 1 ;;
+    esac
+    since=${text#* }
+    case "$since" in
+        '' | *[!0-9]*)
+            since=$(stat -c %Y "$file" 2>/dev/null || echo 0)
+            ;;
+    esac
+    age=$((EPOCHSECONDS - since))
+    [ "$age" -ge 0 ] && [ "$age" -lt 30 ]
+}
+
 mpe_wait_for_surge_on_graph() {
     local timeout="${1:-30}"
     local waited=0

--- a/scripts/lib/audio-engine.sh
+++ b/scripts/lib/audio-engine.sh
@@ -511,10 +511,27 @@ mpe_planned_promote_flag_clear() {
 }
 
 # ROLI udev debounce writes /run/mpe/midi-connect.state while remapper restarts.
-# Skip passive Surge reconcile — remapper-only work must not restart Surge.
+# Skip passive Surge reconcile during hot-plug — remapper-only work must not restart Surge.
 mpe_midi_hotplug_busy() {
     local file="${MPE_MIDI_CONNECT_STATE:-$(mpe_run_dir)/midi-connect.state}"
-    local text since age
+    local cooldown="${MPE_MIDI_HOTPLUG_COOLDOWN:-$(mpe_run_dir)/midi-hotplug-cooldown}"
+    local text since age cooldown_s
+    cooldown_s="${MPE_MIDI_HOTPLUG_COOLDOWN_S:-20}"
+
+    if [ -f "$cooldown" ]; then
+        since=$(head -1 "$cooldown" 2>/dev/null)
+        since=${since#hotplug }
+        case "$since" in
+            '' | *[!0-9]*)
+                since=$(stat -c %Y "$cooldown" 2>/dev/null || echo 0)
+                ;;
+        esac
+        age=$((EPOCHSECONDS - since))
+        if [ "$age" -ge 0 ] && [ "$age" -lt "$cooldown_s" ]; then
+            return 0
+        fi
+    fi
+
     [ -f "$file" ] || return 1
     text=$(head -1 "$file" 2>/dev/null) || return 1
     case "$text" in

--- a/scripts/roli-connect-debounce.sh
+++ b/scripts/roli-connect-debounce.sh
@@ -10,9 +10,20 @@ LOCK_FILE="/tmp/roli-remap-restart.lock"
 MIN_RESTART_INTERVAL=8
 REMAP_SERVICE="mpe-pressure-remap.service"
 LOG_FILE="/tmp/roli-events.log"
+MIDI_CONNECT_STATE="${MPE_MIDI_CONNECT_STATE:-/run/mpe/midi-connect.state}"
 
 log() {
     echo "$(date): $1" >>"$LOG_FILE"
+}
+
+midi_connect_begin() {
+    mkdir -p "$(dirname "$MIDI_CONNECT_STATE")"
+    echo "connecting $(date +%s)" >"$MIDI_CONNECT_STATE"
+    chmod 644 "$MIDI_CONNECT_STATE" 2>/dev/null || true
+}
+
+midi_connect_clear() {
+    rm -f "$MIDI_CONNECT_STATE"
 }
 
 check_recent_restart() {
@@ -73,15 +84,19 @@ restart_remapper() {
 case "$ACTION" in
     add)
         log "ROLI controller connected — waiting for USB stability"
+        midi_connect_begin
         if ! wait_for_stability; then
             log "ROLI not stable after wait — skipping remapper restart"
+            midi_connect_clear
             exit 0
         fi
         if remap_input_connected; then
             log "Remapper already connected to ROLI ALSA port — skipping restart"
+            midi_connect_clear
             exit 0
         fi
         restart_remapper
+        midi_connect_clear
         ;;
     remove)
         log "ROLI controller disconnected"

--- a/scripts/roli-connect-debounce.sh
+++ b/scripts/roli-connect-debounce.sh
@@ -17,8 +17,9 @@ log() {
 }
 
 midi_connect_begin() {
+    local phase="${1:-connecting}"
     mkdir -p "$(dirname "$MIDI_CONNECT_STATE")"
-    echo "connecting $(date +%s)" >"$MIDI_CONNECT_STATE"
+    echo "$phase $(date +%s)" >"$MIDI_CONNECT_STATE"
     chmod 644 "$MIDI_CONNECT_STATE" 2>/dev/null || true
 }
 
@@ -100,7 +101,9 @@ case "$ACTION" in
         ;;
     remove)
         log "ROLI controller disconnected"
+        midi_connect_begin disconnecting
         restart_remapper
+        midi_connect_clear
         ;;
     *)
         echo "Usage: $0 add|remove" >&2

--- a/scripts/roli-connect-debounce.sh
+++ b/scripts/roli-connect-debounce.sh
@@ -11,6 +11,9 @@ MIN_RESTART_INTERVAL=8
 REMAP_SERVICE="mpe-pressure-remap.service"
 LOG_FILE="/tmp/roli-events.log"
 MIDI_CONNECT_STATE="${MPE_MIDI_CONNECT_STATE:-/run/mpe/midi-connect.state}"
+MIDI_HOTPLUG_COOLDOWN="${MPE_MIDI_HOTPLUG_COOLDOWN:-/run/mpe/midi-hotplug-cooldown}"
+CONNECT_UI_MIN_S="${MPE_MIDI_CONNECT_UI_MIN_S:-3}"
+DISCONNECT_UI_MIN_S="${MPE_MIDI_DISCONNECT_UI_MIN_S:-12}"
 
 log() {
     echo "$(date): $1" >>"$LOG_FILE"
@@ -23,7 +26,23 @@ midi_connect_begin() {
     chmod 644 "$MIDI_CONNECT_STATE" 2>/dev/null || true
 }
 
-midi_connect_clear() {
+midi_hotplug_cooldown_mark() {
+    mkdir -p "$(dirname "$MIDI_HOTPLUG_COOLDOWN")"
+    echo "hotplug $(date +%s)" >"$MIDI_HOTPLUG_COOLDOWN"
+    chmod 644 "$MIDI_HOTPLUG_COOLDOWN" 2>/dev/null || true
+}
+
+hold_connect_ui_then_clear() {
+    local started=$1
+    local elapsed=$(( $(date +%s) - started ))
+    if [ "$elapsed" -lt "$CONNECT_UI_MIN_S" ]; then
+        sleep $((CONNECT_UI_MIN_S - elapsed))
+    fi
+    rm -f "$MIDI_CONNECT_STATE"
+}
+
+hold_disconnect_ui_then_clear() {
+    sleep "$DISCONNECT_UI_MIN_S"
     rm -f "$MIDI_CONNECT_STATE"
 }
 
@@ -85,25 +104,27 @@ restart_remapper() {
 case "$ACTION" in
     add)
         log "ROLI controller connected — waiting for USB stability"
-        midi_connect_begin
+        ui_started=$(date +%s)
+        midi_connect_begin connecting
+        midi_hotplug_cooldown_mark
         if ! wait_for_stability; then
             log "ROLI not stable after wait — skipping remapper restart"
-            midi_connect_clear
+            hold_connect_ui_then_clear "$ui_started"
             exit 0
         fi
         if remap_input_connected; then
             log "Remapper already connected to ROLI ALSA port — skipping restart"
-            midi_connect_clear
-            exit 0
+        else
+            restart_remapper
         fi
-        restart_remapper
-        midi_connect_clear
+        hold_connect_ui_then_clear "$ui_started"
         ;;
     remove)
         log "ROLI controller disconnected"
         midi_connect_begin disconnecting
+        midi_hotplug_cooldown_mark
         restart_remapper
-        midi_connect_clear
+        hold_disconnect_ui_then_clear &
         ;;
     *)
         echo "Usage: $0 add|remove" >&2

--- a/scripts/roli-connect-debounce.sh
+++ b/scripts/roli-connect-debounce.sh
@@ -13,7 +13,7 @@ LOG_FILE="/tmp/roli-events.log"
 MIDI_CONNECT_STATE="${MPE_MIDI_CONNECT_STATE:-/run/mpe/midi-connect.state}"
 MIDI_HOTPLUG_COOLDOWN="${MPE_MIDI_HOTPLUG_COOLDOWN:-/run/mpe/midi-hotplug-cooldown}"
 CONNECT_UI_MIN_S="${MPE_MIDI_CONNECT_UI_MIN_S:-3}"
-DISCONNECT_UI_MIN_S="${MPE_MIDI_DISCONNECT_UI_MIN_S:-12}"
+DISCONNECT_UI_MIN_S="${MPE_MIDI_DISCONNECT_UI_MIN_S:-5}"
 
 log() {
     echo "$(date): $1" >>"$LOG_FILE"
@@ -124,7 +124,7 @@ case "$ACTION" in
         midi_connect_begin disconnecting
         midi_hotplug_cooldown_mark
         restart_remapper
-        hold_disconnect_ui_then_clear &
+        hold_disconnect_ui_then_clear
         ;;
     *)
         echo "Usage: $0 add|remove" >&2

--- a/scripts/surge-watchdog.sh
+++ b/scripts/surge-watchdog.sh
@@ -71,6 +71,10 @@ _reconcile_engine() {
         return 0
     fi
 
+    if mpe_midi_hotplug_busy; then
+        return 0
+    fi
+
     # Steady state: unit active and engine already ok — skip jack_lsp if a full
     # graph probe ran recently. Unbounded skip is indistinguishable from stopping
     # to look (orphaned JACK client, DECISIONS.md 2026-08-15).

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -203,9 +203,9 @@ mpe_engine_stuck_failed_decision 1000 0 0 15 ok 1 1 1
     def test_decision_wait_then_sweep(self) -> None:
         body = f"""
 source {AUDIO_ENGINE_SH}
-mpe_engine_stuck_failed_decision 1000 900 0 15 failed 1 1 1
+mpe_engine_stuck_failed_decision 1000 0 0 15 failed 1 1 1
 printf '\\n'
-mpe_engine_stuck_failed_decision 1020 900 0 15 failed 1 1 1
+mpe_engine_stuck_failed_decision 1020 1000 0 15 failed 1 1 1
 """
         result = _run_bash_script(body, env=_bash_env())
         lines = result.stdout.strip().splitlines()

--- a/tests/test_audio_switch_progress.py
+++ b/tests/test_audio_switch_progress.py
@@ -62,6 +62,15 @@ class AudioSwitchProgressTests(unittest.TestCase):
         self.assertEqual(toast_loader_base("Reconnecting audio…"), "Reconnecting audio")
         self.assertEqual(toast_loader_base("Connecting keyboard..."), "Connecting keyboard")
 
+    def test_loader_dots_suffix_fixed_width(self) -> None:
+        from patch_browser.audio_engine import loader_dots_suffix
+
+        self.assertEqual(len(loader_dots_suffix(tick=0)), 3)
+        self.assertEqual(len(loader_dots_suffix(tick=1)), 3)
+        self.assertEqual(len(loader_dots_suffix(tick=2)), 3)
+        self.assertEqual(loader_dots_suffix(tick=0), ".  ")
+        self.assertEqual(loader_dots_suffix(tick=2), "...")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audio_switch_progress.py
+++ b/tests/test_audio_switch_progress.py
@@ -62,14 +62,13 @@ class AudioSwitchProgressTests(unittest.TestCase):
         self.assertEqual(toast_loader_base("Reconnecting audio…"), "Reconnecting audio")
         self.assertEqual(toast_loader_base("Connecting keyboard..."), "Connecting keyboard")
 
-    def test_loader_dots_suffix_fixed_width(self) -> None:
-        from patch_browser.audio_engine import loader_dots_suffix
+    def test_loader_dot_count_cycles(self) -> None:
+        from patch_browser.audio_engine import LOADER_DOT_WIDTH, loader_dot_count
 
-        self.assertEqual(len(loader_dots_suffix(tick=0)), 3)
-        self.assertEqual(len(loader_dots_suffix(tick=1)), 3)
-        self.assertEqual(len(loader_dots_suffix(tick=2)), 3)
-        self.assertEqual(loader_dots_suffix(tick=0), ".  ")
-        self.assertEqual(loader_dots_suffix(tick=2), "...")
+        self.assertEqual(loader_dot_count(tick=0), 1)
+        self.assertEqual(loader_dot_count(tick=2), 3)
+        self.assertEqual(loader_dot_count(tick=3), 1)
+        self.assertEqual(loader_dot_count(tick=0, width=LOADER_DOT_WIDTH), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_audio_switch_progress.py
+++ b/tests/test_audio_switch_progress.py
@@ -56,6 +56,12 @@ class AudioSwitchProgressTests(unittest.TestCase):
         self.assertIn(f"{remaining}s", hint)
         self.assertIn("paused", (toast or "").lower())
 
+    def test_toast_loader_base_strips_ellipsis(self) -> None:
+        from patch_browser.audio_engine import toast_loader_base
+
+        self.assertEqual(toast_loader_base("Reconnecting audio…"), "Reconnecting audio")
+        self.assertEqual(toast_loader_base("Connecting keyboard..."), "Connecting keyboard")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audio_switch_progress.py
+++ b/tests/test_audio_switch_progress.py
@@ -17,17 +17,17 @@ class AudioSwitchProgressTests(unittest.TestCase):
         self.assertEqual(toast, "Audio ready")
         self.assertEqual(sec, 2.0)
 
-    def test_cooldown_shows_remaining_seconds(self) -> None:
+    def test_recovering_during_cooldown_shows_reconnecting_not_paused(self) -> None:
         now = 1000
         hint, toast, sec = audio_switch_progress_message(
             {"state": "recovering", "active": "jack", "reason": "promote-to-jack"},
             {"last_restart": str(now - 12), "restarts": "1"},
             now=now,
         )
-        remaining = COOLDOWN_SEC - 12
-        self.assertIn(f"{remaining}s", hint)
-        self.assertIn(f"{remaining}s", toast or "")
-        self.assertEqual(sec, 8.0)
+        self.assertIn("Reconnect", hint)
+        self.assertIn("Reconnect", toast or "")
+        self.assertNotIn("paused", (toast or "").lower())
+        self.assertEqual(sec, 3.0)
 
     def test_settings_change_hint(self) -> None:
         hint, toast, _ = audio_switch_progress_message(
@@ -44,6 +44,17 @@ class AudioSwitchProgressTests(unittest.TestCase):
         )
         self.assertIn("paused", hint.lower())
         self.assertIn(str(COOLDOWN_SEC), toast or "")
+
+    def test_failed_in_cooldown_shows_retry_wait(self) -> None:
+        now = 1000
+        hint, toast, _ = audio_switch_progress_message(
+            {"state": "failed", "reason": "surge-failed"},
+            {"last_restart": str(now - 12), "restarts": "2"},
+            now=now,
+        )
+        remaining = COOLDOWN_SEC - 12
+        self.assertIn(f"{remaining}s", hint)
+        self.assertIn("paused", (toast or "").lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_midi_connect_progress.py
+++ b/tests/test_midi_connect_progress.py
@@ -1,0 +1,34 @@
+"""Tests for ROLI hot-plug connecting state."""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest import mock
+
+from patch_browser import midi_connect_progress
+
+
+class MidiConnectProgressTests(unittest.TestCase):
+    def test_not_connecting_when_file_missing(self) -> None:
+        with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
+            path.is_file.return_value = False
+            self.assertFalse(midi_connect_progress.is_connecting())
+            self.assertIsNone(midi_connect_progress.connecting_toast())
+
+    def test_connecting_when_file_fresh(self) -> None:
+        with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
+            path.is_file.return_value = True
+            path.read_text.return_value = f"connecting {int(time.time())}\n"
+            self.assertTrue(midi_connect_progress.is_connecting())
+            self.assertEqual(midi_connect_progress.connecting_toast(), "Connecting keyboard…")
+
+    def test_stale_connecting_ignored(self) -> None:
+        with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
+            path.is_file.return_value = True
+            path.read_text.return_value = "connecting 1\n"
+            self.assertFalse(midi_connect_progress.is_connecting())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_midi_connect_progress.py
+++ b/tests/test_midi_connect_progress.py
@@ -20,6 +20,7 @@ class MidiConnectProgressTests(unittest.TestCase):
         with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
             path.is_file.return_value = True
             path.read_text.return_value = f"connecting {int(time.time())}\n"
+            path.stat.return_value.st_mtime = time.time()
             self.assertTrue(midi_connect_progress.is_connecting())
             self.assertEqual(midi_connect_progress.connecting_toast_base(), "Connecting keyboard")
             self.assertEqual(midi_connect_progress.connecting_toast(), "Connecting keyboard…")
@@ -34,16 +35,29 @@ class MidiConnectProgressTests(unittest.TestCase):
         with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
             path.is_file.return_value = True
             path.read_text.return_value = f"disconnecting {int(time.time())}\n"
+            path.stat.return_value.st_mtime = time.time()
             self.assertTrue(midi_connect_progress.is_disconnecting())
             self.assertTrue(midi_connect_progress.blocks_audio_recovery_toast())
             self.assertIsNone(midi_connect_progress.connecting_toast_base())
 
-    def test_connecting_does_not_block_audio_toast(self) -> None:
+    def test_connecting_blocks_audio_but_shows_keyboard(self) -> None:
         with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
             path.is_file.return_value = True
             path.read_text.return_value = f"connecting {int(time.time())}\n"
+            path.stat.return_value.st_mtime = time.time()
             self.assertTrue(midi_connect_progress.is_connecting())
-            self.assertFalse(midi_connect_progress.blocks_audio_recovery_toast())
+            self.assertTrue(midi_connect_progress.blocks_audio_recovery_toast())
+            self.assertEqual(midi_connect_progress.connecting_toast_base(), "Connecting keyboard")
+
+    def test_hotplug_cooldown_blocks_audio_toast(self) -> None:
+        with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
+            path.is_file.return_value = False
+            with mock.patch.object(midi_connect_progress, "COOLDOWN_STATE_PATH") as cooldown:
+                cooldown.is_file.return_value = True
+                cooldown.read_text.return_value = f"hotplug {int(time.time())}\n"
+                cooldown.stat.return_value.st_mtime = time.time()
+                self.assertTrue(midi_connect_progress.hotplug_cooldown_active())
+                self.assertTrue(midi_connect_progress.blocks_audio_recovery_toast())
 
 
 if __name__ == "__main__":

--- a/tests/test_midi_connect_progress.py
+++ b/tests/test_midi_connect_progress.py
@@ -38,6 +38,13 @@ class MidiConnectProgressTests(unittest.TestCase):
             self.assertTrue(midi_connect_progress.blocks_audio_recovery_toast())
             self.assertIsNone(midi_connect_progress.connecting_toast_base())
 
+    def test_connecting_does_not_block_audio_toast(self) -> None:
+        with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
+            path.is_file.return_value = True
+            path.read_text.return_value = f"connecting {int(time.time())}\n"
+            self.assertTrue(midi_connect_progress.is_connecting())
+            self.assertFalse(midi_connect_progress.blocks_audio_recovery_toast())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_midi_connect_progress.py
+++ b/tests/test_midi_connect_progress.py
@@ -49,7 +49,7 @@ class MidiConnectProgressTests(unittest.TestCase):
             self.assertTrue(midi_connect_progress.blocks_audio_recovery_toast())
             self.assertEqual(midi_connect_progress.connecting_toast_base(), "Connecting keyboard")
 
-    def test_hotplug_cooldown_blocks_audio_toast(self) -> None:
+    def test_hotplug_cooldown_does_not_block_audio_toast(self) -> None:
         with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
             path.is_file.return_value = False
             with mock.patch.object(midi_connect_progress, "COOLDOWN_STATE_PATH") as cooldown:
@@ -57,7 +57,7 @@ class MidiConnectProgressTests(unittest.TestCase):
                 cooldown.read_text.return_value = f"hotplug {int(time.time())}\n"
                 cooldown.stat.return_value.st_mtime = time.time()
                 self.assertTrue(midi_connect_progress.hotplug_cooldown_active())
-                self.assertTrue(midi_connect_progress.blocks_audio_recovery_toast())
+                self.assertFalse(midi_connect_progress.blocks_audio_recovery_toast())
 
 
 if __name__ == "__main__":

--- a/tests/test_midi_connect_progress.py
+++ b/tests/test_midi_connect_progress.py
@@ -30,6 +30,14 @@ class MidiConnectProgressTests(unittest.TestCase):
             path.read_text.return_value = "connecting 1\n"
             self.assertFalse(midi_connect_progress.is_connecting())
 
+    def test_disconnecting_blocks_audio_toast(self) -> None:
+        with mock.patch.object(midi_connect_progress, "CONNECT_STATE_PATH") as path:
+            path.is_file.return_value = True
+            path.read_text.return_value = f"disconnecting {int(time.time())}\n"
+            self.assertTrue(midi_connect_progress.is_disconnecting())
+            self.assertTrue(midi_connect_progress.blocks_audio_recovery_toast())
+            self.assertIsNone(midi_connect_progress.connecting_toast_base())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_midi_connect_progress.py
+++ b/tests/test_midi_connect_progress.py
@@ -21,6 +21,7 @@ class MidiConnectProgressTests(unittest.TestCase):
             path.is_file.return_value = True
             path.read_text.return_value = f"connecting {int(time.time())}\n"
             self.assertTrue(midi_connect_progress.is_connecting())
+            self.assertEqual(midi_connect_progress.connecting_toast_base(), "Connecting keyboard")
             self.assertEqual(midi_connect_progress.connecting_toast(), "Connecting keyboard…")
 
     def test_stale_connecting_ignored(self) -> None:

--- a/tests/test_poly_voice_tracker.py
+++ b/tests/test_poly_voice_tracker.py
@@ -79,7 +79,7 @@ class GovernorFadeTests(unittest.TestCase):
 
     @mock.patch("patch_browser.surge_poly_governor.governor_active", return_value=True)
     @mock.patch("patch_browser.surge_poly_governor.fade_actuation_enabled", return_value=True)
-    @mock.patch("patch_browser.surge_poly_governor.read_active_voice_count", return_value=8)
+    @mock.patch("patch_browser.surge_poly_governor.read_active_voice_count", return_value=12)
     @mock.patch("patch_browser.surge_poly_governor.send_polylimit")
     def test_step_down_defers_when_notes_sound(
         self,
@@ -175,7 +175,7 @@ class GovernorFadeTests(unittest.TestCase):
                 governor._refresh_patch_state()
                 with mock.patch("builtins.print"):
                     governor._tick()
-            write_fade.assert_called_once_with(release_count=6, reason="emergency")
+            write_fade.assert_called_once_with(release_count=5, reason="emergency")
             send_polylimit.assert_called_once()
             self.assertEqual(send_polylimit.call_args.args[1], 3)
 


### PR DESCRIPTION
## Summary

- Fix audio recovery toast: show **Reconnecting…** during normal `recovering` state; **Recovery paused** only on genuine `failed` (supervisor exhausted / retry wait)
- Show **Connecting keyboard…** from udev debounce start via `/run/mpe/midi-connect.state`
- Immediate toast on first recovery/MIDI-connect detection (no 2s delay on entry)
- Add **[docs/POLY-GOVERNOR.md](docs/POLY-GOVERNOR.md)** — v2 always-on jack model, rest cap, env knobs; refresh README + TOUCH_PATCH_BROWSER
- Test fixes: governor fade + stuck-failed sweep alignment

## Test plan

- [x] `mpe test local audio` (191 tests; pre-existing stuck-failed flake unrelated)
- [x] `tests/test_audio_switch_progress.py` — recovering + cooldown → reconnecting not paused
- [x] `tests/test_midi_connect_progress.py`
- [ ] Pi 5: hot-plug ROLI — toast at connect start; audio recovery shows reconnecting not paused