### PR TITLE
vol: the touch fader moves the stems, by moving the master it already had

### DIFF
--- a/config/mpe.env.example
+++ b/config/mpe.env.example
@@ -56,6 +56,13 @@
 # PipeWire names the master pair AUX0/AUX1 instead of FL/FR.
 # MPE_USB_STEM_CHANNELS=2
 #
+# UDP port the looper's fader surface listens on for the touch UI's Vol fader
+# (default: 9956, loopback only). The touch screen and the fader surface are
+# different services, so the Vol position is carried across as a fader move and
+# replayed through the master fader's own path — see scripts/sooperlooper
+# /README.md. Change it only if 9956 collides; both sides read this variable.
+# MPE_LOOPER_CTL_PORT=9956
+#
 # Keep the UAC2 USB gadget bound when switching to analog (default: 1).
 # Host DAWs (e.g. REAPER + PipeWire) keep the same capture device — no restart.
 # Surge routes to Sound Blaster in standalone; the host input is silent until USB mode.

--- a/patch_browser/touch_browser_prefs.py
+++ b/patch_browser/touch_browser_prefs.py
@@ -546,10 +546,38 @@ class TouchBrowserPrefsMixin:
             name="MidiSyncSwitch",
         ).start()
 
+    def _send_looper_volume(self, level: float) -> None:
+        """Carry the Vol position to the looper's master fader.
+
+        Surge's amp trim moves the live synth only, so on the multichannel USB
+        out it moves channels 1/2 and nothing else — every loop stem keeps
+        playing at its recorded level and the fader feels dead. The master gain
+        the looper already composes into every loop's `wet` is the level that
+        moves them, and it lives in the other process.
+
+        This does not write `wet`. It hands a fader position to
+        `sooperlooper-apc-bench`, which replays it through the same `handle_cc`
+        the hardware master fader uses, so `loop_mix` remains the only composer.
+        Failure is silent by design: no looper running means Surge-only volume,
+        which is what this did before.
+        """
+        import sys
+        from pathlib import Path as _Path
+
+        sooper = _Path(__file__).resolve().parent.parent / "scripts" / "sooperlooper"
+        if str(sooper) not in sys.path:
+            sys.path.insert(0, str(sooper))
+        try:
+            from remote_fader import send_master
+        except ImportError:
+            return
+        send_master(level)
+
     def _apply_volume(self, level: float, persist: bool = True) -> None:
         self.volume_level = max(VOLUME_MIN, min(VOLUME_MAX, level))
         if self.loader.osc_enabled:
             self.loader.set_volume(self.volume_level)
+        self._send_looper_volume(self.volume_level)
         if persist:
             self._save_volume_level()
 

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -23,6 +23,7 @@ from track_gesture import (  # noqa: E402
     poll_track_gestures,
     reset_all_loops,
     stop_all_loops,
+    verify_stop_all,
 )
 from apc_faders import MASTER, fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
 from apc_grid import NUM_LOOPS, GridView, is_clip_note  # noqa: E402
@@ -747,9 +748,26 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
         track_reset.note_event(note, down)
         transport_leds.note_event(note, down)
 
+    #: When to ask SL what Stop All actually achieved. A one-element list
+    #: because this is a closure, not a class.
+    stop_all_verify_at: list[float | None] = [None]
+
+    def poll_stop_all_verify(now_mono: float) -> None:
+        """Report the TRUTH about the last Stop All, once SL has told us.
+
+        Deliberately separate from `act_stop_all_loops`: SL pushes state, so
+        asking in the same breath as the pause returns the pre-stop value and
+        confirms whatever was already there.
+        """
+        due = stop_all_verify_at[0]
+        if due is None or now_mono < due:
+            return
+        stop_all_verify_at[0] = None
+        verify_stop_all(gestures)
+
     def act_stop_all_loops(_note: int, _down: bool, _control: str) -> None:
         print("transport: Shift+StopAll short -> stop all", flush=True)
