### PR TITLE
usb: per-loop stems over the UAC2 gadget (MPE_USB_STEM_CHANNELS)

### DIFF
--- a/config/host/52-mpe-stems-channel-names.conf
+++ b/config/host/52-mpe-stems-channel-names.conf
@@ -1,0 +1,36 @@
+# WirePlumber drop-in — install to ~/.config/wireplumber/wireplumber.conf.d/
+#
+# Name the stems-mode channels so channels 1/2 read as a real L/R stereo pair.
+#
+# WHY THIS IS NEEDED. PipeWire names channels from a *profile*, not from what
+# the device advertises. It ships named profiles for standard layouts only
+# (stereo, 2.1, 5.1, 7.1). At 2 channels the gadget matches "Analogue Stereo"
+# and you get L/R. At 18 it matches nothing, so every channel falls back to
+# AUX0..AUX17 — including the master pair.
+#
+# This is not specific to the gadget: any multichannel interface behaves the
+# same way under PipeWire (a Scarlett 18i20 shows AUX too). The UAC2 channel
+# positions ARE correct on the wire — bit 0 is Front Left, bit 1 Front Right —
+# PipeWire simply does not use them for naming. So the fix belongs here, on the
+# host, and not in the gadget descriptor.
+#
+# Layout this assumes (MPE_AUDIO_PROFILE=usb-host-stems, 18 channels):
+#   1-2    stereo master  (SooperLooper common_out — the post-fader loop mix)
+#   3-18   loop 0..15     (per-loop mono stems)
+#
+# Install only alongside stems mode. In plain usb-host (2 channels) it is
+# harmless but does nothing — the position list is longer than the node's
+# channel count and PipeWire keeps its stereo profile.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      { node.name = "~alsa_input.usb-MPE_Sound_Module.*" }
+    ]
+    actions = {
+      update-props = {
+        audio.position = "FL,FR,AUX0,AUX1,AUX2,AUX3,AUX4,AUX5,AUX6,AUX7,AUX8,AUX9,AUX10,AUX11,AUX12,AUX13,AUX14,AUX15"
+      }
+    }
+  }
+]

--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -45,6 +45,17 @@
 # (toggle in touch settings also writes this file via set-audio-profile.sh).
 # MPE_AUDIO_PROFILE=standalone
 #
+# USB playback channel count (usb-host profiles). 2 = stereo, the default.
+# Above 2 the host receives per-loop stems as well as the master pair:
+#   ch 1-2   stereo master (Surge live + SooperLooper common_out)
+#   ch 3+    loop 0.. as mono folds of each stereo loop
+# 18 covers all 15 usable loops with one channel spare. Range is 2-27: UAC2
+# defines channel-position bits 0-26 only and f_uac2 rejects any mask above
+# that, so 27 is a hard ceiling, not a bandwidth limit.
+# Also install config/host/52-mpe-stems-channel-names.conf on the host, or
+# PipeWire names the master pair AUX0/AUX1 instead of FL/FR.
+# MPE_USB_STEM_CHANNELS=2
+#
 # Keep the UAC2 USB gadget bound when switching to analog (default: 1).
 # Host DAWs (e.g. REAPER + PipeWire) keep the same capture device — no restart.
 # Surge routes to Sound Blaster in standalone; the host input is silent until USB mode.

--- a/scripts/setup-usb-audio-gadget.sh
+++ b/scripts/setup-usb-audio-gadget.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # USB Audio Class 2 gadget — Surge output to tethered host PC (Approach C).
-# Playback-only stereo @ MPE_SURGE_SAMPLE_RATE (default 48000 Hz); no ALSA loopback.
+# Playback-only @ MPE_SURGE_SAMPLE_RATE (default 48000 Hz); no ALSA loopback.
+#
+# Channel count is MPE_USB_STEM_CHANNELS (default 2 = stereo). Above 2 the host
+# receives per-loop stems as well as the master pair — see docs/USB-MULTICHANNEL-STEMS.md.
 #
 # Usage:
 #   setup-usb-audio-gadget.sh start|stop|status|restart [--dry-run]
@@ -16,6 +19,23 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && 
 source "$SCRIPT_DIR/lib/paths.sh"
 
 GADGET_NAME="${MPE_USB_GADGET_NAME:-mpe_audio}"
+# Playback channel count. 2 = stereo (the historical behaviour).
+#
+# The 27-channel ceiling is not arbitrary and not a bandwidth limit. p_chmask is
+# the UAC2 bmChannelConfig field, where every bit is a NAMED speaker position
+# (bit 0 Front Left, bit 1 Front Right, ...). UAC2 defines positions for bits
+# 0-26 only, and f_uac2 rejects a mask touching any bit above that:
+#
+#   configfs-gadget gadget.0: Error: unsupported playback channels mask
+#   probe with driver configfs-gadget failed with error -22
+#
+# MEASURED 2026-08-30 on pi5: 27 channels bind, 28 do not; and a mask of just
+# THREE channels is rejected if one of them uses bit 27 — so it is the bit
+# positions that are limited, not the count. 28 channels also failed at 44100 Hz,
+# where bandwidth is not close to binding (27ch x 16-bit x 48kHz is ~2.6 MB/s
+# against ~24 MB/s on the high-speed link).
+MPE_USB_STEM_CHANNELS="${MPE_USB_STEM_CHANNELS:-2}"
+UAC2_MAX_CHANNELS=27
 GADGET_ROOT="/sys/kernel/config/usb_gadget"
 GADGET_DIR="$GADGET_ROOT/$GADGET_NAME"
 CONFIG_NAME="c.1"
