### PR TITLE
record-screen: survive SIGHUP so ssh Ctrl+C stops producing empty files

### DIFF
--- a/scripts/record-screen.sh
+++ b/scripts/record-screen.sh
@@ -72,17 +72,33 @@ cleanup() {
     fi
     exit "$code"
 }
-trap cleanup EXIT INT TERM
+# HUP matters as much as INT here: `mpe record` runs this over ssh, and Ctrl+C
+# there can drop the connection before SIGINT is delivered. The remote process
+# group then gets SIGHUP, and without it in the trap ffmpeg dies unfinalised —
+# leaving a 0-byte .mkv that still matches the `mpe pull-videos` glob, plus a
+# stale env file and FIFO. A recording that looks like a recording and holds no
+# frames is the failure shape this project keeps meeting; it should not survive
+# in the tool used to record the evidence. (MEASURED 2026-08-30: INT -> 28KB
+# valid file, HUP -> 0 bytes.)
+trap cleanup EXIT INT TERM HUP
 
 rm -f "$PIPE"
 mkfifo "$PIPE"
 chmod 666 "$PIPE" 2>/dev/null || true
 
 echo "record-screen: ffmpeg → $OUT @ ${FPS}fps (${WIDTH}x${HEIGHT})" >&2
-ffmpeg -y -loglevel warning \
+# ffmpeg must ignore SIGHUP, and the trap above is not enough on its own.
+# `mpe record` runs this over ssh; a Ctrl+C there can drop the connection
+# before SIGINT arrives, and SIGHUP then goes to the whole process group.
+# ffmpeg would die mid-stream with no moov/EBML header written, and cleanup's
+# `kill -INT` would arrive at a process that is already gone. Ignoring HUP in
+# a subshell that execs into ffmpeg keeps it alive just long enough for
+# cleanup to shut it down properly. (MEASURED 2026-08-30 on pi5: without
+# this, HUP -> 0-byte .mkv that ffprobe rejects; with it -> valid file.)
+( trap '' HUP; exec ffmpeg -y -loglevel warning \
     -f rawvideo -pix_fmt rgb24 -s "${WIDTH}x${HEIGHT}" -r "$FPS" -i "$PIPE" \
     -c:v libx264 -preset veryfast -crf 18 -pix_fmt yuv420p \
-    "$OUT" &
+    "$OUT" ) &
 FFPID=$!
 
 tee "$ENV_FILE" >/dev/null <<EOF


### PR DESCRIPTION
`mpe record` runs `record-screen.sh` over ssh. Ctrl+C there can drop the connection before SIGINT is delivered, and SIGHUP then goes to the whole remote process group. ffmpeg died mid-stream with no EBML header, and `cleanup`'s `kill -INT` arrived at a process that was already gone.

The result was a **0-byte `.mkv` that still matches the `mpe pull-videos` glob** — a recording that looks like a recording and holds no frames. That is the failure shape this project keeps meeting, and it should not survive in the tool used to record the evidence.

## Two changes, because the first alone is not sufficient

Measured, not assumed. Adding `HUP` to the trap makes cleanup run (the leftover env file and FIFO are removed) but the file is **still 0 bytes**, because ffmpeg has already been killed by the same group signal. ffmpeg also has to ignore HUP so it is still alive when cleanup shuts it down.

## Measured on pi5, 2026-08-30, 9s captures

| | INT | HUP | TERM |
|---|---|---|---|
| before | 28616 B valid | **0 B, ffprobe rejects** | — |
| after | 30455 B / 5.97 s | 30455 B / 5.97 s | 30418 B / 5.93 s |

No leftovers (`/tmp/mpe-screen-record.{env,pipe}`) and no orphan ffmpeg in any case. Pi restored to its original script after testing.

## Scope

One file, `scripts/record-screen.sh`. No behaviour change on the working path — a normal local Ctrl+C was already fine and still is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)