-        stop_all_loops(
+        stop_all_verify_at[0] = stop_all_loops(
             osc,
             num_loops=num_loops,
             gestures=gestures,
@@ -840,6 +858,7 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
         if packet is None:
             poll_holds()
             poll_transport_leds()
+            poll_stop_all_verify(time.monotonic())
             maybe_track_transport()
             tick_faders()
             state_listener.maybe_reregister()
@@ -882,6 +901,7 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
 
         poll_holds()
         poll_transport_leds()
+        poll_stop_all_verify(time.monotonic())
         maybe_track_transport()
         state_listener.maybe_reregister()
 

--- a/scripts/sooperlooper-apc-bench.py
+++ b/scripts/sooperlooper-apc-bench.py
@@ -26,6 +26,7 @@ from track_gesture import (  # noqa: E402
     verify_stop_all,
 )
 from apc_faders import MASTER, fader_for_cc, is_control_change, resolve_fader_ccs  # noqa: E402
+from remote_fader import RemoteFaderReceiver  # noqa: E402
 from apc_grid import NUM_LOOPS, GridView, is_clip_note  # noqa: E402
 from apc_transport import (  # noqa: E402
     Mk1ShiftGhostFilter,
@@ -383,6 +384,17 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
     mix = LoopMix(num_loops=num_loops, view=view)
     faders = CoalescingSender(_send, interval_s=fader_interval_ms / 1000.0)
 
+    # The touch UI's Vol fader, arriving as if it were the master CC. It is not
+    # a second writer of `wet`: it goes through `handle_cc` below, the same
+    # entry the hardware master fader uses, so `LoopMix` still composes alone.
+    remote_faders = RemoteFaderReceiver()
+    if not remote_faders.open():
+        print(
+            f"bench: WARN — remote volume off ({remote_faders.error}); "
+            "the touch Vol fader will trim Surge only.",
+            file=sys.stderr,
+        )
+
     def on_wet(loop_index: int, value: float) -> None:
         mix.seed_from_engine(loop_index, value)
 
@@ -613,6 +625,12 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
     def tick_faders() -> None:
         """Ramp smoothed wet toward targets between CC events."""
         faders.tick(now=time.monotonic())
+
+    def poll_remote_faders() -> None:
+        """Replay a remote master move through the hardware fader's own path."""
+        value = remote_faders.poll()
+        if value is not None:
+            handle_cc(master_cc, value)
 
     def handle_cc(cc: int, value: int) -> None:
         fader = fader_for_cc(cc, loop_fader_ccs=loop_fader_ccs, master_cc=master_cc)
@@ -861,6 +879,7 @@ def run_bench(argv: list[str] | None = None, *, osc_session=None) -> int:
             poll_stop_all_verify(time.monotonic())
             maybe_track_transport()
             tick_faders()
+            poll_remote_faders()
             state_listener.maybe_reregister()
 
             poll_engine_events(time.monotonic())

--- a/scripts/sooperlooper/README.md
+++ b/scripts/sooperlooper/README.md
@@ -194,6 +194,26 @@ one that is actually true:
 | **Reconciliation** | The bench *subscribes* to `wet` (`sl_osc_session` `register_auto_update` — a read, not a write) and `LoopMix.seed_from_engine` adopts any value it did not ask for: it backs out master and law, adopts the implied column position and re-arms pickup. The foreign write is absorbed, not fought |
 | **Also gated** | `sl_probe` can write `wet` as a command-path probe *only* if `MPE_SL_PROBE_CONTROLS` names it — it is not in the default chain (`rec_thresh,dry`), and `AUDIO_PATH_CONTROLS` exists to warn when a probe lands in the audio path. It restores after every write |
 | **Enforced by** | `tests/test_track_state_ownership.py::WetOwnershipTests`. A third writer fails the build naming its file, line and function |
+| **Not an exception** | `remote_fader` carries the touch UI's Vol position across the process boundary as a *fader position*, and the bench replays it through `handle_cc` — the same entry the hardware master fader uses. It composes nothing and writes nothing; the master gain it moves is still multiplied in by `wet_for()`. `tests/test_remote_fader.py::TestBenchWiring` fails if that path ever calls the sender or the composer directly |
+
+**Why the touch Vol fader is not a second writer.** Surge's amp trim moves the
+live synth only. On the multichannel USB out that is channels 1/2 — every loop
+stem keeps playing at its recorded level, which is why the fader felt dead once
+stems existed. The level that moves the stems is the master gain already inside
+`wet_for()`, and it lives in `mpe-looper-session.service`.
+
+Letting the touch UI write `wet` directly, the way `load_song` may, would have
+been the short path and the wrong one: `load_song` fires **once**, and
+`seed_from_engine` adopts the result afterwards. A volume fader is a continuous
+drag, so it would be a *continuous* second writer — `seed_from_engine` would
+keep back-computing column gains from a master the other process was still
+moving, and the resulting drift would present as a hardware fault. Instead
+`remote_fader` ships the fader position (UDP, `master <0-127>`, port
+`MPE_LOOPER_CTL_PORT`, default 9956) and the bench feeds it to `handle_cc`. The
+socket is non-blocking and drained from the bench's existing idle branch: a
+thread would be another scheduler client in a process whose job is to not be
+late. If the looper is not running the send fails silently and Vol trims Surge
+alone, exactly as before.
 
 **Known consequence, undecided.** The manifest stores the **composed** level —
 `save_song` reads the engine's `wet`, which already has master and law in it.

--- a/scripts/sooperlooper/remote_fader.py
+++ b/scripts/sooperlooper/remote_fader.py
@@ -1,0 +1,170 @@
+"""Inbound fader moves from another process, replayed as if they were CCs.
+
+The touch UI's Vol fader and the APC's master fader mean the same thing, but
+they live in different processes: the fader surface is in
+`mpe-looper-session.service` and the touch screen is in
+`touch-patch-browser.service`. `LoopMix` — and therefore the master gain that
+`wet_for()` multiplies — is only reachable from the first.
+
+The obvious shortcut is to let the touch UI write `wet` directly, the way
+`looper_songs.load_song` is permitted to. That exception is safe because it
+fires once, at song load, and `LoopMix.seed_from_engine` adopts the value
+afterwards. A volume fader is not once — it is a continuous drag, and a second
+continuous writer is exactly the drift `loop_mix` was built to make impossible:
+`seed_from_engine` would keep back-computing column gains from a master that
+the other process is still moving, and the corruption would look like a
+hardware fault.
+
+So nothing here composes or writes a level. This is a *transport*: it carries a
+master fader position across the process boundary, and the bench feeds it into
+the same `handle_cc` path the hardware fader uses. One writer, one composition
+point, one more surface.
+
+Wire format is one line of ASCII per datagram, `master <0-127>`, deliberately
+not OSC: the receiver must be drainable without a thread (see below), and a
+text line keeps the touch UI's side a three-line `sendto` with no dependency on
+pythonosc being importable there.
+
+The socket is non-blocking and drained from the bench's existing idle branch
+rather than served on a thread. A thread would be one more scheduler client in
+a process whose whole job is to not be late; a `recvfrom` on an empty
+non-blocking socket is a single syscall, and the idle branch already sleeps 2 ms
+between passes.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import socket
+
+#: Only the master is carried today. Per-column moves stay on the APC, which is
+#: the surface that has pickup state for them; a touch column fader would need
+#: its own pickup story before it could use this.
+MASTER_KEY = "master"
+
+CC_MIN = 0
+CC_MAX = 127
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 9956
+
+#: Cap on datagrams drained per pass, so a flood cannot hold the loop. A drag
+#: is far below this; anything above it is a fault, and dropping is correct
+#: because only the newest position matters.
+MAX_DRAIN = 64
+
+
+def resolve_port() -> int:
+    raw = os.environ.get("MPE_LOOPER_CTL_PORT", "")
+    try:
+        port = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_PORT
+    return port if 1 <= port <= 65535 else DEFAULT_PORT
+
+
+def parse_message(data: bytes) -> int | None:
+    """`b"master 96"` -> 96. Anything else -> None, silently.
+
+    Silently, because this socket is reachable by anything on loopback and a
+    malformed datagram must not be able to stop the fader surface.
+    """
+    try:
+        text = data.decode("ascii", "strict").strip()
+    except UnicodeDecodeError:
+        return None
+    parts = text.split()
+    if len(parts) != 2 or parts[0] != MASTER_KEY:
+        return None
+    try:
+        value = int(parts[1])
+    except ValueError:
+        return None
+    if not CC_MIN <= value <= CC_MAX:
+        return None
+    return value
+
+
+def level_to_cc(level: float) -> int:
+    """0.0-1.0 -> 0-127, clamped. The touch UI's Vol scale is 0-1."""
+    try:
+        scaled = round(float(level) * CC_MAX)
+    except (TypeError, ValueError):
+        return CC_MAX
+    return max(CC_MIN, min(CC_MAX, scaled))
+
+
+class RemoteFaderReceiver:
+    """Non-blocking UDP source of master fader positions.
+
+    `open()` never raises: a port already in use means the fader surface runs
+    without remote volume, which is a degraded feature, not a dead looper.
+    """
+
+    def __init__(self, *, host: str = DEFAULT_HOST, port: int | None = None) -> None:
+        self.host = host
+        self.port = resolve_port() if port is None else port
+        self._sock: socket.socket | None = None
+        self.error: str | None = None
+
+    def open(self) -> bool:
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setblocking(False)
+            sock.bind((self.host, self.port))
+        except OSError as exc:
+            self.error = f"{exc}"
+            self._sock = None
+            return False
+        self._sock = sock
+        self.error = None
+        return True
+
+    def poll(self) -> int | None:
+        """Newest valid master position since the last poll, or None.
+
+        Coalescing here rather than replaying every datagram: intermediate
+        positions of a drag that already arrived are stale by definition, and
+        the sender is rate-limited anyway.
+        """
+        if self._sock is None:
+            return None
+        latest: int | None = None
+        for _ in range(MAX_DRAIN):
+            try:
+                data, _addr = self._sock.recvfrom(64)
+            except BlockingIOError:
+                break
+            except OSError as exc:
+                if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK, errno.ECONNREFUSED):
+                    break
+                break
+            value = parse_message(data)
+            if value is not None:
+                latest = value
+        return latest
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+
+
+def send_master(level: float, *, host: str = DEFAULT_HOST, port: int | None = None) -> bool:
+    """Fire-and-forget a 0.0-1.0 level at the fader surface.
+
+    Returns False rather than raising when the looper is not running: the touch
+    UI's volume must keep working on Surge alone.
+    """
+    target = resolve_port() if port is None else port
+    payload = f"{MASTER_KEY} {level_to_cc(level)}".encode("ascii")
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.setblocking(False)
+            sock.sendto(payload, (host, target))
+    except OSError:
+        return False
+    return True

--- a/scripts/sooperlooper/track_gesture.py
+++ b/scripts/sooperlooper/track_gesture.py
@@ -93,6 +93,7 @@ from sl_loop_states import (
     SL_STATE_OFF,
     SL_STATE_OFF_MUTED,
     SL_STATE_OVERDUBBING,
+    SL_STATE_PAUSED,
     SL_STATE_PLAYING,
     SL_STATE_RECORDING,
     SL_STATE_WAIT_START,
@@ -1120,13 +1121,56 @@ def reset_all_loops(
     print(f"-> track reset: cleared {num_loops} loops", flush=True)
 
 
+#: How long to wait before believing SL about what Stop All achieved.
+#:
+#: SL pushes state asynchronously, so reading `fs.sl_state` in the same breath
+#: as the pause returns the PRE-stop value and would confirm whatever was
+#: already there. One second is far longer than the observed update latency and
+#: still inside the window where a spurious restart shows up.
+STOP_ALL_VERIFY_S: float = 1.0
+
+#: What "stopped" is allowed to look like after Stop All.
+#: OFF is an empty loop, OFF_MUTED an empty loop after global mute, PAUSED a
+#: loop with audio that is holding position.
+STOPPED_STATES = frozenset({SL_STATE_OFF, SL_STATE_OFF_MUTED, SL_STATE_PAUSED})
+
+
+def verify_stop_all(gestures: list["TrackGesture"], *, log=log) -> list[tuple[int, int]]:
+    """Report what Stop All ACTUALLY achieved. Returns the loops still active.
+
+    The counterpart to the request `stop_all_loops` sends. Separated in time
+    because SL's state arrives by push, so the honest answer does not exist yet
+    when the commands go out.
+
+    Reported 2026-08-30: clips restarting 5-10s after Stop All. The only
+    evidence was a log line that said "paused 15 loops" unconditionally, so
+    "they never stopped" and "they stopped and something restarted them" were
+    indistinguishable. This makes them distinguishable, which is the whole
+    point -- it is an instrument, not a fix.
+    """
+    still_active = [
+        (fs.loop, fs.sl_state)
+        for fs in gestures
+        if fs.sl_state not in STOPPED_STATES
+    ]
+    if still_active:
+        detail = ", ".join(f"loop {i} state={st}" for i, st in still_active)
+        log(f"stop all VERIFY: {len(still_active)} loop(s) did NOT stop -- {detail}")
+    else:
+        log(f"stop all VERIFY: all {len(gestures)} loops stopped")
+    return still_active
+
+
 def stop_all_loops(
     osc,
     *,
     num_loops: int,
     gestures: list[TrackGesture],
-) -> None:
+) -> float:
     """Pause every loop without clearing audio; LEDs -> stopped (yellow).
+
+    Returns the monotonic time at which `verify_stop_all` should be called to
+    find out whether it actually worked.
 
     Nothing is playing now, so the grid position resets to zero: the next clip
     launched starts from the top of the bar instead of joining a cycle that has
@@ -1200,4 +1244,11 @@ def stop_all_loops(
         if fs.sl_state not in (SL_STATE_OFF, SL_STATE_OFF_MUTED):
             fs._expect(STATE_STOPPED)
         fs._sync_led()
-    print(f"-> stop all: paused {num_loops} loops", flush=True)
+    # NOT "paused 15 loops". This print used to claim the outcome while only
+    # ever having sent the request -- it read identically whether every loop
+    # paused, some paused, or none did, which is the one bug shape this
+    # project keeps paying for. It now says what it DID, and the truth is
+    # reported a moment later by `verify_stop_all` once SL's own state
+    # updates have arrived.
+    print(f"-> stop all: pause requested for {num_loops} loops", flush=True)
+    return time.monotonic() + STOP_ALL_VERIFY_S

--- a/tests/test_remote_fader.py
+++ b/tests/test_remote_fader.py
@@ -1,0 +1,165 @@
+"""The touch Vol fader's path into the looper's master gain.
+
+The point under test is not "a datagram arrives". It is that the touch fader
+reaches loop levels *without* becoming a second writer of `wet` — the drift
+`loop_mix` exists to prevent. So the transport tests are joined by a structural
+test that the bench replays remote moves through the hardware fader's own
+entry point.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "sooperlooper"))
+
+import remote_fader  # noqa: E402
+
+BENCH_SRC = REPO / "scripts" / "sooperlooper-apc-bench.py"
+
+
+class TestParsing(unittest.TestCase):
+    def test_valid_master_message(self):
+        self.assertEqual(remote_fader.parse_message(b"master 96"), 96)
+        self.assertEqual(remote_fader.parse_message(b"  master 0 \n"), 0)
+        self.assertEqual(remote_fader.parse_message(b"master 127"), 127)
+
+    def test_rejects_out_of_range(self):
+        # Not clamped on receive: an out-of-range value means the sender is not
+        # the sender we think it is, and guessing its intent is worse than
+        # ignoring it.
+        self.assertIsNone(remote_fader.parse_message(b"master 128"))
+        self.assertIsNone(remote_fader.parse_message(b"master -1"))
+
+    def test_rejects_malformed(self):
+        for bad in (b"", b"master", b"master 5 5", b"wet 5", b"master x",
+                    b"\xff\xfe", b"MASTER 5"):
+            self.assertIsNone(remote_fader.parse_message(bad), bad)
+
+
+class TestScaling(unittest.TestCase):
+    def test_level_to_cc_endpoints_and_clamp(self):
+        self.assertEqual(remote_fader.level_to_cc(0.0), 0)
+        self.assertEqual(remote_fader.level_to_cc(1.0), 127)
+        self.assertEqual(remote_fader.level_to_cc(0.5), 64)
+        self.assertEqual(remote_fader.level_to_cc(2.0), 127)
+        self.assertEqual(remote_fader.level_to_cc(-1.0), 0)
+
+    def test_non_numeric_falls_back_to_unity(self):
+        # A broken level must not silently mute the rig.
+        self.assertEqual(remote_fader.level_to_cc(None), 127)
+
+
+class TestTransport(unittest.TestCase):
+    PORT = 19956
+
+    def setUp(self):
+        self.rx = remote_fader.RemoteFaderReceiver(port=self.PORT)
+        self.assertTrue(self.rx.open(), self.rx.error)
+        self.addCleanup(self.rx.close)
+
+    def _settle(self):
+        time.sleep(0.05)
+
+    def test_empty_socket_yields_none(self):
+        self.assertIsNone(self.rx.poll())
+
+    def test_round_trip(self):
+        remote_fader.send_master(1.0, port=self.PORT)
+        self._settle()
+        self.assertEqual(self.rx.poll(), 127)
+
+    def test_newest_wins(self):
+        # A drag delivers many positions; only the last is not already stale.
+        for level in (1.0, 0.75, 0.25):
+            remote_fader.send_master(level, port=self.PORT)
+        self._settle()
+        self.assertEqual(self.rx.poll(), 32)
+        self.assertIsNone(self.rx.poll())
+
+    def test_garbage_does_not_break_the_surface(self):
+        import socket
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.sendto(b"\xff\xfe garbage", ("127.0.0.1", self.PORT))
+            s.sendto(b"master 40", ("127.0.0.1", self.PORT))
+        self._settle()
+        self.assertEqual(self.rx.poll(), 40)
+
+    def test_second_bind_fails_without_raising(self):
+        other = remote_fader.RemoteFaderReceiver(port=self.PORT)
+        self.assertFalse(other.open())
+        self.assertIsNotNone(other.error)
+        self.assertIsNone(other.poll())
+
+    def test_send_to_nothing_does_not_raise(self):
+        remote_fader.send_master(0.5, port=self.PORT + 1)
+
+    def test_closed_receiver_is_inert(self):
+        self.rx.close()
+        self.assertIsNone(self.rx.poll())
+
+
+class TestBenchWiring(unittest.TestCase):
+    """Structural: the remote path must not grow its own level arithmetic."""
+
+    def setUp(self):
+        self.tree = ast.parse(BENCH_SRC.read_text(encoding="utf-8"))
+        self.fn = next(
+            (n for n in ast.walk(self.tree)
+             if isinstance(n, ast.FunctionDef) and n.name == "poll_remote_faders"),
+            None,
+        )
+        self.assertIsNotNone(self.fn, "bench lost poll_remote_faders")
+
+    def test_remote_moves_go_through_handle_cc(self):
+        called = {
+            n.func.id for n in ast.walk(self.fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        }
+        self.assertIn("handle_cc", called)
+
+    def test_remote_path_does_not_compose_or_send_wet(self):
+        # If this ever calls the sender or the composer directly, the touch
+        # fader has become a second writer and loop_mix no longer owns level.
+        names = {
+            ast.unparse(n.func) for n in ast.walk(self.fn) if isinstance(n, ast.Call)
+        }
+        for forbidden in ("faders.submit", "mix.messages_for", "mix.wet_for"):
+            self.assertNotIn(forbidden, names)
+
+    def test_poller_runs_in_the_idle_branch(self):
+        src = BENCH_SRC.read_text(encoding="utf-8")
+        self.assertIn("poll_remote_faders()", src.split("def poll_remote_faders")[0]
+                      + src.split("def poll_remote_faders")[1])
+
+
+class TestTouchFaderSends(unittest.TestCase):
+    """The Vol fader must actually reach the transport, not just be able to."""
+
+    def test_apply_volume_calls_the_looper_send(self):
+        src = (REPO / "patch_browser" / "touch_browser_prefs.py").read_text(
+            encoding="utf-8"
+        )
+        tree = ast.parse(src)
+        fn = next(
+            (n for n in ast.walk(tree)
+             if isinstance(n, ast.FunctionDef) and n.name == "_apply_volume"),
+            None,
+        )
+        self.assertIsNotNone(fn, "touch UI lost _apply_volume")
+        calls = {ast.unparse(n.func) for n in ast.walk(fn) if isinstance(n, ast.Call)}
+        self.assertIn("self._send_looper_volume", calls)
+
+    def test_send_helper_never_raises_without_a_looper(self):
+        # No mocks: the real socket call, at a port nothing is bound to. The
+        # touch UI must keep working when the looper is not running.
+        remote_fader.send_master(0.5, port=19999)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_track_gesture.py
+++ b/tests/test_track_gesture.py
@@ -683,3 +683,74 @@ class OverdubOnePassTests(unittest.TestCase):
         self._pos(fs, 1.9)
         self._pos(fs, 0.02)
         self.assertNotIn("overdub", self._hits(fs))
+
+
+class StopAllVerificationTests(unittest.TestCase):
+    """Stop All must report what it ACHIEVED, not what it requested.
+
+    Reported 2026-08-30: clips restarting 5-10s after Stop All. The only
+    evidence was `-> stop all: paused 15 loops`, printed unconditionally at the
+    end of the function -- it read the same whether every loop paused, some
+    did, or none did. So "they never stopped" and "something restarted them"
+    could not be told apart, and the log actively pointed away from the first.
+    """
+
+    def _gestures(self, states):
+        from scripts.sooperlooper.track_gesture import TrackGesture
+
+        out = []
+        for loop, state in enumerate(states):
+            fs = TrackGesture(loop=loop, hold_ms=1000.0, debounce_ms=0.0)
+            fs.bind(MagicMock(), compositor(), 36 + loop)
+            fs.sync_from_sl(state)
+            out.append(fs)
+        return out
+
+    def test_a_loop_that_did_not_stop_is_named(self) -> None:
+        from scripts.sooperlooper.track_gesture import verify_stop_all
+        from scripts.sooperlooper.sl_loop_states import (
+            SL_STATE_PAUSED, SL_STATE_PLAYING,
+        )
+
+        lines = []
+        still = verify_stop_all(
+            self._gestures([SL_STATE_PAUSED, SL_STATE_PLAYING, SL_STATE_PAUSED]),
+            log=lines.append,
+        )
+        self.assertEqual(still, [(1, SL_STATE_PLAYING)])
+        self.assertIn("did NOT stop", lines[0])
+        self.assertIn("loop 1", lines[0], "the offender must be named")
+
+    def test_all_stopped_reports_clean(self) -> None:
+        """Positive control: a verifier that always cried wolf would be as
+        useless as the unconditional print it replaces."""
+        from scripts.sooperlooper.track_gesture import verify_stop_all
+        from scripts.sooperlooper.sl_loop_states import (
+            SL_STATE_OFF, SL_STATE_OFF_MUTED, SL_STATE_PAUSED,
+        )
+
+        lines = []
+        still = verify_stop_all(
+            self._gestures([SL_STATE_PAUSED, SL_STATE_OFF, SL_STATE_OFF_MUTED]),
+            log=lines.append,
+        )
+        self.assertEqual(still, [])
+        self.assertIn("all 3 loops stopped", lines[0])
+
+    def test_stop_all_returns_a_verification_deadline(self) -> None:
+        """Asking in the same breath returns SL's PRE-stop state, which would
+        confirm whatever was already there."""
+        import time
+        from scripts.sooperlooper.track_gesture import (
+            build_track_gestures, stop_all_loops, STOP_ALL_VERIFY_S,
+        )
+
+        osc = MagicMock()
+        _, gestures = build_track_gestures(
+            osc=osc, compositor=compositor(), num_loops=2,
+            hold_ms=1000.0, debounce_ms=0.0
+        )
+        before = time.monotonic()
+        due = stop_all_loops(osc, num_loops=2, gestures=gestures)
+        self.assertIsNotNone(due, "no deadline — nothing would ever verify")
+        self.assertGreaterEqual(due, before + STOP_ALL_VERIFY_S)


### PR DESCRIPTION
Surge amp trim moves the live synth only — on the multichannel USB out that is channels 1/2, so every loop stem kept playing at its recorded level and the Vol fader felt dead once stems existed.

The level that moves the stems is the master gain `loop_mix.wet_for()` already multiplies in. It lives in `mpe-looper-session.service`; the fader lives in `touch-patch-browser.service`. So this is a process-boundary problem, not a level-composition one, and it is solved as a **transport**: `remote_fader` ships the fader *position* over loopback UDP and the bench replays it through `handle_cc`, the same entry the hardware master fader uses.

**Deliberately not** the shortcut of writing `wet` directly the way `looper_songs.load_song` may. That exception is safe because it fires once and `seed_from_engine` adopts the result. A volume fader is a continuous drag, so it would be a *continuous* second writer: `seed_from_engine` would keep back-computing column gains from a master the other process was still moving, and the drift would present as a hardware fault. `loop_mix` stays the only composer and the only writer.

Non-blocking socket drained from the bench existing idle branch — a thread would be one more scheduler client in a process whose job is to not be late. Bind and send failures are both silent: no looper running means Vol trims Surge alone, exactly as before.

## Tests
17 new — parse/clamp/coalesce, a real socket round-trip, plus structural guards that the remote path calls neither the sender nor the composer and that `_apply_volume` actually sends. Both guards mutation-checked. Full suite 1795 passed, 3 skipped.

## Not yet verified
No sound has been made through this path. Hardware verification follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)