@@ -90,6 +110,28 @@ ensure_configfs() {
     fi
 }
 
+# Playback channel mask for N channels: bits 0..N-1 set.
+#
+# Refuses anything the driver would reject at bind time. A rejected mask does
+# not fail loudly at write time — it fails later, when the UDC is written, and
+# the gadget simply never appears. Better to say so here with the reason.
+resolve_chmask() {
+    local n="$1"
+    case "$n" in
+        ''|*[!0-9]*)
+            log "ERROR: MPE_USB_STEM_CHANNELS must be an integer, got '$n'"
+            return 1
+            ;;
+    esac
+    if [ "$n" -lt 2 ] || [ "$n" -gt "$UAC2_MAX_CHANNELS" ]; then
+        log "ERROR: MPE_USB_STEM_CHANNELS=$n out of range (2-$UAC2_MAX_CHANNELS)"
+        log "       UAC2 defines channel positions for mask bits 0-26 only;"
+        log "       f_uac2 rejects any mask above that (MEASURED 2026-08-30)."
+        return 1
+    fi
+    python3 -c "print((1 << $n) - 1)"
+}
+
 create_gadget() {
     local udc
     udc="$(find_udc)" || {
@@ -100,6 +142,9 @@ create_gadget() {
     ensure_configfs
 
     local sample_rate="${MPE_SURGE_SAMPLE_RATE:-48000}"
+    local channels="$MPE_USB_STEM_CHANNELS"
+    local chmask
+    chmask="$(resolve_chmask "$channels")" || exit 1
 
     if [ "$DRY_RUN" = true ]; then
         log "DRY-RUN: would create gadget $GADGET_NAME on UDC $udc (${sample_rate} Hz stereo UAC2)"
@@ -129,19 +174,19 @@ create_gadget() {
     echo "0001" > strings/0x409/serialnumber
 
     mkdir -p "configs/$CONFIG_NAME/strings/0x409"
-    echo "UAC2 stereo playback" > "configs/$CONFIG_NAME/strings/0x409/configuration"
+    echo "UAC2 ${channels}ch playback" > "configs/$CONFIG_NAME/strings/0x409/configuration"
     echo 250 > "configs/$CONFIG_NAME/MaxPower"
 
     mkdir -p "functions/$FUNCTION_NAME"
     echo "$sample_rate" > "functions/$FUNCTION_NAME/p_srate"
     echo 2 > "functions/$FUNCTION_NAME/p_ssize"
-    echo 3 > "functions/$FUNCTION_NAME/p_chmask"
+    echo "$chmask" > "functions/$FUNCTION_NAME/p_chmask"
     echo 0 > "functions/$FUNCTION_NAME/c_chmask"
 
     ln -sf "functions/$FUNCTION_NAME" "configs/$CONFIG_NAME/"
 
     echo "$udc" > UDC
-    log "Bound UAC2 gadget on $udc (${sample_rate} Hz stereo playback)"
+    log "Bound UAC2 gadget on $udc (${sample_rate} Hz, ${channels}ch playback, chmask=${chmask})"
 }
 
 destroy_gadget() {

--- a/scripts/sooperlooper/wire-jack-graph.sh
+++ b/scripts/sooperlooper/wire-jack-graph.sh
@@ -17,6 +17,8 @@ MODE="${1:-connect}"
 OSC_HOST="${MPE_SL_OSC_HOST:-127.0.0.1}"
 OSC_PORT="${MPE_SL_OSC_PORT:-9951}"
 LOOPS="${MPE_SL_LOOPS:-15}"  # 15 usable max — see sl_limits.py
+STEM_CHANNELS="${MPE_USB_STEM_CHANNELS:-2}"
+STEM_FIRST_CH=3   # 1/2 are the master pair
 JACK_CLIENT="${MPE_SL_JACK_CLIENT:-mpe-looper}"
 SURGE_CLIENT="${MPE_SL_SURGE_CLIENT:-Surge XT}"
 
@@ -75,6 +77,38 @@ disconnect_loop_outs_from_playback() {
   done
 }
 
+# Per-loop stems on playback 3.. — only when the gadget is running multichannel.
+#
+# Both loopN_out_1 and loopN_out_2 go to the SAME playback port. JACK sums
+# multiple sources into one port, so this is a real mono fold-down of a stereo
+# loop, not the left channel with the right discarded.
+#
+# Gated on the ports actually existing rather than on the env var alone: with
+# jackd on the Sound Blaster there are only two playback ports, and every
+# connection here would be logged as a failure for a graph that is in fact
+# correct — the same "reads the same whether it works or not" trap the rest of
+# this file is annotated for.
+connect_stems() {
+  if [ "$STEM_CHANNELS" -le 2 ] 2>/dev/null; then
+    return 0
+  fi
+  local available
+  available="$(jack_lsp 2>/dev/null | grep -c '^system:playback_' || true)"
+  if [ "${available:-0}" -lt "$STEM_FIRST_CH" ]; then
+    log "stems: only ${available:-0} playback port(s) — not multichannel, skipping"
+    return 0
+  fi
+  local wired=0 i ch
+  for i in $(seq 0 $((LOOPS - 1))); do
+    ch=$((STEM_FIRST_CH + i))
+    [ "$ch" -le "$available" ] || break
+    try_jack jack_connect "${JACK_CLIENT}:loop${i}_out_1" "system:playback_${ch}"
+    try_jack jack_connect "${JACK_CLIENT}:loop${i}_out_2" "system:playback_${ch}"
+    wired=$((wired + 1))
+  done
+  log "stems: loop0..$((wired - 1)) -> playback_${STEM_FIRST_CH}..$((STEM_FIRST_CH + wired - 1)) (mono fold, ${available} ports available)"
+}
+
 connect_graph() {
   local i
   for i in $(seq 0 $((LOOPS - 1))); do
@@ -99,6 +133,7 @@ wire_connect() {
   need_cmd oscsend
   log "connect-only (${MODE}): Surge -> loop0..$((LOOPS - 1)) in; common_out -> playback"
   connect_graph
+  connect_stems
   set_dry_all
   log "dry=0 on loops 0..$((LOOPS - 1))"
 }
@@ -112,6 +147,7 @@ wire_rewire() {
   log "disconnecting per-loop outs from playback (use common_out mix instead)"
   disconnect_loop_outs_from_playback
   connect_graph
+  connect_stems
   set_dry_all
   log "dry=0 on loops 0..$((LOOPS - 1)); common_out -> playback; Surge parallel fail-open"
 }


### PR DESCRIPTION
The gadget was hardcoded to stereo. It now takes a channel count, and above 2 the host receives each loop as its own channel alongside the master pair:

```
ch 1-2   stereo master  (Surge live + SooperLooper common_out)
ch 3-17  loop 0..14     (mono fold of each stereo loop)
ch 18    spare          (SooperLooper's usable max is 15 loops)
```

**No bridge, no second clock domain.** The earlier scoping assumed one would be needed. It isn't: in `usb-host` with the host capturing, `detect-audio-device.sh` Tier 0 already puts jackd directly on the gadget card, so the extra channels are simply more `system:playback` ports.

## The 27-channel ceiling

`p_chmask` is not a count — it is the UAC2 `bmChannelConfig` field, where every bit is a **named speaker position** (bit 0 Front Left, bit 1 Front Right, …). UAC2 defines positions for bits 0–26 only, and `f_uac2` rejects a mask touching anything above:

```
configfs-gadget gadget.0: Error: unsupported playback channels mask
probe with driver configfs-gadget failed with error -22
```

MEASURED on pi5: 27 bind, 28 do not — and a **three-channel** mask is rejected if one of its bits is bit 27. So the limit is on bit positions, not count. 28 also failed at 44100 Hz, where bandwidth is nowhere near binding (27ch × 16-bit × 48 kHz ≈ 2.6 MB/s against ~24 MB/s; the Pi 5 USB-C port is dwc2, **USB 2.0 High-Speed**, despite the connector).

Consequence: stereo stems don't fit. 13 stereo stems + master = 28, one over. So stems are a **mono fold** — both `loopN_out_1` and `loopN_out_2` to the same port, summed by JACK, rather than the left channel with the right discarded. That trade waits for panning to actually exist.

## Guard

`connect_stems()` gates on the playback ports **existing**, not on the env var. With jackd on the Sound Blaster there are only two, and wiring 30 connections into the void would log 30 failures for a graph that is correct.

## Host-side naming

PipeWire names channels from a *profile* and ships them only for standard layouts, so at 18 channels the master pair reads `AUX0/AUX1` even though the UAC2 positions are correct on the wire. `config/host/52-mpe-stems-channel-names.conf` pins `audio.position` so it reads FL/FR. Not a gadget fix — any multichannel interface behaves this way under PipeWire.

## Verified end to end on pi5

- Cold gadget rebuild `chmask 3 -> 262143`. **The first attempt did not rebuild** — `MPE_USB_GADGET_PERSIST=1` left it bound and chmask read the same either way; redone so the test could fail.
- Host sees 18 channels, `FL,FR,AUX0..AUX15`, ports `capture_FL/capture_FR/capture_AUX0..`
- Wiring script: `stems: loop0..14 -> playback_3..17 (mono fold, 18 ports available)`, 0 failures; graph matches
- Skip guard: `stems: only 2 playback port(s) — not multichannel, skipping`

1775 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)