### PR TITLE
SR&ED technical narrative for the 2026 work period

### DIFF
--- a/docs/sred/PROMPT-looper-agent.md
+++ b/docs/sred/PROMPT-looper-agent.md
@@ -1,0 +1,75 @@
+# Request: SR&ED account of the looper work
+
+*Paste the section below to the agent/session that carried out the SooperLooper
+seam and multi-clip investigation.*
+
+---
+
+I'm assembling an SR&ED technical narrative for this project covering
+**2026-07-18 to 2026-08-28**. It lives at `docs/sred/SRED-NARRATIVE-2026.md`.
+The looper thread is the one section I could not write properly, because most of
+that investigation happened in your session and I only have its endpoints.
+
+**Do not write marketing copy, and do not inflate this.** SR&ED rests on
+*uncertainty* and *systematic investigation*, and the strongest evidence is the
+work that failed. Routine debugging weakens a claim if it's included — leave it
+out. If part of the work was straightforward engineering with no real unknown,
+say so plainly; that's a useful answer.
+
+Please produce a markdown document at `docs/sred/looper-thread.md` answering:
+
+### 1. What was genuinely uncertain
+
+For each distinct uncertainty — not each task — state what was unknown at the
+outset and **why it could not be resolved by standard practice** (documentation,
+a library's API, an obvious experiment). Be specific about the technical
+obstacle. "Making loops sound good" is not an uncertainty; "whether a loop could
+be closed sample-accurately when the recorder, synthesiser and control layer are
+separate processes with independent clocks" is.
+
+### 2. What you actually tried, in order
+
+Include the approaches that were **abandoned**, and why. Specifically:
+
+- The offline "seam weld" approach: what was the hypothesis behind it, what did
+  it assume about the recorder's behaviour, and how were those assumptions
+  eventually tested?
+- I have recorded that **two premises were measured false** — that `load_loop`
+  halts playback (it does not; loop position ran straight through), and that the
+  `SEAM_LOAD_LEAD_MS` sweep was tuning the join (it was measuring the landing
+  error of a subsequent retrigger). Confirm, correct, or expand on that.
+- What made the eventual native-overdub mechanism work where the previous
+  approach could not?
+- Anything else abandoned: tail capture, scratch loops, timing offsets.
+
+### 3. Measurements and instruments
+
+- What was measured, with what instrument, and how did you establish the
+  instrument was sound before trusting it?
+- Were there **positive controls** — a case where the instrument should show
+  nothing, used to prove a null result was real rather than a dead probe?
+- Any measurement discarded for a confound, and what the confound was.
+- Any result that **contradicted** an expectation.
+
+### 4. What was advanced
+
+What is now known, or now possible, that was not before — stated narrowly and
+scoped to the conditions actually tested. Do not generalise beyond the hardware,
+buffer configuration and patch library measured.
+
+### 5. Multi-clip work
+
+`multi-clip-slot-spike-2026-08-26.md` and
+`multi-clip-p2-composition-failure-2026-08-27.md` suggest a composition failure
+and a spike series. Same four questions for that thread.
+
+---
+
+**Format.** Follow the structure of §1 in `SRED-NARRATIVE-2026.md`: for each
+uncertainty, four headed parts — **Uncertainty / Work performed / Advancement /
+Evidence** — with Evidence citing repo paths (documents, commits, scripts) that
+already exist. Do not cite anything you have not verified is there.
+
+**Flag anything you are unsure of** rather than smoothing it over. A gap I know
+about is far more useful than a confident sentence I have to retract in front of
+an auditor.

--- a/docs/sred/SRED-NARRATIVE-2026.md
+++ b/docs/sred/SRED-NARRATIVE-2026.md
@@ -1,0 +1,222 @@
+# SR&ED technical narrative — MPE Sound Module
+
+**Claimant:** Ops Machine (Mitch Schwartz)
+**Project:** Headless polyphonic MPE synthesis appliance on ARM single-board hardware
+**Work period covered:** 2026-07-18 (first commit) to 2026-08-28
+**Prepared:** 2026-08-28
+
+> **This is a technical narrative, not an eligibility determination.** Whether this
+> work qualifies, which costs are claimable, and how it maps to your fiscal year are
+> your accountant's calls. What follows is the engineering record organised the way
+> CRA asks for it, with every claim pointing at contemporaneous evidence in the repo.
+
+---
+
+## 0. Why this record is unusually strong
+
+The claim rests on **59 measurement documents** written *during* the work, not
+reconstructed afterward. Several record hypotheses that turned out to be **wrong**,
+and say so explicitly. That matters more than the successes: a systematic
+investigation is evidenced by its failed hypotheses, and those are the thing nobody
+can credibly recreate after the fact.
+
+Concrete examples, all in `docs/measurements/`:
+
+| document | what it records |
+|---|---|
+| `PATCH-COST-what-makes-them-heavy.md` | A **retraction**. An earlier analysis named unison as the dominant CPU cost and "the only lever with an order of magnitude in it." Reading the patch files directly showed unison is 1–2 across every heavy patch, and the field being read was an *engine selector*, not a voice count. |
+| `HANDOVER-census-unison-fix.md` | A measurement **instrument** found to be fabricating a value that was already being cited in decisions. |
+| `classic-midi-router-hop-2026-08-28.md` | A latency result **discarded** for a confound (connection setup inside the measured arm), with the biased numbers preserved alongside the corrected ones. |
+| `classic-midi-phase2-hardware-2026-08-28.md` | A **prediction that did not hold**, recorded as refuted rather than deleted. |
+| `PI5-LOOPER-SEAM-WRAP.md` | Two premises **measured false**, closing out a line of work that had been built on them. |
+| `pi5-predictions-2026-08-23.md` | Predictions **pre-registered** before the hardware booted, marked never to be edited retroactively. |
+| `MEASUREMENT-DISCIPLINE.md` | A written analysis of the project's own recurring failure mode, with a cost table. |
+
+---
+
+## 1. Uncertainties addressed
+
+CRA's first question is what could not be resolved by standard practice. Six threads.
+
+### 1.1 Whether the target hardware could sustain the required polyphony at all
+
+**Uncertainty.** Whether a single-board ARM computer could compute the required number
+of simultaneous synthesis voices, for this specific patch library, inside a real-time
+audio deadline — and if not, whether the limit was the processor, the software's
+threading model, the audio buffer configuration, or patch construction. Published
+benchmarks do not answer this: the workload is a specific synthesiser running specific
+patches under a specific buffer regime.
+
+**Work performed.** A staged elimination across buffer sizes, sample rates, CPU
+governor settings, IRQ affinity, an overclock used *as a diagnostic instrument* rather
+than as a fix, and a compiler-architecture rebuild (`-mcpu=cortex-a72`) measured
+against a stock control binary. Each hypothesis was recorded before testing and
+eliminated on evidence.
+
+**Advancement.** A narrowly stated, defensible platform conclusion — deliberately
+scoped to the hardware, patch library, and buffer regime measured, and explicitly
+*not* generalised. `PI4-CLOSEOUT-2026-08-23.md` excludes corroborating data from the
+newer board so the conclusion stands or falls on its own evidence.
+
+**Evidence.** `PI4-CLOSEOUT-2026-08-23.md`, `CEILING-ANALYSIS-what-maxed-out-means.md`,
+`P7-RESULT-2026-08-23.md`, `reference-suite-pi4-a3-a72-comparison-2026-08-22.md`,
+`MULTITHREADING-ASSESSMENT.md`.
+
+### 1.2 Whether the measurements themselves could be trusted
+
+**Uncertainty.** This is the project's deepest recurring problem and is itself a
+technological uncertainty: for several instruments it was unknown whether a reading
+distinguished a working system from a broken one. A counter believed to mean "the
+audio buffer emptied" did not. A patch-metadata parser emitted a voice count that was
+not in the file. A MIDI port reported as open was subscribed to nothing, and the
+startup banner read identically in both cases.
+
+**Work performed.** Instruments were audited before their outputs were trusted;
+positive controls were introduced so a null result could be distinguished from a dead
+instrument; and the kernel's own subscription graph was consulted rather than the MIDI
+library's return value. The recurring failure mode was analysed and written up.
+
+**Advancement.** A reusable discipline — pre-registration, positive controls,
+instrument audit before interpretation — plus specific corrected instruments. The
+project now detects a class of fault it previously could not see.
+
+**Evidence.** `MEASUREMENT-DISCIPLINE.md`, `HANDOVER-census-unison-fix.md`,
+`X1-confirm-vs-soak` prompt and result, `scripts/sooperlooper/midi_subscription.py`
+(module docstring records the seventeen-minute silent failure that motivated it).
+
+### 1.3 Adaptive voice limiting under real-time load
+
+**Uncertainty.** Whether polyphony could be constrained dynamically, from a live load
+signal, without the limiter itself causing audible artefacts or becoming a load source.
+The uncertainty was both control-theoretic (what signal, what headroom, what response
+curve) and practical (whether measurement could be done inside the audio path at all).
+
+**Work performed.** Instrumentation first, then a v2 "always-on" model driven by the
+audio server's own load figure, calibrated by ear against measured headroom.
+
+**Advancement.** A working adaptive governor with characterised behaviour under load.
+
+**Evidence.** `poly-governor-instrumentation-2026-08-21.md`,
+`poly-governor-v2-always-on-pi5-2026-08-23.md`, `G2-RESULT-2026-08-23.md`.
+
+### 1.4 Seamless audio loop continuity
+
+**Uncertainty.** How to close a recorded audio loop so playback continues across the
+join without a discontinuity, on a system where the recorder, the synthesiser, and the
+control layer are separate processes with independent timing.
+
+**Work performed.** An offline "seam weld" approach was built, instrumented, and
+measured. Its premises were then tested directly and **both were found false** — the
+operation believed to halt playback did not, and a parameter sweep believed to be
+tuning the join was in fact measuring the landing error of a subsequent retrigger.
+
+**Advancement.** The join was resolved by a different mechanism entirely, and the
+false premises are recorded so the abandoned approach is not re-derived.
+
+**Evidence.** `PI5-LOOPER-SEAM-WRAP.md` (close-out section), `multi-clip-slot-spike-2026-08-26.md`,
+`multi-clip-p2-composition-failure-2026-08-27.md`.
+
+> **See §4** — the majority of this thread was performed by a different agent/session
+> and needs its own account.
+
+### 1.5 Translating conventional MIDI instruments into an MPE-only signal path
+
+**Uncertainty.** The appliance's synthesis engine runs in a mode where per-note
+expression is carried on separate MIDI channels. A conventional keyboard sends
+everything on one channel. It was unknown whether the two could coexist without
+restarting the engine — which would be unacceptable in live use — and unknown whether
+a device's expressive capability could be determined automatically at all.
+
+**Work performed.**
+- Established by reading the synthesiser's source that **no runtime control path exists**
+  to change its expression mode or bend range. This eliminated the obvious approach and
+  forced a translation layer.
+- Measured the cost of an additional processing hop **before** building on it
+  (0.053 ms median), and discarded a first result found to be confounded.
+- Designed channel allocation with voice stealing, bend-range rescaling between
+  differing conventions, and note retriggering.
+- Investigated whether a control surface with an instrument mode could serve both roles
+  at once. Three outcomes were enumerated in advance; capture determined the answer, and
+  **an initial conclusion was published and then retracted** when a cleaner experiment
+  showed the first capture had a mode change inside it.
+- Designed a behavioural classifier for devices that do not announce their capability,
+  with an explicit constraint that a false positive is worse than a miss.
+
+**Advancement.** Conventional MIDI instruments now play the appliance from a cold boot
+with no user configuration, while the existing expressive path is preserved. Real
+hardware behaviour was characterised that is not documented by the manufacturer,
+including a device announcing its mode over a vendor-specific message, and a pad
+controller emitting duplicate note events (~4% of messages) that the translation layer
+must absorb.
+
+**Evidence.** `docs/CLASSIC-MIDI-PLAN.md`, `classic-midi-router-hop-2026-08-28.md`,
+`classic-midi-phase2-hardware-2026-08-28.md`, `classic-midi-phase4-coldboot-2026-08-28.md`,
+`tests/fixtures/apc-mini-mk2-notes-2026-08-28.jsonl` (captured hardware output retained
+as a test fixture).
+
+### 1.6 Platform configuration for real-time determinism
+
+**Uncertainty.** Which of interrupt affinity, CPU governor pinning, core allocation,
+power delivery, and thermal behaviour actually affect audio deadline misses on this
+hardware — as opposed to being folklore carried over from desktop audio tuning.
+
+**Work performed.** A census-based investigation with loaded and unloaded captures,
+recording throttle flags, temperature, and clock alongside audio performance, with
+power-supply conditions stated as part of the measurement conditions.
+
+**Advancement.** An evidence-based configuration baseline, with several widely repeated
+tuning assumptions tested rather than adopted.
+
+**Evidence.** `PI5-IRQ-INVESTIGATION-PLAN.md`, `pi5-irq-phase1-2026-08-23.md`,
+`PI5-HYGIENE-AND-CONFIG-PLAN.md`.
+
+---
+
+## 2. What is deliberately excluded
+
+Listing this protects the claim. The following were performed in the same period and
+are **routine engineering**, not experimental development:
+
+- Deployment scripting, service unit configuration, git and release mechanics.
+- Straightforward defect fixes with no uncertainty — e.g. a logging call that warned on
+  a normally-absent file, and a startup gate that checked for the wrong device.
+- Writing tests for behaviour already understood.
+- Documentation, refactoring for readability, and user-interface layout work.
+
+Where a debugging episode *did* involve genuine uncertainty, it appears in §1 under the
+thread it belongs to, not as a separate item.
+
+---
+
+## 3. Suggested T661 wording
+
+**Line 242 — technological uncertainties.** Six threads, above. If a single framing is
+needed: *whether a general-purpose ARM single-board computer could host a
+polyphonic, per-note-expressive synthesis instrument with live looping at usable
+polyphony inside real-time audio deadlines — and, at each stage, whether the
+instruments used to answer that question were themselves sound.*
+
+**Line 244 — work performed.** Staged hypothesis elimination across hardware, compiler,
+buffer, scheduling and patch-construction variables; instrument audit and correction;
+adaptive load control; and a translation layer between two incompatible MIDI
+expression conventions. Evidence is contemporaneous and includes recorded failures.
+
+**Line 246 — advancements achieved.** A characterised polyphony ceiling stated narrowly
+to its conditions; a corrected measurement methodology with a documented failure mode;
+an adaptive voice governor; a resolved loop-continuity mechanism with two disproved
+premises recorded; and automatic conventional-MIDI interoperability with an MPE-only
+engine, including hardware behaviour not present in vendor documentation.
+
+---
+
+## 4. Gaps to close before filing
+
+1. **The looper thread (§1.4) is under-documented here.** Most of that investigation was
+   carried out in a separate session. See `docs/sred/PROMPT-looper-agent.md` for the
+   request to send to whoever holds that context.
+2. **Time and cost records.** This narrative covers the *what*, not the *how much*. No
+   hours are recorded in the repo.
+3. **Fiscal year boundary.** The work period here is 2026-07-18 to 2026-08-28. Which
+   portion falls in the claim year is your accountant's determination.
+4. **Prior-period work.** If work on this project predates the first commit
+   (design, research, hardware evaluation), it is not represented in the repo at all.

--- a/docs/sred/SRED-NARRATIVE-2026.md
+++ b/docs/sred/SRED-NARRATIVE-2026.md
@@ -31,12 +31,14 @@ Concrete examples, all in `docs/measurements/`:
 | `PI5-LOOPER-SEAM-WRAP.md` | Two premises **measured false**, closing out a line of work that had been built on them. |
 | `pi5-predictions-2026-08-23.md` | Predictions **pre-registered** before the hardware booted, marked never to be edited retroactively. |
 | `MEASUREMENT-DISCIPLINE.md` | A written analysis of the project's own recurring failure mode, with a cost table. |
+| `sooperlooper-loop-ceiling-2026-08-27.md` | A **third-party dependency** found to report resources it does not provide — reads answered with defaults, writes discarded, every health check passing. |
+| `multi-clip-p2-composition-failure-2026-08-27.md` | A **composition failure** recorded as such: two components each deciding what a control press meant, producing defects that were individually fixable and collectively endless. |
 
 ---
 
 ## 1. Uncertainties addressed
 
-CRA's first question is what could not be resolved by standard practice. Six threads.
+CRA's first question is what could not be resolved by standard practice. Eight threads.
 
 ### 1.1 Whether the target hardware could sustain the required polyphony at all
 
@@ -69,7 +71,10 @@ technological uncertainty: for several instruments it was unknown whether a read
 distinguished a working system from a broken one. A counter believed to mean "the
 audio buffer emptied" did not. A patch-metadata parser emitted a voice count that was
 not in the file. A MIDI port reported as open was subscribed to nothing, and the
-startup banner read identically in both cases.
+startup banner read identically in both cases — that last one recurred and was finally
+quantified and closed under §1.8, and the class reached its most general form in §1.7,
+where the untrustworthy instrument was a third-party engine reporting resources it did
+not provide.
 
 **Work performed.** Instruments were audited before their outputs were trusted;
 positive controls were introduced so a null result could be distinguished from a dead
@@ -116,8 +121,10 @@ false premises are recorded so the abandoned approach is not re-derived.
 **Evidence.** `PI5-LOOPER-SEAM-WRAP.md` (close-out section), `multi-clip-slot-spike-2026-08-26.md`,
 `multi-clip-p2-composition-failure-2026-08-27.md`.
 
-> **See §4** — the majority of this thread was performed by a different agent/session
-> and needs its own account.
+**Full account:** [`looper-thread.md`](looper-thread.md) — written by the session that
+carried out the work, with the seven refuted hypotheses, the quantified limits of the
+abandoned approach (65–139 ms arm latency, +4.05 dB head summing), and the correction
+that the `SEAM_LOAD_LEAD_MS` sweep was measuring a defect the weld itself introduced.
 
 ### 1.5 Translating conventional MIDI instruments into an MPE-only signal path
 
@@ -172,6 +179,53 @@ tuning assumptions tested rather than adopted.
 
 ---
 
+### 1.7 Whether a third-party engine supplies the resources it reports
+
+**Uncertainty.** The multi-track design assumed the audio engine provides as many
+independent loop buffers as requested. It was unknown whether the count SooperLooper
+reports is a guarantee or unrelated to what it will accept commands for — and whether a
+shortfall is detectable from the control layer at all. This is §1.2's problem relocated
+into a dependency, where the discipline cannot be enforced, only checked for.
+
+**Work performed.** Four hypotheses refuted by measurement (grid-sync off-by-one, OSC
+burst loss, memory exhaustion, last-index reservation), then a parameter sweep against an
+isolated second engine instance, writing and reading back every index so the running
+system was never perturbed.
+
+**Advancement.** A hard platform constraint established: 15 usable loops, indices 0–14,
+independent of the configured count. Indices above it are **phantoms** that answer reads
+with plausible defaults and discard writes, so every read-based health check passes while
+configuration vanishes. The remedy is correspondingly different from a corrected
+instrument — an **acceptance probe** that exercises the capability by writing.
+
+**Evidence.** `docs/measurements/sooperlooper-loop-ceiling-2026-08-27.md`,
+`scripts/sooperlooper/sl_limits.py`, [`looper-thread.md`](looper-thread.md) §2.
+
+### 1.8 Keeping a USB control surface alive on a contended bus
+
+**Uncertainty.** The appliance repeatedly presented as unresponsive with no error. The
+prior uncertainty was not the cause but whether **any available reading distinguished a
+live control surface from a dead one** — `systemctl is-active`, absent journal errors,
+the startup banner, and the MIDI library's `open_port()` return value are all satisfied
+equally by a dead surface, which is why the fault survived four or more diagnostic passes.
+
+**Work performed.** The symptom was quantified before it was explained: repeated session
+starts scored on pad response, establishing a **4-in-6 failure rate** — the step that
+matters, since an intermittent fault is exactly what a single restart appears to cure.
+The kernel ring buffer then gave the mechanism: a USB endpoint stall (`-EPIPE`) and
+re-enumeration, provoked by an unpaced 64-message LED burst on a full-speed device two
+hubs deep sharing its chain with streaming audio.
+
+**Advancement.** Writes paced through a queue with a link-health reopen: **0 failures in
+6 starts**, no further disconnects. More durably, the deploy path now consults the
+kernel's subscription graph for an actual reader and refuses to report success without
+one. The pacing fixes this instance; the reading makes the next one detectable.
+
+**Evidence.** `scripts/sooperlooper/apc_link.py`, `tests/test_apc_link.py`,
+`scripts/restart-looper-session.sh`, [`looper-thread.md`](looper-thread.md) §3.
+
+---
+
 ## 2. What is deliberately excluded
 
 Listing this protects the claim. The following were performed in the same period and
@@ -190,7 +244,7 @@ thread it belongs to, not as a separate item.
 
 ## 3. Suggested T661 wording
 
-**Line 242 — technological uncertainties.** Six threads, above. If a single framing is
+**Line 242 — technological uncertainties.** Eight threads, above. If a single framing is
 needed: *whether a general-purpose ARM single-board computer could host a
 polyphonic, per-note-expressive synthesis instrument with live looping at usable
 polyphony inside real-time audio deadlines — and, at each stage, whether the
@@ -204,16 +258,22 @@ expression conventions. Evidence is contemporaneous and includes recorded failur
 **Line 246 — advancements achieved.** A characterised polyphony ceiling stated narrowly
 to its conditions; a corrected measurement methodology with a documented failure mode;
 an adaptive voice governor; a resolved loop-continuity mechanism with two disproved
-premises recorded; and automatic conventional-MIDI interoperability with an MPE-only
-engine, including hardware behaviour not present in vendor documentation.
+premises recorded; a characterised engine resource ceiling with an acceptance probe that
+detects it; a control-surface link made observable, with the failure rate measured before
+and after; and automatic conventional-MIDI interoperability with an MPE-only engine,
+including hardware behaviour not present in vendor documentation.
 
 ---
 
 ## 4. Gaps to close before filing
 
-1. **The looper thread (§1.4) is under-documented here.** Most of that investigation was
-   carried out in a separate session. See `docs/sred/PROMPT-looper-agent.md` for the
-   request to send to whoever holds that context.
+1. ~~**The looper thread (§1.4) is under-documented here.**~~ **Closed 2026-08-28** —
+   answered by the session that held that context in [`looper-thread.md`](looper-thread.md),
+   which also supplied §1.7 and §1.8. It flags four items rather than smoothing them: the
+   final control-surface fix is committed but **unverified on hardware**; a wrong mapping
+   shipped in `8c4aee6` and was corrected the same day by `a2da7a7`; the 64×2 buffer
+   setting is ear-validated only, with an undiagnosed 2026-08-23 collapse behind it; and
+   the thread's hours are not separable from adjacent sessions.
 2. **Time and cost records.** This narrative covers the *what*, not the *how much*. No
    hours are recorded in the repo.
 3. **Fiscal year boundary.** The work period here is 2026-07-18 to 2026-08-28. Which

--- a/docs/sred/looper-thread.md
+++ b/docs/sred/looper-thread.md
@@ -1,0 +1,263 @@
+# The looper thread — SR&ED account
+
+*Written in response to `PROMPT-looper-agent.md`, by the session that carried out the
+seam, multi-clip and control-surface work. Covers 2026-08-25 → 2026-08-28.*
+
+> **Scope and honesty notes.** Where work was routine engineering with no real unknown,
+> it is named as such in §6 rather than dressed up. Two items I would not want an
+> auditor to discover on their own are flagged inline: the hours for this thread are
+> not instrumented (§7), and the final fix is committed but **unverified on hardware**
+> (§5). Everything cited below was checked to exist at the path given before it was
+> written down.
+
+---
+
+## 1. Loop-wrap continuity outside the audio engine
+
+**Uncertainty.** How to close a recorded loop so playback continues across the join
+without a discontinuity, when the recorder (SooperLooper), the synthesiser (Surge XT)
+and the control layer (a Python bench over OSC) are separate processes with independent
+timing. The specific unknown was not "does it click" but **whether the join could be
+repaired from outside the audio engine at all** — whether a control process, which can
+only issue commands between audio callbacks, can act with sample accuracy on a boundary
+that occurs inside one. Standard practice offers no answer: SooperLooper's OSC surface
+documents *what* commands exist, not their latency relative to a loop boundary, and the
+question is a property of the running system, not of the API.
+
+**Work performed.** An offline "seam weld" was built first: capture the ring-out tail
+after the boundary, merge it into the head of the recorded buffer, and reload the
+result. This assumed (a) the tail could be captured close enough to the boundary to
+contain the audible decay, and (b) reloading a buffer would not disturb playback. Both
+assumptions were eventually tested directly rather than argued about.
+
+Seven hypotheses about the residual artefact were pre-registered and **all seven were
+refuted by measurement**: that the merge DSP had changed the audio (output was
+byte-identical); that weld timing had changed; that the tail was wrongly skipped
+(`skip=0`, the full 73,452-frame tail was applied); that the weld failed to load (live
+matched merged exactly); that the click was baked into the buffer (the wrap delta sat at
+the 70th percentile of ordinary motion); that JACK buffer 64 vs 128 was responsible
+(falsification pre-registered, operator-confirmed null); and that `load_loop` halts
+playback.
+
+**Confirming the two premises the narrative records as false — both confirmed, with a
+correction to the second.**
+
+1. **`load_loop` does not halt playback.** Measured directly: `loop_pos` ran 0.805 →
+   0.813 straight through the call. Confirmed as stated.
+2. **The `SEAM_LOAD_LEAD_MS` sweep was not tuning the join.** Confirmed, and I would
+   put it more strongly than "measuring the landing error of a subsequent retrigger":
+   the sweep was measuring a *different defect that the weld had introduced* — a
+   post-weld retrigger landing 4.9 ms early (fixed at `712f012`). The sweep was
+   therefore well-behaved and repeatable while being unrelated to the artefact under
+   investigation, which is the worst case, because a responsive knob is taken as
+   evidence that the right variable has been found.
+
+**Why the native mechanism worked where the offline path could not.** The offline path
+carries limits inherent to its own structure, and these were measured rather than
+assumed: OSC arm latency of **65–139 ms after the wrap**, meaning the loudest part of
+the ring-out was never captured at all; and summed tail energy of **+4.05 dB across the
+loop head**, rising to **+18 dB** against a quiet take head (0.0004 RMS) and spanning up
+to **87% of loop length**. No amount of tuning removes these — they are consequences of
+acting from outside the audio thread. The resolution was a single native `overdub`
+command issued **while still recording**, which closes the take and begins overdubbing
+at the same sample *inside SooperLooper's own audio thread*. Pop-free, operator-confirmed
+on Pi 5, shipped at `117f4cc`.
+
+**A prior refutation that was itself wrong.** This mechanism had been tried on Pi 4 and
+rejected. Re-examination traced that failure to a **two-command sequence** (record-off,
+then overdub-on) which leaves a gap between the two — not to the engine's behaviour. The
+earlier conclusion had been recorded as a property of SooperLooper when it was a property
+of how it had been called.
+
+**Also abandoned.** Tail capture and the scratch-loop mechanism it depended on (the
+offline pipeline became unreachable from the pad and is pending removal); a
+tail-alignment change (`798e376`) reverted within the hour at `c9e7d47` — see §3; and a
+`fade_samples` hypothesis raised and dropped on the operator's prior Pi 4 data **before
+code was written against it**, which is the cheap version of the same discipline.
+
+**Advancement.** Scoped narrowly to Pi 5, SooperLooper 1.7.9, JACK at the buffer sizes
+tested: loop-boundary continuity **cannot** be repaired from a control process outside
+the audio engine, and the reason is quantified (65–139 ms arm latency, +4.05 dB head
+summing) rather than asserted. The engine's own single-command path does close the take
+sample-accurately. Both the working mechanism and the disproved approach are recorded so
+the offline path is not re-derived.
+
+**Evidence.** `docs/measurements/PI5-LOOPER-SEAM-WRAP.md` (close-out section); commits
+`712f012`, `798e376`, `c9e7d47`, `117f4cc`.
+
+---
+
+## 2. Does the loop engine provide the resources it reports?
+
+**Uncertainty.** The multi-track design assumes the engine supplies as many independent
+loop buffers as requested and that the count it reports is that number. SooperLooper
+1.7.9 publishes no ceiling on `-l`, and the appliance had run a 16-track configuration
+for weeks. It was unknown whether the advertised count is a guarantee, an aspiration, or
+unrelated to what the engine will accept commands for — and, critically, **whether a
+shortfall is detectable at all** from the control layer.
+
+**Work performed.** A track at the top of the range recorded but would not obey the bar
+grid. Four hypotheses were refuted before the answer: grid-sync off-by-one (the source
+iterates `range(num_loops)`); OSC burst loss (re-sent alone, 20 ms apart, still ignored);
+memory exhaustion (2.6 GB free, reproduces at `-t 10`); last-index reservation (`-l 4`
+yields four usable loops). Resolved by a parameter sweep against an **isolated second
+engine on port 9971**, writing and reading back every index, so the running instrument
+was never perturbed.
+
+**Advancement.** SooperLooper 1.7.9 provides **15 usable loops, indices 0–14**,
+independent of `-l` and `-t`. Indices above the ceiling are **phantoms**: they answer
+`get` with plausible defaults and silently discard every `set`, so `/ping` and every
+read-based health check pass while configuration vanishes. Because the unreliable
+component is a third-party dependency, the remedy could not be a corrected instrument —
+it is an **acceptance probe** (`check_loops_writable`) that exercises the capability by
+writing rather than querying it.
+
+**Knowledge decay as a distinct failure mode.** This ceiling had been discovered once
+before and survived only as a string in a shell log line — `16 loops, scratch 14 — loop
+15 empty on Pi`. The workaround outlived its explanation, was read as stale copy about a
+deleted feature, and was removed, re-exposing the phantom to the player. The constant
+and its measurement now travel together in `sl_limits.py`.
+
+**Evidence.** `docs/measurements/sooperlooper-loop-ceiling-2026-08-27.md`;
+`scripts/sooperlooper/sl_limits.py`.
+
+---
+
+## 3. Can a control surface be kept alive on a bus it is losing?
+
+**Uncertainty.** The appliance repeatedly presented as "dead" — pads unlit and
+unresponsive after a session start, with no error anywhere. It had been attributed to
+process state (orphans, duplicate instances, stale code) and "fixed" by restarting, four
+or more times. The real unknown was not the cause but something prior to it: **whether
+the control layer possessed any reading capable of distinguishing a live surface from a
+dead one.** `systemctl is-active`, the absence of journal errors, the startup banner's
+device line, and `rtmidi`'s `open_port()` return value are all satisfied equally by a
+dead surface. This is why the fault survived repeated diagnosis — every check performed
+was structurally incapable of returning a negative.
+
+**Work performed.** The symptom was made measurable *before* it was explained: session
+starts were repeated and scored on whether the pads responded, establishing a baseline of
+**4 failures in 6 starts**. Quantifying the intermittency was the step that mattered — an
+intermittent fault is precisely the kind that single-restart "fixes" appear to resolve.
+The kernel ring buffer then supplied the mechanism: `urb status -32` (`-EPIPE`) against
+the device's USB address — an **endpoint stall** followed by re-enumeration. The APC MINI
+is a 12 Mbit full-speed device two hubs deep, sharing that chain with streaming USB
+audio, and the startup sequence blanked all 64 pads in one unpaced burst.
+
+A second, independent path to the same symptom was found alongside it: `systemctl
+restart` can SIGKILL the outgoing process and start its replacement within the same
+second, before ALSA has released the port, leaving the subscription unmade while the
+banner still prints correctly.
+
+**Advancement.** Writes are paced through a queue at a 1.5 ms gap, with the startup blank
+drained explicitly (~96 ms) before anything paints over it, and a link-health poll
+re-asks the kernel and reopens the port by name. Re-measured: **0 failures in 6 starts**,
+no further USB disconnects for the remainder of the session. Separately, and more
+durably, the deploy path now interrogates `/proc/asound/seq/clients` for an actual reader
+on the port and refuses to report success without one — **a reading that can come back
+negative**. The pacing fixes this instance; the reading is what makes the next one
+detectable.
+
+**Positive controls and a contradicted expectation.** The 4-of-6 baseline is itself the
+positive control for the fix: without a measured failure rate, "0 of 6 after" is
+unfalsifiable, since a fault that fires two times in three is easily "fixed" by any
+change followed by three lucky starts. The contradicted expectation was the original
+diagnosis: the fault was assumed for days to be software state, and is bus contention.
+
+**Evidence.** `scripts/sooperlooper/apc_link.py`, `tests/test_apc_link.py`,
+`scripts/sooperlooper/midi_subscription.py` (module docstring records the seventeen-minute
+silent failure), `scripts/restart-looper-session.sh`; commit `5aba06a`.
+
+---
+
+## 4. Multi-clip — the composition failure
+
+**Uncertainty.** Whether a multi-clip-per-track model (Ableton Session View semantics)
+could be layered over an engine whose loops are flat, independent and stateful, without
+the control layer and the engine holding contradictory ideas of what is playing. The
+engine has no concept of a "slot"; it has fifteen loops. Any slot model is a fiction
+maintained entirely in the control layer, and the unknown was whether that fiction can be
+kept consistent with an engine that changes state on its own schedule (quantized to the
+bar) and reports state changes only as **edge-triggered updates**.
+
+**Work performed, and what failed.** The first composition attempt failed in a way worth
+recording: a matrix that re-decided what a press meant, on top of a footswitch that
+already decided what a press meant. Two decision-makers over one buffer produced defects
+that were individually fixable and collectively endless. The structure was replaced with
+a **router**: the active lane forwards the press to the footswitch verbatim, and the
+matrix owns only the cases the footswitch cannot know about (launch, switch,
+record-elsewhere, clear, cancel).
+
+Three defects found in operator testing, each a distinct class:
+
+- **A queued switch resolved on a state *change* that never arrives.** PLAYING → PLAYING
+  is not a change, so a switch between two playing clips never completed. Fixed by
+  polling state rather than waiting on a transition (`6ee8cf5`). Same shape as §3 one
+  layer up: a signal that is absent in exactly the case you care about.
+- **Two independent causes of clip loss, both silent.** (a) The buffer was `unlink`ed
+  before `save_loop` had written it. (b) A take closing into its ring-out overdub was not
+  registered as real, so the flush skipped it **without error** and `undo_all` then
+  destroyed it. (b) was the operator's own hypothesis, formed from the symptom and
+  confirmed in code. Fixed at `1b50f1a`; the save path was made durable (temp `.part` →
+  fsync → `os.replace` → fsync directory) so a failed save leaves the previous take
+  intact rather than a truncated file.
+- **A dual-function control resolved by omission.** The bottom scene button is a scene
+  launcher alone and Stop All Clips with Shift; the conflict had been "resolved" by
+  leaving it out of the scene column, silencing scene row 0 entirely.
+
+**The instrument failure in this thread was the test suite.** The multi-clip suite passed
+while the appliance failed. Cause: every test constructed its starting state by
+assignment (`_tracks[0] = Track(...)`) and then performed one gesture — so **the setup
+line silently repaired whatever the previous gesture had failed to do**. The suite was
+measuring a machine that does not exist. It was rewritten under one rule — state may be
+created *only* by gestures, never by assignment — against a fake engine that, like the
+real one, emits auto-updates **only on change**. Making the harness less accommodating in
+three separate respects (deliver only on change; do not pre-write the WAV; do not wait
+for the tail) surfaced a real defect **each time**, which is the positive control for the
+rewrite.
+
+**Advancement.** A multi-clip model over a flat-loop engine, with the boundary stated:
+the control layer may not re-derive state the engine owns, and any pending intent must be
+resolved by polling rather than by waiting for an edge. The test methodology is the more
+transferable result — a harness that constructs state by assignment cannot detect a
+gesture that fails to construct it.
+
+**Evidence.** `docs/measurements/multi-clip-slot-spike-2026-08-26.md`,
+`docs/measurements/multi-clip-p2-composition-failure-2026-08-27.md`,
+`tests/test_multiclip_workflow.py`, `scripts/sooperlooper/apc_panel.py`; commits
+`0c039e7`, `6ee8cf5`, `1b50f1a`, `a2da7a7`.
+
+---
+
+## 5. Things I am flagging rather than smoothing over
+
+1. **The final fix is unverified on hardware.** `5aba06a` is committed and pushed but was
+   never deployed — the appliance went offline first. The 0-of-6 result in §3 was measured
+   on the pacing change, which *was* deployed and running; the deploy-path reader check
+   was not exercised on the device.
+2. **`8c4aee6` shipped a wrong control-surface mapping** and was corrected by `a2da7a7`
+   the same day. The row mapping was got wrong three times in one session, each time by
+   reasoning from prose that contradicted the note table three lines above it. I record it
+   because the remedy is structural (a single source of truth for every note, with the
+   rule that a disputed fact is measured on the device again rather than reasoned about)
+   and because a claim that shows only clean commits is less credible, not more.
+3. **The buffer setting at 64×2 is ear-validated only** — no xrun soak was run. The env
+   file says so at the point of use. 64×2 collapsed ALSA/USB on 2026-08-23 for reasons
+   never diagnosed, and that non-diagnosis is an open item, not a closed one.
+4. **§1's hours are not separable** from the same-day sessions around them.
+
+## 6. Named as routine, and excluded
+
+Deploy scripting and service-unit work; the systemd unit-name correction; git worktree
+and stash hygiene; LED colour-table plumbing; test writing for behaviour already
+understood; and the ordinary defect fixes that carried no uncertainty (a health probe
+rewriting the audio path on a timer, `e111719`). The *waiting* in
+`restart-looper-session.sh` is routine; only the **verification** is claimed.
+
+## 7. Time records
+
+None instrumented for this thread. Appliance logs bound some sessions from the outside
+(first bench activity, last deploy) but the operator's hands-on time began earlier than
+the appliance record shows in at least one case, which is noted in the daily log rather
+than reconciled. Hours are the operator's recall, not a measurement, and should be
+presented that way.


### PR DESCRIPTION
Technical narrative organised for SR&ED: six uncertainty threads, each with uncertainty / work performed / advancement / evidence, every claim pointing at a contemporaneous document already in `docs/measurements/`.

Docs only — no code, no behaviour change.

Two things worth reading before it lands:

- **§2 lists what is deliberately excluded** (deployment, routine defect fixes, test writing, UI work). Including routine engineering is the fastest way to have a claim questioned, so the exclusions are stated rather than left implicit.
- **§4 lists the gaps**: the looper thread is under-documented here because it happened in another session, there are no time or cost records in the repo, and the fiscal-year boundary is not something this document decides.

`PROMPT-looper-agent.md` is the request to send to whoever holds the looper context.

This is a technical narrative, not an eligibility determination — that is the accountant's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)