### PR TITLE
filter pane: sort instrument chips A-Z

### DIFF
--- a/patch_browser/instrument_filter.py
+++ b/patch_browser/instrument_filter.py
@@ -32,8 +32,20 @@ def instrument_counts(patches: list[dict]) -> dict[str, int]:
 
 
 def instruments_with_patches(patches: list[dict]) -> list[str]:
+    """Instruments that have at least one patch, ordered A-Z by chip label.
+
+    Sorted here rather than by reordering INSTRUMENT_VOCAB, because that tuple
+    is also the key order for classification scoring
+    (`patch_metadata.classify_instrument`) — reordering it would change
+    tie-breaks between instruments that score equally, which is a silent
+    change to how patches are labelled, not a display change.
+
+    Membership still comes from the vocab, so an unknown instrument_primary
+    cannot introduce a chip.
+    """
     counts = instrument_counts(patches)
-    return [name for name in INSTRUMENT_VOCAB if counts.get(name, 0) > 0]
+    present = [name for name in INSTRUMENT_VOCAB if counts.get(name, 0) > 0]
+    return sorted(present, key=instrument_chip_label)
 
 
 def instrument_chip_label(instrument: str) -> str:

--- a/tests/test_instrument_filter.py
+++ b/tests/test_instrument_filter.py
@@ -21,13 +21,33 @@ class InstrumentFilterTests(unittest.TestCase):
         filtered = filter_patches_by_instrument(patches, "bass")
         self.assertEqual([p["name"] for p in filtered], ["A", "C"])
 
-    def test_instruments_with_patches_respects_vocab_order(self) -> None:
+    def test_instruments_with_patches_is_alphabetical(self) -> None:
+        """bass/lead/pad alone cannot prove this — they are alphabetical AND in
+        vocab order. Use instruments whose two orderings disagree."""
         patches = [
-            {"instrument_primary": "pad"},
-            {"instrument_primary": "bass"},
-            {"instrument_primary": "lead"},
+            {"instrument_primary": "piano"},   # vocab index 0
+            {"instrument_primary": "bass"},    # vocab index 3
+            {"instrument_primary": "organ"},   # vocab index 2
         ]
-        self.assertEqual(instruments_with_patches(patches), ["bass", "lead", "pad"])
+        self.assertEqual(
+            instruments_with_patches(patches), ["bass", "organ", "piano"]
+        )
+
+    def test_instruments_with_patches_is_not_in_vocab_order(self) -> None:
+        """Anti-vacuity: the assertion above must be able to fail."""
+        from patch_browser.patch_metadata import INSTRUMENT_VOCAB
+
+        patches = [{"instrument_primary": n} for n in ("piano", "bass", "organ")]
+        vocab_order = [n for n in INSTRUMENT_VOCAB if n in {"piano", "bass", "organ"}]
+        self.assertEqual(vocab_order, ["piano", "organ", "bass"])
+        self.assertNotEqual(instruments_with_patches(patches), vocab_order)
+
+    def test_only_vocab_instruments_become_chips(self) -> None:
+        patches = [
+            {"instrument_primary": "bass"},
+            {"instrument_primary": "not-a-real-instrument"},
+        ]
+        self.assertEqual(instruments_with_patches(patches), ["bass"])
 
     def test_primary_instrument_defaults_to_other(self) -> None:
         self.assertEqual(primary_instrument({}), "other")


### PR DESCRIPTION
The chips followed `INSTRUMENT_VOCAB` order (piano, keys, organ, bass, lead, pad, …) — a semantic grouping rather than something you can scan.

Sorted in `instruments_with_patches`, **not** by reordering `INSTRUMENT_VOCAB`: that tuple is also the key order for classification scoring in `patch_metadata.classify_instrument`, so reordering it would change tie-breaks between instruments that score equally. That is a silent change to how patches get labelled, not a display change.

"All" stays pinned first — it is prepended separately.

## The existing test was vacuous for this

`test_instruments_with_patches_respects_vocab_order` asserted `[bass, lead, pad]` — which is alphabetical **and** vocab order, so it passed either way and could not distinguish them. Replaced with piano/bass/organ, where the two orderings disagree, plus an anti-vacuity test pinning that they disagree.

Mutation-checked: reverting the sort fails both new assertions. Full suite 1773 passed, 3 skipped.

Also added a test that an unknown `instrument_primary` cannot introduce a chip — previously untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)